### PR TITLE
Search for additional string in device return text.  Fixes #57.

### DIFF
--- a/pywemo/ouimeaux_device/__init__.py
+++ b/pywemo/ouimeaux_device/__init__.py
@@ -28,7 +28,7 @@ def probe_wemo(host):
         try:
             r = requests.get('http://%s:%i/setup.xml' % (host, port),
                              timeout=10)
-            if 'WeMo' in r.text:
+            if ('WeMo' in r.text) or ('Belkin' in r.text):
                 return port
         except requests.exceptions.ConnectTimeout:
             # If we timed out connecting, then the wemo is gone,


### PR DESCRIPTION
Verified fixes #57 as well as does not break previous functionality:
```python
import pywemo

addresses = ("192.168.14.103", "192.168.14.100", "192.168.14.102")

for a in addresses:
    try:
        port = pywemo.ouimeaux_device.probe_wemo(a)
        print(port)
        url = 'http://%s:%i/setup.xml' % (a, port)
        print(url)
        device = pywemo.discovery.device_from_description(url, None)
        print(device)
    except:
        s = "Could not probe device %s" % (a)
        print(s)
```
```
[kjohnson@kyle-arch pywemo]$ python test.py 
49153
http://192.168.14.103:49153/setup.xml
<WeMo Switch "Humidifier Switch">
49153
http://192.168.14.100:49153/setup.xml
<WeMo LightSwitch "Kitchen Lights">
49153
http://192.168.14.102:49153/setup.xml
<WeMo LightSwitch "Island">
```

On master, the following is returned:
```
[kjohnson@kyle-arch pywemo]$ python test.py 
None
Could not probe device 192.168.14.103
49153
http://192.168.14.100:49153/setup.xml
<WeMo LightSwitch "Kitchen Lights">
49153
http://192.168.14.102:49153/setup.xml
<WeMo LightSwitch "Island">

```