### PR TITLE
attempt to handle probing devices that offer multiple switches

### DIFF
--- a/pywemo/ouimeaux_device/__init__.py
+++ b/pywemo/ouimeaux_device/__init__.py
@@ -14,7 +14,8 @@ from .api.xsd import device as deviceParser
 log = logging.getLogger(__name__)
 
 # Start with the most commonly used port
-PROBE_PORTS = (49153, 49152, 49154, 49155, 49156, 49157, 49158, 49159)
+PROBE_PORTS = (49153, 49152, 49154, 49155, 49156, 49157, 49158, 49159,
+        49160)
 
 
 def probe_wemo(host, description=None):


### PR DESCRIPTION
devices such as https://www.digital-loggers.com/pro.html emulate a
wemo device. They offer multiple ports by having each switch port
use a different tcp port. added an optional argument to probe_wemo
function to pass in the description and have an extra check. In my
testing it worked to detect my devices and get the tcp ports correct

Signed-off-by: Dennis Gilmore <dennis@ausil.us>