### PR TITLE
WeMo Link add support for tunable white and RGBW lights

### DIFF
--- a/pywemo/color.py
+++ b/pywemo/color.py
@@ -1,0 +1,55 @@
+# Define usable ranges as bulbs either ignore or behave unexpectedly
+# when it is sent a value is outside of the range.
+TEMPERATURE_PROFILES = dict((model, temp) for models, temp in (
+    # Lightify RGBW, 1900-6500K
+    (["LIGHTIFY A19 RGBW"], (151, 555)),
+) for model in models)
+
+COLOR_PROFILES = dict((model, gamut) for models, gamut in (
+    # Lightify RGBW, 1900-6500K
+    # http://flow-morewithless.blogspot.com/2015/01/osram-lightify-color-gamut-and-spectrum.html
+    (["LIGHTIFY A19 RGBW"],
+     ((0.683924, 0.315904), (0.391678, 0.501414), (0.136990, 0.051035))),
+) for model in models)
+
+
+def get_profiles(model):
+    return (TEMPERATURE_PROFILES.get(model, (150, 600)),
+            COLOR_PROFILES.get(model, ((1., 0.), (0., 1.), (0., 0.))))
+
+
+def is_same_side(p1, p2, a, b):
+    """Test if points p1 and p2 lie on the same size of line a-b."""
+    vector_ab = [y - x for x, y in zip(a, b)]
+    vector_ap1 = [y - x for x, y in zip(a, p1)]
+    vector_ap2 = [y - x for x, y in zip(a, p2)]
+    cross_vab_ap1 = vector_ab[0] * vector_ap1[1] - vector_ab[1] * vector_ap1[0]
+    cross_vab_ap2 = vector_ab[0] * vector_ap2[1] - vector_ab[1] * vector_ap2[0]
+    return (cross_vab_ap1 * cross_vab_ap2) >= 0
+
+
+def closest_point(p, a, b):
+    """Test if points p1 and p2 lie on the same size of line a-b."""
+    vector_ab = [y - x for x, y in zip(a, b)]
+    vector_ap = [y - x for x, y in zip(a, p)]
+    dot_ap_ab = sum(x * y for x, y in zip(vector_ap, vector_ab))
+    dot_ab_ab = sum(x * y for x, y in zip(vector_ab, vector_ab))
+    t = max(0.0, min(dot_ap_ab / dot_ab_ab, 1.0))
+    return a[0] + vector_ab[0] * t, a[1] + vector_ab[1] * t
+
+
+def limit_to_gamut(xy, gamut):
+    """Return the closest point within the gamut triangle for colorxy."""
+    r, g, b = gamut
+
+    # http://www.blackpawn.com/texts/pointinpoly/
+    if not is_same_side(xy, r, g, b):
+        xy = closest_point(xy, g, b)
+
+    if not is_same_side(xy, g, b, r):
+        xy = closest_point(xy, b, r)
+
+    if not is_same_side(xy, b, r, g):
+        xy = closest_point(xy, r, g)
+
+    return xy

--- a/pywemo/ouimeaux_device/bridge.py
+++ b/pywemo/ouimeaux_device/bridge.py
@@ -1,6 +1,34 @@
 from pywemo.ouimeaux_device import Device
 
 from xml.etree import cElementTree as et
+import six
+try:
+    from html import escape as html_escape
+except ImportError:
+    from cgi import escape as html_escape
+
+
+CAPABILITY_ID2NAME = dict((
+    ('10006', "onoff"),
+    ('10008', "levelcontrol"),
+    ('30008', "sleepfader"),
+    ('30009', "levelcontrol_move"),
+    ('3000A', "levelcontrol_stop"),
+    ('10300', "colorcontrol"),
+    ('30301', "colortemperature"),
+))
+CAPABILITY_NAME2ID = dict(
+    (val, cap) for cap, val in CAPABILITY_ID2NAME.items())
+
+# acceptable values for 'onoff'
+OFF = 0
+ON = 1
+TOGGLE = 2
+
+
+def limit(value, min_val, max_val):
+    """Returns value clipped to the range [min_val, max_val]"""
+    return max(min_val, min(value, max_val))
 
 
 class Bridge(Device):
@@ -65,41 +93,156 @@ class Bridge(Device):
         return self.group_attributes(group).get('GroupID')
 
     def light_get_state(self, light):
-        (
-            state, # 0 (off) or 1 (on)
-            dim # 0-255 dark to bright
-        ) = self.light_attributes(light).get('state').split(':', 1)[0].split(',',1)
-        return {
-            'state' : state,
-            'dim' : dim
-        }
+        """Return a dict with
+        state = 0 (off) or 1 (on)
+        dim = 0-255 dark to bright
+        """
+        state = self.getdevicestatus(light)
+        return dict(
+            state=state['onoff'],
+            dim=state['levelcontrol'][0],
+        )
 
     def group_get_state(self, group):
-        (
-            state, # 0 (off) or 1 (on)
-            dim # 0-255 dark to bright
-        ) = self.group_attributes(group).get('state').split(':', 1)[0].split(',',1)
-        return {
-            'state' : state,
-            'dim' : dim
-        }
+        """Return a dict with
+        state = 0 (off) or 1 (on)
+        dim = 0-255 dark to bright
+        """
+        state = self.getdevicestatus(group)
+        return dict(
+            state=state['onoff'],
+            dim=state['levelcontrol'][0],
+        )
 
     def light_set_state(self, light, state=None, dim=None):
-        if state == None:
-            state = self.light_get_state(light).get('state')
-        if dim == None:
-            state = self.light_get_state(light).get('dim')
-
-        sendState = '&lt;?xml version=&quot;1.0&quot; encoding=&quot;UTF-8&quot;?&gt;&lt;DeviceStatus&gt;&lt;IsGroupAction&gt;NO&lt;/IsGroupAction&gt;&lt;DeviceID available=&quot;YES&quot;&gt;{devID}&lt;/DeviceID&gt;&lt;CapabilityID&gt;10006,10008&lt;/CapabilityID&gt;&lt;CapabilityValue&gt;{state},{dim}&lt;/CapabilityValue&gt;&lt;/DeviceStatus&gt;'.format(devID=self.light_get_id(light),state=state,dim=dim)
-
-        return self.bridge.SetDeviceStatus(DeviceStatusList=sendState)
+        if dim is None:
+            return self.setdevicestatus(light, onoff=state)
+        return self.setdevicestatus(light, levelcontrol=(dim, 0))
 
     def group_set_state(self, group, state=None, dim=None):
-        if state == None:
-            state = self.group_get_state(group).get('state')
-        if dim == None:
-            state = self.group_get_state(group).get('dim')
+        if dim is None:
+            return self.setdevicestatus(group, onoff=state)
+        return self.setdevicestatus(group, levelcontrol=(dim, 0))
 
-        sendState = '&lt;?xml version=&quot;1.0&quot; encoding=&quot;UTF-8&quot;?&gt;&lt;DeviceStatus&gt;&lt;IsGroupAction&gt;YES&lt;/IsGroupAction&gt;&lt;DeviceID available=&quot;YES&quot;&gt;{groupID}&lt;/DeviceID&gt;&lt;CapabilityID&gt;10006,10008&lt;/CapabilityID&gt;&lt;CapabilityValue&gt;{state},{dim}&lt;/CapabilityValue&gt;&lt;/DeviceStatus&gt;'.format(groupID=self.group_get_id(group),state=state,dim=dim)
+    def capabilities(self, device):
+        if device.tag == 'DeviceInfo':
+            capids = device.find('CapabilityIDs')
+        else:
+            assert device.tag == 'GroupInfo'
+            capids = device.find('GroupCapabilityIDs')
+        return [CAPABILITY_ID2NAME.get(c, c) for c in capids.text.split(',')]
 
+    def getdevicestatus(self, device):
+        if device.tag == 'DeviceInfo':
+            states = device.find('CurrentState').text
+        else:
+            assert device.tag == 'GroupInfo'
+            states = device.find('GroupCapabilityValues').text
+
+        status = {}
+        capabilities = self.capabilities(device)
+        for capability, state in zip(capabilities, states.split(',')):
+            if not state:
+                state = None
+            elif ':' in state:
+                state = tuple(int(v) for v in state.split(':'))
+            else:
+                state = int(state)
+            status[capability] = state
+        return status
+
+    def setdevicestatus(self, device, **kwargs):
+        if device.tag == 'DeviceInfo':
+            isgroup = 'NO'
+            devid = self.light_get_id(device)
+        else:
+            assert device.tag == 'GroupInfo'
+            isgroup = 'YES'
+            devid = self.group_get_id(device)
+
+        capids = []
+        values = []
+        for cap, val in kwargs.items():
+            capids.append(CAPABILITY_NAME2ID[cap])
+
+            if not isinstance(val, (list, tuple)):
+                val = (val,)
+            values.append(':'.join(str(v) for v in val))
+
+        req = et.Element('DeviceStatus')
+        et.SubElement(req, 'IsGroupAction').text = isgroup
+        et.SubElement(req, 'DeviceID', available="YES").text = str(devid)
+        et.SubElement(req, 'CapabilityID').text = ','.join(capids)
+        et.SubElement(req, 'CapabilityValue').text = ','.join(values)
+
+        buf = six.StringIO()
+        et.ElementTree(req).write(buf, encoding='unicode',
+                                  xml_declaration=True)
+        sendState = html_escape(buf.getvalue(), quote=True)
         return self.bridge.SetDeviceStatus(DeviceStatusList=sendState)
+
+    def get_state(self, device):
+        status = self.getdevicestatus(device)
+        state = {}
+
+        state['onoff'] = status['onoff']
+
+        if 'levelcontrol' in status:
+            state['level'] = status['levelcontrol'][0]
+
+        if 'colortemperature' in status:
+            temperature = status['colortemperature'][0]
+            state['temperature_mireds'] = temperature
+            state['temperature_kelvin'] = int(1000000 / temperature)
+
+        if 'colorcontrol' in status:
+            colorx, colory = status['colorcontrol'][:2]
+            colorxy = colorx / 65535., colory / 65535.
+            state['color_xy'] = colorxy
+
+        return state
+
+    def turn_on(self, device, level=None, transition=0):
+        T = limit(int(transition * 10), 0, 65535)
+        capabilities = self.capabilities(device)
+
+        if level is not None and 'levelcontrol' in capabilities:
+            level = limit(int(level), 0, 255)
+            return self.setdevicestatus(device, levelcontrol=(level, T))
+        elif level == 0:
+            return self.setdevicestatus(device, onoff=OFF)
+        else:
+            return self.setdevicestatus(device, onoff=ON)
+
+    def turn_off(self, device):
+        return self.setdevicestatus(device, onoff=OFF)
+
+    def toggle(self, device):
+        return self.setdevicestatus(device, onoff=TOGGLE)
+
+    def set_temperature(self, device, kelvin=2700, mireds=None, transition=0):
+        T = limit(int(transition * 10), 0, 65535)
+        if mireds is None:
+            mireds = 1000000 / kelvin
+
+        # Lightify RGBW has a range of 1900-6500K and will not change
+        # temperature if the requested value is outside of [151, 555].
+        mireds = limit(int(mireds), 151, 555)
+        return self.setdevicestatus(device, colortemperature=(mireds, T))
+
+    def set_color(self, device, colorxy, transition=0):
+        T = limit(int(transition * 10), 0, 65535)
+        colorx = limit(int(colorxy[0] * 65535), 0, 65535)
+        colory = limit(int(colorxy[1] * 65535), 0, 65535)
+        return self.setdevicestatus(device, colorcontrol=(colorx, colory, T))
+
+    def start_ramp(self, device, up, rate):
+        updown = '1' if up else '0'
+        rate = limit(int(rate), 0, 255)
+        return self.setdevicestatus(device, levelcontrol_move=(updown, rate))
+
+    def stop_ramp(self, device):
+        return self.setdevicestatus(device, levelcontrol_stop='')
+
+    def sleepfader(self, device, fadetime):
+        return self.setdevicestatus(device, sleepfader=int(fadetime))

--- a/pywemo/ouimeaux_device/bridge.py
+++ b/pywemo/ouimeaux_device/bridge.py
@@ -1,12 +1,11 @@
-from pywemo.ouimeaux_device import Device
-
+import time
 from xml.etree import cElementTree as et
 import six
-try:
-    from html import escape as html_escape
-except ImportError:
-    from cgi import escape as html_escape
+six.add_move(six.MovedAttribute('html_escape', 'cgi', 'html', 'escape'))
+from six.moves import html_escape
 
+from . import Device
+from ..color import get_profiles, limit_to_gamut
 
 CAPABILITY_ID2NAME = dict((
     ('10006', "onoff"),
@@ -35,130 +34,67 @@ class Bridge(Device):
     Lights = {}
     Groups = {}
 
+    def __init__(self, *args, **kwargs):
+        super(Bridge, self).__init__(*args, **kwargs)
+        self.get_state(force_update=True)
+
     def __repr__(self):
-        self.bridge_get_lights()
-        self.bridge_get_groups()
-        return '<WeMo Bridge "{name}", Lights: {LightCount}, Groups: {GroupCount}>'.format(name=self.name, LightCount=len(self.Lights), GroupCount=len(self.Groups))
+        return '<WeMo Bridge "{name}", Lights: {l}, Groups: {g}>'.format(
+            name=self.name, l=len(self.Lights), g=len(self.Groups))
 
-    def bridge_get_lights(self):
-        UDN = self.basicevent.GetMacAddr().get('PluginUDN')
-        endDevices = self.bridge.GetEndDevices(DevUDN=UDN,ReqListType='PAIRED_LIST')
-        endDeviceList = et.fromstring(endDevices.get('DeviceLists'))
+    def get_state(self, force_update=False):
+        if force_update or not self.Lights:
+            UDN = self.basicevent.GetMacAddr().get('PluginUDN')
+            endDevices = self.bridge.GetEndDevices(
+                DevUDN=UDN, ReqListType='PAIRED_LIST')
+            endDeviceList = et.fromstring(endDevices.get('DeviceLists'))
 
-        for light in endDeviceList.iter('DeviceInfo'):
-            self.Lights[self.light_name(light)] = light
-        return self.Lights
+            for light in endDeviceList.iter('DeviceInfo'):
+                uniqueID = light.find('DeviceID').text
+                if uniqueID in self.Lights:
+                    self.Lights[uniqueID].update(light)
+                else:
+                    self.Lights[uniqueID] = Light(self, light)
 
-    def bridge_get_groups(self):
-        UDN = self.basicevent.GetMacAddr().get('PluginUDN')
-        endDevices = self.bridge.GetEndDevices(DevUDN=UDN,ReqListType='PAIRED_LIST')
-        endDeviceList = et.fromstring(endDevices.get('DeviceLists'))
+            for group in endDeviceList.iter('GroupInfo'):
+                uniqueID = group.find('GroupID').text
+                if uniqueID in self.Groups:
+                    self.Groups[uniqueID].update(group)
+                else:
+                    self.Groups[uniqueID] = Group(self, group)
+        return self.Lights, self.Groups
 
-        for group in endDeviceList.iter('GroupInfo'):
-            self.Groups[self.group_name(group)] = group
-        return self.Groups
+    def bridge_setdevicestatus(self, isgroup, deviceid, capids, values):
+        req = et.Element('DeviceStatus')
+        et.SubElement(req, 'IsGroupAction').text = isgroup
+        et.SubElement(req, 'DeviceID', available="YES").text = deviceid
+        et.SubElement(req, 'CapabilityID').text = ','.join(capids)
+        et.SubElement(req, 'CapabilityValue').text = ','.join(values)
 
-    def light_attributes(self, light):
-        return {
-            'devIndex' : light.find('DeviceIndex').text,
-            'devID' : light.find('DeviceID').text,
-            'name' : light.find('FriendlyName').text,
-            'iconvalue' : light.find('IconVersion').text,
-            'firmware' : light.find('FirmwareVersion').text,
-            'capabilities' : light.find('CapabilityIDs').text,
-            'state' : light.find('CurrentState').text,
-            'manufacturer' : light.find('Manufacturer').text,
-            'model' : light.find('ModelCode').text,
-            'certified' : light.find('WeMoCertified').text
-        }
+        buf = six.StringIO()
+        et.ElementTree(req).write(buf, encoding='unicode',
+                                  xml_declaration=True)
+        sendState = html_escape(buf.getvalue(), quote=True)
+        return self.bridge.SetDeviceStatus(DeviceStatusList=sendState)
 
-    def group_attributes(self, group):
-        return {
-            'GroupID' : group.find('GroupID').text,
-            'name' : group.find('GroupName').text,
-            'capabilities' : group.find('GroupCapabilityIDs').text,
-            'state': group.find('GroupCapabilityValues').text
-        }
 
-    def light_name(self, light):
-        return self.light_attributes(light).get('name')
+class LinkedDevice(object):
+    def __init__(self, bridge, info):
+        self.bridge = bridge
+        self.capabilities = []
+        self._states = []
+        self.update(info)
 
-    def group_name(self, group):
-        return self.group_attributes(group).get('name')
+    def update(self, info):
+        self.info = info
 
-    def light_get_id(self, light):
-        return self.light_attributes(light).get('devID')
+    def get_state(self, force_update=False):
+        if force_update:
+            self.bridge.get_state(force_update=True)
+        return self.state
 
-    def group_get_id(self, group):
-        return self.group_attributes(group).get('GroupID')
-
-    def light_get_state(self, light):
-        """Return a dict with
-        state = 0 (off) or 1 (on)
-        dim = 0-255 dark to bright
-        """
-        state = self.getdevicestatus(light)
-        return dict(
-            state=state['onoff'],
-            dim=state['levelcontrol'][0],
-        )
-
-    def group_get_state(self, group):
-        """Return a dict with
-        state = 0 (off) or 1 (on)
-        dim = 0-255 dark to bright
-        """
-        state = self.getdevicestatus(group)
-        return dict(
-            state=state['onoff'],
-            dim=state['levelcontrol'][0],
-        )
-
-    def light_set_state(self, light, state=None, dim=None):
-        if dim is None:
-            return self.setdevicestatus(light, onoff=state)
-        return self.setdevicestatus(light, levelcontrol=(dim, 0))
-
-    def group_set_state(self, group, state=None, dim=None):
-        if dim is None:
-            return self.setdevicestatus(group, onoff=state)
-        return self.setdevicestatus(group, levelcontrol=(dim, 0))
-
-    def capabilities(self, device):
-        if device.tag == 'DeviceInfo':
-            capids = device.find('CapabilityIDs')
-        else:
-            assert device.tag == 'GroupInfo'
-            capids = device.find('GroupCapabilityIDs')
-        return [CAPABILITY_ID2NAME.get(c, c) for c in capids.text.split(',')]
-
-    def getdevicestatus(self, device):
-        if device.tag == 'DeviceInfo':
-            states = device.find('CurrentState').text
-        else:
-            assert device.tag == 'GroupInfo'
-            states = device.find('GroupCapabilityValues').text
-
-        status = {}
-        capabilities = self.capabilities(device)
-        for capability, state in zip(capabilities, states.split(',')):
-            if not state:
-                state = None
-            elif ':' in state:
-                state = tuple(int(v) for v in state.split(':'))
-            else:
-                state = int(state)
-            status[capability] = state
-        return status
-
-    def setdevicestatus(self, device, **kwargs):
-        if device.tag == 'DeviceInfo':
-            isgroup = 'NO'
-            devid = self.light_get_id(device)
-        else:
-            assert device.tag == 'GroupInfo'
-            isgroup = 'YES'
-            devid = self.group_get_id(device)
+    def _setdevicestatus(self, **kwargs):
+        isgroup = 'YES' if isinstance(self, Group) else 'NO'
 
         capids = []
         values = []
@@ -169,22 +105,26 @@ class Bridge(Device):
                 val = (val,)
             values.append(':'.join(str(v) for v in val))
 
-        req = et.Element('DeviceStatus')
-        et.SubElement(req, 'IsGroupAction').text = isgroup
-        et.SubElement(req, 'DeviceID', available="YES").text = str(devid)
-        et.SubElement(req, 'CapabilityID').text = ','.join(capids)
-        et.SubElement(req, 'CapabilityValue').text = ','.join(values)
+        return self.bridge.bridge_setdevicestatus(
+            isgroup, self.uniqueID, capids, values)
 
-        buf = six.StringIO()
-        et.ElementTree(req).write(buf, encoding='unicode',
-                                  xml_declaration=True)
-        sendState = html_escape(buf.getvalue(), quote=True)
-        return self.bridge.SetDeviceStatus(DeviceStatusList=sendState)
+    def _getdevicestatus(self):
+        status = {}
+        for capability, state in zip(self.capabilities, self._states):
+            if not state:
+                state = None
+            elif ':' in state:
+                state = tuple(int(v) for v in state.split(':'))
+            else:
+                state = int(state)
+            status[capability] = state
+        return status
 
-    def get_state(self, device):
-        status = self.getdevicestatus(device)
+    @property
+    def state(self):
+        status = self._getdevicestatus()
+
         state = {}
-
         state['onoff'] = status['onoff']
 
         if 'levelcontrol' in status:
@@ -197,52 +137,96 @@ class Bridge(Device):
 
         if 'colorcontrol' in status:
             colorx, colory = status['colorcontrol'][:2]
-            colorxy = colorx / 65535., colory / 65535.
-            state['color_xy'] = colorxy
-
+            colorx, colory = colorx / 65535., colory / 65535.
+            state['color_xy'] = colorx, colory
         return state
 
-    def turn_on(self, device, level=None, transition=0):
+    def turn_on(self, *kwargs):
+        return self._setdevicestatus(onoff=ON)
+
+    def turn_off(self):
+        return self._setdevicestatus(onoff=OFF)
+
+    def toggle(self):
+        return self._setdevicestatus(onoff=TOGGLE)
+
+
+class Light(LinkedDevice):
+    def __init__(self, bridge, info):
+        super(Light, self).__init__(bridge, info)
+        self.devIndex = info.find('DeviceIndex').text
+        self.uniqueID = info.find('DeviceID').text
+        self.iconvalue = info.find('IconVersion').text
+        self.firmware = info.find('FirmwareVersion').text
+        self.manufacturer = info.find('Manufacturer').text
+        self.model = info.find('ModelCode').text
+        self.certified = info.find('WeMoCertified').text
+
+        self.temperature_range, self.gamut = get_profiles(self.model)
+
+    def update(self, info):
+        self.info = info
+        self.name = info.find('FriendlyName').text
+        self.capabilities = [
+            CAPABILITY_ID2NAME.get(c, c)
+            for c in info.find('CapabilityIDs').text.split(',')
+        ]
+        self._states = info.find('CurrentState').text.split(',')
+
+    def __repr__(self):
+        return '<LIGHT "{name}">'.format(name=self.name)
+
+    def turn_on(self, level=None, transition=0):
         T = limit(int(transition * 10), 0, 65535)
-        capabilities = self.capabilities(device)
 
-        if level is not None and 'levelcontrol' in capabilities:
+        if level is not None and 'levelcontrol' in self.capabilities:
             level = limit(int(level), 0, 255)
-            return self.setdevicestatus(device, levelcontrol=(level, T))
+            return self._setdevicestatus(levelcontrol=(level, T))
         elif level == 0:
-            return self.setdevicestatus(device, onoff=OFF)
+            return self._setdevicestatus(onoff=OFF)
         else:
-            return self.setdevicestatus(device, onoff=ON)
+            return self._setdevicestatus(onoff=ON)
 
-    def turn_off(self, device):
-        return self.setdevicestatus(device, onoff=OFF)
-
-    def toggle(self, device):
-        return self.setdevicestatus(device, onoff=TOGGLE)
-
-    def set_temperature(self, device, kelvin=2700, mireds=None, transition=0):
+    def set_temperature(self, kelvin=2700, mireds=None, transition=0):
         T = limit(int(transition * 10), 0, 65535)
         if mireds is None:
             mireds = 1000000 / kelvin
+        mireds = limit(int(mireds), *self.temperature_range)
+        return self._setdevicestatus(colortemperature=(mireds, T))
 
-        # Lightify RGBW has a range of 1900-6500K and will not change
-        # temperature if the requested value is outside of [151, 555].
-        mireds = limit(int(mireds), 151, 555)
-        return self.setdevicestatus(device, colortemperature=(mireds, T))
-
-    def set_color(self, device, colorxy, transition=0):
+    def set_color(self, colorxy, transition=0):
         T = limit(int(transition * 10), 0, 65535)
+        colorxy = limit_to_gamut(colorxy, self.gamut)
         colorx = limit(int(colorxy[0] * 65535), 0, 65535)
         colory = limit(int(colorxy[1] * 65535), 0, 65535)
-        return self.setdevicestatus(device, colorcontrol=(colorx, colory, T))
+        return self._setdevicestatus(colorcontrol=(colorx, colory, T))
 
-    def start_ramp(self, device, up, rate):
+    def start_ramp(self, up, rate):
         updown = '1' if up else '0'
         rate = limit(int(rate), 0, 255)
-        return self.setdevicestatus(device, levelcontrol_move=(updown, rate))
+        return self._setdevicestatus(levelcontrol_move=(updown, rate))
 
-    def stop_ramp(self, device):
-        return self.setdevicestatus(device, levelcontrol_stop='')
+    def stop_ramp(self):
+        return self._setdevicestatus(levelcontrol_stop='')
 
-    def sleepfader(self, device, fadetime):
-        return self.setdevicestatus(device, sleepfader=int(fadetime))
+    def sleepfader(self, fadetime):
+        fadetime = limit(int(fadetime * 10), 0, 65535)
+        reference = int(time.time())
+        return self._setdevicestatus(sleepfader=(fadetime, reference))
+
+
+class Group(LinkedDevice):
+    def __init__(self, bridge, info):
+        super(Group, self).__init__(bridge, info)
+        self.uniqueID = info.find('GroupID').text
+
+    def update(self, info):
+        self.name = info.find('GroupName').text
+        self.capabilities = [
+            CAPABILITY_ID2NAME.get(c, c)
+            for c in info.find('GroupCapabilityIDs').text.split(',')
+        ]
+        self._states = info.find('GroupCapabilityValues').text.split(',')
+
+    def __repr__(self):
+        return '<GROUP "{name}">'.format(name=self.name)


### PR DESCRIPTION
This pretty much rewrites the interface how we talk to zigbee devices through a wemo bridge, so this is really a request for comments.
- Using elementtree to format the setdevicestatus xml request.
- Added support for colortemperature and colorcontrol, see #33  (tested with Osram Lightify RGBW)
- Added per-light/group instances which reduce the number of arguments we need to pass when controlling the lights.
- On the bridge, index devices based on unique device identifier, instead of the user-configured name.
