### PR TITLE
Fix available status on light bulbs

### DIFF
--- a/pywemo/ouimeaux_device/bridge.py
+++ b/pywemo/ouimeaux_device/bridge.py
@@ -44,8 +44,12 @@ class Bridge(Device):
 
     def bridge_update(self):
         UDN = self.basicevent.GetMacAddr().get('PluginUDN')
-        endDevices = self.bridge.GetEndDevices(
-            DevUDN=UDN, ReqListType='PAIRED_LIST')
+        if hasattr(self.bridge,'GetEndDevicesWithStatus'):
+            endDevices = self.bridge.GetEndDevicesWithStatus(
+                DevUDN=UDN, ReqListType='PAIRED_LIST')
+        else:
+            endDevices = self.bridge.GetEndDevices(
+                DevUDN=UDN, ReqListType='PAIRED_LIST')
         endDeviceList = et.fromstring(endDevices.get('DeviceLists'))
 
         for light in endDeviceList.iter('DeviceInfo'):


### PR DESCRIPTION
My Wemo bulbs don't properly report their status after power up or power down using the 'GetEndDevices' request. 'GetEndDevicesWithStatus' appears to report almost exactly the same thing with a couple of extra xml elements and it does correctly notice the power state change. I have kept the old request in the code as a backup in-case older or other devices don't have 'GetEndDevicesWithStatus'.