### PR TITLE
Add additional commonly used ports for probing

### DIFF
--- a/pywemo/ouimeaux_device/__init__.py
+++ b/pywemo/ouimeaux_device/__init__.py
@@ -14,7 +14,7 @@ from .api.xsd import device as deviceParser
 log = logging.getLogger(__name__)
 
 # Start with the most commonly used port
-PROBE_PORTS = (49153, 49152, 49154)
+PROBE_PORTS = (49153, 49152, 49154, 49151, 49155)
 
 
 def probe_wemo(host):


### PR DESCRIPTION
Fixes pavoni/pywemo#80

Looking at other similar libraries it seems to be consensus that ports 49151, 49155 should also be probed when communicating with WeMo switches.