### PR TITLE
Handle None uuid in discovery

### DIFF
--- a/pywemo/discovery.py
+++ b/pywemo/discovery.py
@@ -42,7 +42,9 @@ def device_from_description(description_url, mac):
 
 def device_from_uuid_and_location(uuid, mac, location):
     """ Tries to determine which device it is based on the uuid. """
-    if uuid.startswith('uuid:Socket'):
+    if uuid is None:
+        return None
+    elif uuid.startswith('uuid:Socket'):
         return Switch(location, mac)
     elif uuid.startswith('uuid:Lightswitch'):
         return LightSwitch(location, mac)


### PR DESCRIPTION
I'm using [Home Assistant](https://home-assistant.io/) to manage my WeMo devices, and I'm encountering this error:
```
2017-06-18 11:26:21 ERROR (MainThread) [homeassistant.setup] Error during setup of component wemo
Traceback (most recent call last):
  File "/home/homeassistant/homeassistant/lib/python3.4/site-packages/homeassistant/setup.py", line 190, in _async_setup_component
    component.setup, hass, processed_config)
  File "/usr/lib/python3.4/asyncio/futures.py", line 388, in __iter__
    yield self  # This tells Task to wait for completion.
  File "/usr/lib/python3.4/asyncio/tasks.py", line 286, in _wakeup
    value = future.result()
  File "/usr/lib/python3.4/asyncio/futures.py", line 277, in result
    raise self._exception
  File "/usr/lib/python3.4/concurrent/futures/thread.py", line 54, in run
    result = self.fn(*self.args, **self.kwargs)
  File "/home/homeassistant/homeassistant/lib/python3.4/site-packages/homeassistant/components/wemo.py", line 82, in setup
    devices = [(device.host, device) for device in pywemo.discover_devices()]
  File "/home/homeassistant/.homeassistant/deps/pywemo/discovery.py", line 28, in discover_devices
    device = device_from_description(entry.location, mac)
  File "/home/homeassistant/.homeassistant/deps/pywemo/discovery.py", line 40, in device_from_description
    return device_from_uuid_and_location(uuid, mac, description_url)
  File "/home/homeassistant/.homeassistant/deps/pywemo/discovery.py", line 45, in device_from_uuid_and_location
    if uuid.startswith('uuid:Socket'):
AttributeError: 'NoneType' object has no attribute 'startswith'
```

I've been using this fix locally for some time, but thought it would be worth contributing upstream. I'm not sure exactly why the switches on my network cause this - happy to help investigate the underlying cause if needs be!