### PR TITLE
Bind to ip address of host name in ssdp::scan function

### DIFF
--- a/pywemo/ssdp.py
+++ b/pywemo/ssdp.py
@@ -216,6 +216,7 @@ def scan(st=None, timeout=DISCOVER_TIMEOUT, max_entries=None, match_mac=None):
 
     try:
         sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        sock.bind((socket.gethostbyname(socket.gethostname()),0))
 
         sock.sendto(ssdp_request, ssdp_target)
 


### PR DESCRIPTION
This fixes my Windows 10 issue but messes up linux, as my linux machine hostname is mapped to 127.0.0.1 where the Windows machine is resolving to the IP address of the ethernet card.
My solution on linux is to modify the /etc/hosts file so the hostname points to the IP address you wish to use for the source address. The other option would be to redesign and pass in the source IP address on the command line or via a config file.

Thoughts?
