### PR TITLE
Ability to use subscription to update insight switch.

### DIFF
--- a/pywemo/ouimeaux_device/coffeemaker.py
+++ b/pywemo/ouimeaux_device/coffeemaker.py
@@ -72,7 +72,7 @@ class CoffeeMaker(Switch):
         self._attributes = attributeXmlToDict(resp)
         self._state = self.mode
 
-    def subscription_callback(self, xmlBlob):
+    def subscription_update(self, _type, xmlBlob):
         """
         Handle reports from device
         """

--- a/pywemo/subscribe.py
+++ b/pywemo/subscribe.py
@@ -146,7 +146,7 @@ class SubscriptionRegistry(object):
     LOG.info("Received event from %s(%s) - %s %s", device, device.host, type_, value)
     for type_filter, callback in self._callbacks.get(device, ()):
       if type_filter is None or type_ == type_filter:
-        callback(device, value)
+        callback(device, type_, value)
 
   def on(self, device, type_filter, callback):
     self._callbacks[device].append((type_filter, callback))

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 
 setup(name='pywemo',
-      version='0.4.13',
+      version='0.4.14',
       description='Access WeMo switches using their SOAP API',
       url='http://github.com/pavoni/pywemo',
       author='Greg Dowling',


### PR DESCRIPTION
This steals the idea from @stu-gott to use the subscription update to set the device state for Insight switches - rather than refetching.

 This is a bigger win now we're getting updates for Insight devices every second.

@stu-gott At some point I'll finish the refactor - and add this to other devices. Could you let me know what `_type` is logged for the `CoffeeMaker`? My plan is to pass unknown subscription types up the object hierarchy (eg so the base `Switch` can handle the basic on off updates).

I'll merge and release - so this can easily be tested in HA - but happy to fix any concerns or issues.