### PR TITLE
Fixes for WeMo led devices

### DIFF
--- a/pywemo/__init__.py
+++ b/pywemo/__init__.py
@@ -8,6 +8,7 @@ from .ouimeaux_device.lightswitch import LightSwitch
 from .ouimeaux_device.motion import Motion
 from .ouimeaux_device.switch import Switch
 from .ouimeaux_device.maker import Maker
+from .ouimeaux_device.bridge import Bridge
 
 from .discovery import discover_devices
 from .subscribe import SubscriptionRegistry

--- a/pywemo/discovery.py
+++ b/pywemo/discovery.py
@@ -4,6 +4,7 @@ Module to discover WeMo devices.
 import requests
 
 from . import ssdp
+from .ouimeaux_device.bridge import Bridge
 from .ouimeaux_device.insight import Insight
 from .ouimeaux_device.lightswitch import LightSwitch
 from .ouimeaux_device.motion import Motion
@@ -56,5 +57,7 @@ def device_from_uuid_and_location(uuid, mac, location):
         return Motion(location, mac)
     elif uuid.startswith('uuid:Maker'):
         return Maker(location, mac)
+    elif uuid.startswith('uuid:Bridge'):
+        return Bridge(location, mac)
     else:
         return None

--- a/pywemo/ouimeaux_device/bridge.py
+++ b/pywemo/ouimeaux_device/bridge.py
@@ -18,10 +18,7 @@ class Bridge(Device):
         endDeviceList = et.fromstring(endDevices.get('DeviceLists'))
 
         for light in endDeviceList.iter('DeviceInfo'):
-            if self.light_name(light) in self.Lights:
-                pass
-            else:
-                self.Lights[self.light_name(light)] = light
+            self.Lights[self.light_name(light)] = light
         return self.Lights
 
     def bridge_get_groups(self):
@@ -30,10 +27,7 @@ class Bridge(Device):
         endDeviceList = et.fromstring(endDevices.get('DeviceLists'))
 
         for group in endDeviceList.iter('GroupInfo'):
-            if self.group_name(group) in self.Groups:
-                pass
-            else:
-                self.Groups[self.group_name(group)] = group
+            self.Groups[self.group_name(group)] = group
         return self.Groups
 
     def light_attributes(self, light):


### PR DESCRIPTION
- autodiscovery for the bridge device
- make sure cached data about lights and groups gets refreshed
