### PR TITLE
Fix compatability with Sylvania tunable white bulbs

### DIFF
--- a/pywemo/ouimeaux_device/bridge.py
+++ b/pywemo/ouimeaux_device/bridge.py
@@ -105,7 +105,7 @@ class LinkedDevice(object):
             if not value:
                 value = None
             elif ':' in value:
-                value = tuple(int(v) for v in value.split(':'))
+                value = tuple(int(float(v)) for v in value.split(':'))
             else:
                 value = int(value)
             status[capability] = value

--- a/pywemo/ouimeaux_device/bridge.py
+++ b/pywemo/ouimeaux_device/bridge.py
@@ -105,7 +105,7 @@ class LinkedDevice(object):
             if not value:
                 value = None
             elif ':' in value:
-                value = tuple(int(float(v)) for v in value.split(':'))
+                value = tuple(int(round(float(v))) for v in value.split(':'))
             else:
                 value = int(value)
             status[capability] = value

--- a/pywemo/ouimeaux_device/bridge.py
+++ b/pywemo/ouimeaux_device/bridge.py
@@ -107,7 +107,7 @@ class LinkedDevice(object):
             elif ':' in value:
                 value = tuple(int(round(float(v))) for v in value.split(':'))
             else:
-                value = int(value)
+                value = int(round(float(value)))
             status[capability] = value
 
         # unreachable devices have empty strings for all capability values


### PR DESCRIPTION
It seems that Osram/Sylvania Lightify tunable white bulbs report their status as float strings, which led to a typecasting issue when casting directly to int. This has now been tested to work with the Sylvania Lightify A19 Tunable White 60W equivalent bulb.