### PR TITLE
Add rediscovery to resubscribe

### DIFF
--- a/pywemo/ssdp.py
+++ b/pywemo/ssdp.py
@@ -133,7 +133,7 @@ class UPNPEntry(object):
 
         if url not in UPNPEntry.DESCRIPTION_CACHE:
             try:
-                xml = requests.get(url).text
+                xml = requests.get(url, timeout=10).text
 
                 tree = None
                 if len(xml) > 0:
@@ -146,13 +146,13 @@ class UPNPEntry(object):
                     UPNPEntry.DESCRIPTION_CACHE[url] = None
 
             except requests.RequestException:
-                logging.getLogger(__name__).exception(
+                logging.getLogger(__name__).error(
                     "Error fetching description at {}".format(url))
 
                 UPNPEntry.DESCRIPTION_CACHE[url] = {}
 
             except (requests.RequestException, ElementTree.ParseError):
-                logging.getLogger(__name__).exception(
+                logging.getLogger(__name__).error(
                     "Found malformed XML at {}: {}".format(url, xml))
 
                 UPNPEntry.DESCRIPTION_CACHE[url] = {}

--- a/pywemo/subscribe.py
+++ b/pywemo/subscribe.py
@@ -93,12 +93,11 @@ class SubscriptionRegistry(object):
     device.register_listener = functools.partial(self.on, device, 'BinaryState')
     self._devices[device.host] = device
 
-    url = device.basicevent.eventSubURL
     with self._event_thread_cond:
-      self._events[url] = self._sched.enter(0, 0, self._resubscribe, [url])
+      self._events[url] = self._sched.enter(0, 0, self._resubscribe, [device])
       self._event_thread_cond.notify()
 
-  def _resubscribe(self, url, sid=None):
+  def _resubscribe(self, device, sid=None, retry = 0):
     LOG.info("Wemo resubscribe for %s", url)
     headers = {'TIMEOUT': 300}
     if sid is not None:
@@ -110,6 +109,7 @@ class SubscriptionRegistry(object):
           "NT": "upnp:event"
       })
     try:
+      url = device.basicevent.eventSubURL
       response = requests.request(method="SUBSCRIBE", url=url,
                                   headers=headers)
       if response.status_code == 412 and sid:
@@ -123,11 +123,15 @@ class SubscriptionRegistry(object):
       sid = response.headers.get('sid', sid)
       with self._event_thread_cond:
         LOG.info("Wemo resubscribe in %ss", int(timeout * 0.75))
-        self._events[url] = self._sched.enter(int(timeout * 0.75), 0, self._resubscribe, [url, sid])
+        self._events[url] = self._sched.enter(int(timeout * 0.75), 0, self._resubscribe, [device, sid])
     except requests.exceptions.RequestException:
       LOG.warning("Wemo resubscribe error for %s, will retry in %ss", url, SUBSCRIPTION_RETRY)
+      retry += 1
+      if retry > 1:
+        # If this wan't a one off try rediscovery in case device has changed
+        device.reconnect_with_device()
       with self._event_thread_cond:
-        self._events[url] = self._sched.enter(SUBSCRIPTION_RETRY, 0, self._resubscribe, [url, sid])
+        self._events[url] = self._sched.enter(SUBSCRIPTION_RETRY, 0, self._resubscribe, [device, sid, retry])
 
 
   def _event(self, device, type_, value):

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 
 setup(name='pywemo',
-      version='0.3.7',
+      version='0.3.8',
       description='Access WeMo switches using their SOAP API',
       url='http://github.com/pavoni/pywemo',
       author='Greg Dowling',


### PR DESCRIPTION
Sometimes wemo devices shift their url and port - so handle this when trying to resubscript.
Also removes / improves error messages

Finally adds a timeout to get description in SSDP.

Closes https://github.com/pavoni/pywemo/issues/22
