### PR TITLE
Import errors directly to module for probe_wemo

### DIFF
--- a/pywemo/ouimeaux_device/__init__.py
+++ b/pywemo/ouimeaux_device/__init__.py
@@ -7,6 +7,9 @@ except ImportError:
     from urlparse import urlparse
 
 import requests
+from requests import ConnectTimeout
+from requests import ConnectionError
+from requests import Timeout
 
 from .api.service import Service
 from .api.xsd import device as deviceParser
@@ -30,20 +33,20 @@ def probe_wemo(host):
                              timeout=10)
             if ('WeMo' in r.text) or ('Belkin' in r.text):
                 return port
-        except requests.exceptions.ConnectTimeout:
+        except ConnectTimeout:
             # If we timed out connecting, then the wemo is gone,
             # no point in trying further.
             log.debug('Timed out connecting to %s on port %i, '
                       'wemo is offline', host, port)
             break
-        except requests.exceptions.Timeout:
+        except Timeout:
             # Apparently sometimes wemos get into a wedged state where
             # they still accept connections on an old port, but do not
             # respond. If that happens, we should keep searching.
             log.debug('No response from %s on port %i, continuing',
                       host, port)
             continue
-        except requests.exceptions.ConnectionError:
+        except ConnectionError:
             pass
     return None
 


### PR DESCRIPTION
This resolves an issue when running in home-assistant that causes different instances
of requests to be used when the errors are raised

Fixes #93 and fixes #90.