### PR TITLE
Fix incompatibility with requests 2.11.0 and port number typo 

### DIFF
--- a/pywemo/ouimeaux_device/__init__.py
+++ b/pywemo/ouimeaux_device/__init__.py
@@ -13,7 +13,7 @@ from .api.xsd import device as deviceParser
 
 log = logging.getLogger(__name__)
 
-PROBE_PORTS = (45152, 49153, 49154)
+PROBE_PORTS = (49152, 49153, 49154)
 
 
 def probe_wemo(host):

--- a/pywemo/subscribe.py
+++ b/pywemo/subscribe.py
@@ -100,7 +100,7 @@ class SubscriptionRegistry(object):
 
   def _resubscribe(self, device, sid=None, retry=0):
     LOG.info("Resubscribe for %s", device)
-    headers = {'TIMEOUT': 300}
+    headers = {'TIMEOUT': '300'}
     if sid is not None:
       headers['SID'] = sid
     else:
@@ -126,10 +126,10 @@ class SubscriptionRegistry(object):
         self._events[device.serialnumber] = (
             self._sched.enter(int(timeout * 0.75),
                               0, self._resubscribe, [device, sid]))
-    except requests.exceptions.RequestException:
+    except requests.exceptions.RequestException as ex:
       LOG.warning(
-          "Resubscribe error for %s, will retry in %ss",
-          device, SUBSCRIPTION_RETRY)
+          "Resubscribe error for %s (%s), will retry in %ss",
+          device, ex, SUBSCRIPTION_RETRY)
       retry += 1
       if retry > 1:
         # If this wan't a one off try rediscovery in case device has changed

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 
 setup(name='pywemo',
-      version='0.4.4',
+      version='0.4.5',
       description='Access WeMo switches using their SOAP API',
       url='http://github.com/pavoni/pywemo',
       author='Greg Dowling',


### PR DESCRIPTION
Fixes an incompability with requests 2.11.0 that stop subscriptions working.

Closes https://github.com/pavoni/pywemo/issues/51 

Also fixes a long standing port number typo.

Closes https://github.com/pavoni/pywemo/issues/50
