### PR TITLE
Distinguish between connection and read timeouts when probing wemos

### DIFF
--- a/pywemo/ouimeaux_device/__init__.py
+++ b/pywemo/ouimeaux_device/__init__.py
@@ -29,7 +29,18 @@ def probe_wemo(host):
                              timeout=10)
             if 'WeMo' in r.text:
               return port
+        except requests.exceptions.ConnectTimeout:
+            # If we timed out connecting, then the wemo is gone,
+            # no point in trying further.
+            log.debug('Timed out connecting to %s on port %i, '
+                      'wemo is offline', host, port)
+            break
         except requests.exceptions.Timeout:
+            # Apparently sometimes wemos get into a wedged state where
+            # they still accept connections on an old port, but do not
+            # respond. If that happens, we should keep searching.
+            log.debug('No response from %s on port %i, continuing',
+                      host, port)
             continue
         except requests.exceptions.ConnectionError:
             pass


### PR DESCRIPTION
When probing for a wemo, we want to stop the probe immediately when
we get a connection timeout because it means the wemo didn't respond
at all (even with a RST on the invalid port). However, it appears
that sometimes wemos will get wedged such that they continue to
accept() on the old port, but won't respond. Our current logic treats
that the same as a connection timeout, when really we need to ignore
that case and continue to the next port.

This change breaks out ConnectTimeout from Timeout (which is really
just ReadTimeout). It bails on the former and continues on the latter
to give the desired behavior.

I tested this by simulating a connection reset on 49152 (nothing running), a stuck port on 49153 (nc -l), and finally a dead wemo when we get to 49154, by dropping inbound packets:

```
$ iptables -I INPUT -p tcp --dport 49154 -i lo -j DROP
$ nc -l 49153 &
$ python
Python 2.7.6 (default, Jun 22 2015, 17:58:13)
[GCC 4.8.2] on linux2
Type "help", "copyright", "credits" or "license" for more information.
>>> import logging
>>> logging.basicConfig(level=logging.DEBUG)
>>> import pywemo
>>> pywemo.ouimeaux_device.probe_wemo('127.0.0.1')
INFO:requests.packages.urllib3.connectionpool:Starting new HTTP connection (1): 127.0.0.1
INFO:requests.packages.urllib3.connectionpool:Starting new HTTP connection (1): 127.0.0.1
DEBUG:pywemo.ouimeaux_device:No response from 127.0.0.1 on port 49153, continuing
INFO:requests.packages.urllib3.connectionpool:Starting new HTTP connection (1): 127.0.0.1
DEBUG:pywemo.ouimeaux_device:Timed out connecting to 127.0.0.1 on port 49154, wemo is offline
```

The first log line is it trying 49152, failing immediately with connection refused. The second is it talking to a non-responding netcat on 49153, and the last appears to it to be a dead wemo because it gets a connection timeout due to dropped packets on 49154.
