### PR TITLE
Update bridge.py

### DIFF
--- a/pywemo/ouimeaux_device/bridge.py
+++ b/pywemo/ouimeaux_device/bridge.py
@@ -76,10 +76,10 @@ class Bridge(Device):
         et.SubElement(req, 'CapabilityID').text = ','.join(capids)
         et.SubElement(req, 'CapabilityValue').text = ','.join(values)
 
-        buf = six.StringIO()
+        buf = six.BytesIO()
         et.ElementTree(req).write(buf, encoding='utf-8',
                                   xml_declaration=True)
-        sendState = html_escape(buf.getvalue(), quote=True)
+        sendState = html_escape(str(buf.getvalue()), quote=True)
         return self.bridge.SetDeviceStatus(DeviceStatusList=sendState)
 
 

--- a/pywemo/ouimeaux_device/bridge.py
+++ b/pywemo/ouimeaux_device/bridge.py
@@ -79,7 +79,7 @@ class Bridge(Device):
         buf = six.BytesIO()
         et.ElementTree(req).write(buf, encoding='utf-8',
                                   xml_declaration=True)
-        sendState = html_escape(str(buf.getvalue()), quote=True)
+        sendState = html_escape(buf.getvalue().decode(), quote=True)
         return self.bridge.SetDeviceStatus(DeviceStatusList=sendState)
 
 


### PR DESCRIPTION
Python 3.5. When I tried to turn on a light, I got the following error (from ElementTree):
TypeError: string argument expected, got 'bytes'

My edit seems to solve the problem. However, you should check it still works in Python 2.
