### PR TITLE
Allow autodiscovery of mac in pywemo.discovery.device_from_description()

### DIFF
--- a/pywemo/discovery.py
+++ b/pywemo/discovery.py
@@ -1,6 +1,7 @@
 """
 Module to discover WeMo devices.
 """
+import logging
 import requests
 
 from . import ssdp
@@ -14,6 +15,8 @@ from .ouimeaux_device.maker import Maker
 from .ouimeaux_device.coffeemaker import CoffeeMaker
 from .ouimeaux_device.humidifier import Humidifier
 from .ouimeaux_device.api.xsd import device as deviceParser
+
+LOG = logging.getLogger(__name__)
 
 
 def discover_devices(st=None, max_devices=None, match_mac=None):
@@ -39,6 +42,15 @@ def device_from_description(description_url, mac):
     """ Returns object representing WeMo device running at host, else None. """
     xml = requests.get(description_url, timeout=10)
     uuid = deviceParser.parseString(xml.content).device.UDN
+
+    if mac is None:
+        try:
+            mac = deviceParser.parseString(xml.content).device.macAddress
+        except:
+            LOG.debug(
+                'No MAC address was supplied, and discovery is unable to find device MAC in setup xml at: %s.'
+                , description_url)
+
     return device_from_uuid_and_location(uuid, mac, description_url)
 
 

--- a/pywemo/ouimeaux_device/api/xsd/device.py
+++ b/pywemo/ouimeaux_device/api/xsd/device.py
@@ -718,7 +718,7 @@ class SpecVersionType(GeneratedsSuper):
 class DeviceType(GeneratedsSuper):
     subclass = None
     superclass = None
-    def __init__(self, deviceType=None, friendlyName=None, manufacturer=None, manufacturerURL=None, modelDescription=None, modelName=None, modelNumber=None, modelURL=None, serialNumber=None, UDN=None, UPC=None, iconList=None, serviceList=None, deviceList=None, presentationURL=None, anytypeobjs_=None):
+    def __init__(self, deviceType=None, friendlyName=None, manufacturer=None, manufacturerURL=None, modelDescription=None, modelName=None, modelNumber=None, modelURL=None, serialNumber=None, UDN=None, macAddress=None, UPC=None, iconList=None, serviceList=None, deviceList=None, presentationURL=None, anytypeobjs_=None):
         self.deviceType = deviceType
         self.friendlyName = friendlyName
         self.manufacturer = manufacturer
@@ -729,6 +729,7 @@ class DeviceType(GeneratedsSuper):
         self.modelURL = modelURL
         self.serialNumber = serialNumber
         self.UDN = UDN
+        self.macAddress = macAddress
         self.UPC = UPC
         self.iconList = iconList
         self.serviceList = serviceList
@@ -764,6 +765,8 @@ class DeviceType(GeneratedsSuper):
     def set_serialNumber(self, serialNumber): self.serialNumber = serialNumber
     def get_UDN(self): return self.UDN
     def set_UDN(self, UDN): self.UDN = UDN
+    def get_macAddress(self): return self.macAddress
+    def set_macAddress(self, macAddress): self.macAddress = macAddress
     def get_UPC(self): return self.UPC
     def set_UPC(self, UPC): self.UPC = UPC
     def get_iconList(self): return self.iconList
@@ -831,6 +834,9 @@ class DeviceType(GeneratedsSuper):
         if self.UDN is not None:
             showIndent(outfile, level, pretty_print)
             outfile.write('<%sUDN>%s</%sUDN>%s' % (namespace_, self.gds_format_string(quote_xml(self.UDN).encode(ExternalEncoding), input_name='UDN'), namespace_, eol_))
+        if self.macAddress is not None:
+            showIndent(outfile, level, pretty_print)
+            outfile.write('<%smacAddress>%s</%smacAddress>%s' % (namespace_, self.gds_format_string(quote_xml(self.macAddress).encode(ExternalEncoding), input_name='macAddress'), namespace_, eol_))
         if self.UPC is not None:
             showIndent(outfile, level, pretty_print)
             outfile.write('<%sUPC>%s</%sUPC>%s' % (namespace_, self.gds_format_string(quote_xml(self.UPC).encode(ExternalEncoding), input_name='UPC'), namespace_, eol_))
@@ -857,6 +863,7 @@ class DeviceType(GeneratedsSuper):
             self.modelURL is not None or
             self.serialNumber is not None or
             self.UDN is not None or
+            self.macAddress is not None or
             self.UPC is not None or
             self.iconList is not None or
             self.serviceList is not None or
@@ -905,6 +912,9 @@ class DeviceType(GeneratedsSuper):
         if self.UDN is not None:
             showIndent(outfile, level)
             outfile.write('UDN=%s,\n' % quote_python(self.UDN).encode(ExternalEncoding))
+        if self.macAddress is not None:
+            showIndent(outfile, level)
+            outfile.write('macAddress=%s,\n' % quote_python(self.macAddress).encode(ExternalEncoding))
         if self.UPC is not None:
             showIndent(outfile, level)
             outfile.write('UPC=%s,\n' % quote_python(self.UPC).encode(ExternalEncoding))
@@ -985,6 +995,10 @@ class DeviceType(GeneratedsSuper):
             UDN_ = child_.text
             UDN_ = self.gds_validate_string(UDN_, node, 'UDN')
             self.UDN = UDN_
+        elif nodeName_ == 'macAddress':
+            macAddress_ = child_.text
+            macAddress_ = self.gds_validate_string(macAddress_, node, 'macAddress')
+            self.macAddress = macAddress_
         elif nodeName_ == 'UPC':
             UPC_ = child_.text
             UPC_ = self.gds_validate_string(UPC_, node, 'UPC')

--- a/pywemo/ouimeaux_device/api/xsd/device.xsd
+++ b/pywemo/ouimeaux_device/api/xsd/device.xsd
@@ -44,6 +44,7 @@
       <xs:element name="modelURL" type="xs:string" minOccurs="0" maxOccurs="1" />
       <xs:element name="serialNumber" type="xs:string" minOccurs="0" maxOccurs="1" />
       <xs:element name="UDN" type="xs:string" minOccurs="1" maxOccurs="1" />
+      <xs:element name="macAddress" type="xs:string" minOccurs="0" maxOccurs="1" />
       <xs:element name="UPC" type="xs:string" minOccurs="0" maxOccurs="1" />
       <xs:element name="iconList" type="IconListType" minOccurs="0" maxOccurs="1" />
       <xs:element name="serviceList" type="ServiceListType" minOccurs="0" maxOccurs="1" />

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 
 setup(name='pywemo',
-      version='0.4.28',
+      version='0.4.29',
       description='Access WeMo switches using their SOAP API',
       url='http://github.com/pavoni/pywemo',
       author='Greg Dowling',


### PR DESCRIPTION
If None is passed to pywemo.discovery.device_from_discovery() for the mac parameter, pywemo will attempt to discover the mac from the description_url.

This will help resolve https://github.com/home-assistant/home-assistant/issues/16010 as Home Assistant calls pywemo.discovery.device_from_description(), passing in None as the mac. This is causing pywemo to never populate the mac of the device, and therefore pywemo can't use the mac during rediscovery when a device goes offline/changes IP address. If pywemo doesn't know the device mac, then rediscovery only attempts to probe the existing device, and doesn't ever run a full discovery to look for the device again (because it needs to find the device by mac to know it has found the same device again).