### PR TITLE
Use common format for CoffeeMaker and Insight

### DIFF
--- a/pywemo/ouimeaux_device/coffeemaker.py
+++ b/pywemo/ouimeaux_device/coffeemaker.py
@@ -72,16 +72,16 @@ class CoffeeMaker(Switch):
         self._attributes = attributeXmlToDict(resp)
         self._state = self.mode
 
-    def subscription_update(self, _type, xmlBlob):
+    def subscription_update(self, _type, _params):
         """
         Handle reports from device
         """
         if _type == "attributeList":
-            self._attributes.update(attributeXmlToDict(xmlBlob))
+            self._attributes.update(attributeXmlToDict(_params))
             self._state = self.mode
             return True
 
-        return Switch.update_insight_params(self, _type, _params)
+        return Switch.subscription_update(self, _type, _params)
 
     @property
     def mode(self):


### PR DESCRIPTION
update_insight_params is not a method that Switch has. I assume this should have been subscription_update.

Tested on HA 0.42.2