### PR TITLE
Fix crash when SSDP response has empty device description.

### DIFF
--- a/pywemo/ssdp.py
+++ b/pywemo/ssdp.py
@@ -236,8 +236,11 @@ def scan(st=None, timeout=DISCOVER_TIMEOUT, max_entries=None, match_mac=None):
                 response = sock.recv(1024).decode("ascii")
 
                 entry = UPNPEntry.from_response(response)
-                device = entry.description.get('device')
-                mac = None if device is None else device.get('macAddress')
+                if entry.description is not None:
+                    device = entry.description.get('device', {})
+                    mac = device.get('macAddress')
+                else:
+                    mac = None
 
                 if ((st is None or entry.st == st) and
                    (match_mac is None or mac == match_mac) and


### PR DESCRIPTION
Bug was reported by @liocer on the home-assistant gitter. This is probably the same problem as in #11, but hitting in a different place of the discovery code.
