### PR TITLE
Change encoding to "utf-8".

### DIFF
--- a/pywemo/ouimeaux_device/bridge.py
+++ b/pywemo/ouimeaux_device/bridge.py
@@ -77,7 +77,7 @@ class Bridge(Device):
         et.SubElement(req, 'CapabilityValue').text = ','.join(values)
 
         buf = six.StringIO()
-        et.ElementTree(req).write(buf, encoding='unicode',
+        et.ElementTree(req).write(buf, encoding='utf-8',
                                   xml_declaration=True)
         sendState = html_escape(buf.getvalue(), quote=True)
         return self.bridge.SetDeviceStatus(DeviceStatusList=sendState)


### PR DESCRIPTION
Using the encoding "unicode" raises the error:
LookupError: unknown encoding: unicode
