### PR TITLE
Revise re-scan on error logic to match on MAC address.

### DIFF
--- a/pywemo/discovery.py
+++ b/pywemo/discovery.py
@@ -12,17 +12,18 @@ from .ouimeaux_device.maker import Maker
 from .ouimeaux_device.api.xsd import device as deviceParser
 
 
-def discover_devices(st=None, max_devices=None):
+def discover_devices(st=None, max_devices=None, match_mac=None):
     """ Finds WeMo devices on the local network. """
     st = st or ssdp.ST_ROOTDEVICE
-    ssdp_entries = ssdp.scan(st, max_entries=max_devices)
+    ssdp_entries = ssdp.scan(st, max_entries=max_devices, match_mac=match_mac)
 
     wemos = []
 
     for entry in ssdp_entries:
         if entry.match_device_description(
                 {'manufacturer': 'Belkin International Inc.'}):
-            device = device_from_description(entry.location)
+            mac = entry.description.get('device').get('macAddress')
+            device = device_from_description(entry.location, mac)
 
             if device is not None:
                 wemos.append(device)
@@ -30,30 +31,30 @@ def discover_devices(st=None, max_devices=None):
     return wemos
 
 
-def device_from_description(description_url):
+def device_from_description(description_url, mac):
     """ Returns object representing WeMo device running at host, else None. """
     try:
         xml = requests.get(description_url, timeout=10)
 
         uuid = deviceParser.parseString(xml.content).device.UDN
 
-        return device_from_uuid_and_location(uuid, description_url)
+        return device_from_uuid_and_location(uuid, mac, description_url)
 
     except Exception:  # pylint: disable=broad-except
         return None
 
 
-def device_from_uuid_and_location(uuid, location):
+def device_from_uuid_and_location(uuid, mac, location):
     """ Tries to determine which device it is based on the uuid. """
     if uuid.startswith('uuid:Socket'):
-        return Switch(location)
+        return Switch(location, mac)
     elif uuid.startswith('uuid:Lightswitch'):
-        return LightSwitch(location)
+        return LightSwitch(location, mac)
     elif uuid.startswith('uuid:Insight'):
-        return Insight(location)
+        return Insight(location, mac)
     elif uuid.startswith('uuid:Sensor'):
-        return Motion(location)
+        return Motion(location, mac)
     elif uuid.startswith('uuid:Maker'):
-        return Maker(location)
+        return Maker(location, mac)
     else:
         return None

--- a/pywemo/ouimeaux_device/__init__.py
+++ b/pywemo/ouimeaux_device/__init__.py
@@ -18,11 +18,12 @@ class UnknownService(Exception): pass
 
 
 class Device(object):
-    def __init__(self, url):
+    def __init__(self, url, mac):
         self._state = None
         base_url = url.rsplit('/', 1)[0]
         self.host = urlparse(url).hostname
         #self.port = urlparse(url).port
+        self.mac = mac
         xml = requests.get(url, timeout=10)
         self._config = deviceParser.parseString(xml.content).device
         sl = self._config.serviceList
@@ -48,7 +49,7 @@ class Device(object):
         try_no = 0
 
         while True:
-            found = discover_devices(self._config.get_UDN(), 1)
+            found = discover_devices(None, 1, self.mac)
 
             if found:
                 log.info("Found it again, updating local values")

--- a/pywemo/ssdp.py
+++ b/pywemo/ssdp.py
@@ -192,7 +192,7 @@ class UPNPEntry(object):
 
 
 # pylint: disable=invalid-name
-def scan(st=None, timeout=DISCOVER_TIMEOUT, max_entries=None):
+def scan(st=None, timeout=DISCOVER_TIMEOUT, max_entries=None, match_mac=None):
     """
     Sends a message over the network to discover upnp devices.
 
@@ -236,8 +236,11 @@ def scan(st=None, timeout=DISCOVER_TIMEOUT, max_entries=None):
                 response = sock.recv(1024).decode("ascii")
 
                 entry = UPNPEntry.from_response(response)
+                mac = entry.description.get('device').get('macAddress')
 
-                if (st is None or entry.st == st) and entry not in entries:
+                if ((st is None or entry.st == st) and
+                   (match_mac is None or mac == match_mac) and
+                   entry not in entries):
                     entries.append(entry)
 
                     if max_entries and len(entries) == max_entries:


### PR DESCRIPTION
In my setup the current re-try logic (which looks for wemo devices changing their ports etc) never finds the device.

This is because the match used for the scan never succeeded. I guess this may be router dependent.

This PR revises the retry scan logic to look for the lost device based on its MAC address.
