### PR TITLE
Roll back the use of the GetDeviceStatus call.

### DIFF
--- a/pywemo/ouimeaux_device/bridge.py
+++ b/pywemo/ouimeaux_device/bridge.py
@@ -93,8 +93,7 @@ class LinkedDevice(object):
 
     def get_state(self, force_update=False):
         if force_update:
-            status = self.bridge.bridge_getdevicestatus(self.uniqueID)
-            self._update_state(status)
+            self.bridge.bridge_update()
         return self.state
 
     def _update_state(self, status):


### PR DESCRIPTION
It turns out that what is reported by GetDeviceStatus is pretty unreliable.
All I had to do was turn on a poor quality lightbulb that has a high pitched
whine, it must be putting out quite a bit of RF noise too because although I
could still control my lights, they were reporting back as unavailable.

This in itself is not a big deal, but when changing the color values with
home-assistant while we are not getting valid status makes the bulbs flash
annoyingly.
