### PR TITLE
Update rediscovery logic to match on serial instead of only on mac

### DIFF
--- a/pywemo/discovery.py
+++ b/pywemo/discovery.py
@@ -19,10 +19,11 @@ from .ouimeaux_device.api.xsd import device as deviceParser
 LOG = logging.getLogger(__name__)
 
 
-def discover_devices(st=None, max_devices=None, match_mac=None):
+def discover_devices(st=None, max_devices=None, match_mac=None, match_serial=None):
     """ Finds WeMo devices on the local network. """
     st = st or ssdp.ST_ROOTDEVICE
-    ssdp_entries = ssdp.scan(st, max_entries=max_devices, match_mac=match_mac)
+    ssdp_entries = ssdp.scan(st, max_entries=max_devices,
+                             match_mac=match_mac, match_serial=match_serial)
 
     wemos = []
 
@@ -48,7 +49,7 @@ def device_from_description(description_url, mac):
             mac = deviceParser.parseString(xml.content).device.macAddress
         except:
             LOG.debug(
-                'No MAC address was supplied, and discovery is unable to find device MAC in setup xml at: %s.'
+                'No MAC address was supplied or found in setup xml at: %s.'
                 , description_url)
 
     return device_from_uuid_and_location(uuid, mac, description_url)

--- a/pywemo/ouimeaux_device/__init__.py
+++ b/pywemo/ouimeaux_device/__init__.py
@@ -150,7 +150,7 @@ class Device(object):
         return True
 
     def reconnect_with_device(self):
-        if not self._reconnect_with_device_by_probing():
+        if not self._reconnect_with_device_by_probing() and (self.mac or self.serialnumber):
             self._reconnect_with_device_by_discovery()
 
     def parse_basic_state(self, params):

--- a/pywemo/ouimeaux_device/__init__.py
+++ b/pywemo/ouimeaux_device/__init__.py
@@ -14,7 +14,7 @@ from requests import Timeout
 from .api.service import Service
 from .api.xsd import device as deviceParser
 
-log = logging.getLogger(__name__)
+LOG = logging.getLogger(__name__)
 
 # Start with the most commonly used port
 PROBE_PORTS = (49153, 49152, 49154, 49151, 49155)
@@ -36,14 +36,14 @@ def probe_wemo(host, ports=PROBE_PORTS, probe_timeout=10):
         except ConnectTimeout:
             # If we timed out connecting, then the wemo is gone,
             # no point in trying further.
-            log.debug('Timed out connecting to %s on port %i, '
+            LOG.debug('Timed out connecting to %s on port %i, '
                       'wemo is offline', host, port)
             break
         except Timeout:
             # Apparently sometimes wemos get into a wedged state where
             # they still accept connections on an old port, but do not
             # respond. If that happens, we should keep searching.
-            log.debug('No response from %s on port %i, continuing',
+            LOG.debug('No response from %s on port %i, continuing',
                       host, port)
             continue
         except ConnectionError:
@@ -103,15 +103,17 @@ class Device(object):
             return
 
         self.retrying = True
-        log.info("Trying to reconnect with {}".format(self.name))
+        LOG.info("Trying to reconnect with {}".format(self.name))
         # We will try to find it 5 times, each time we wait a bigger interval
         try_no = 0
 
         while True:
-            found = discover_devices(None, 1, self.mac)
+            found = discover_devices(st=None, max_devices=1,
+                                     match_mac=self.mac,
+                                     match_serial=self.serialnumber)
 
             if found:
-                log.info("Found {} again, updating local values".
+                LOG.info("Found {} again, updating local values".
                          format(self.name))
 
                 self.__dict__ = found[0].__dict__
@@ -120,12 +122,12 @@ class Device(object):
 
             wait_time = try_no * 5
 
-            log.info(
+            LOG.info(
                 "{} Not found in try {}. Trying again in {} seconds".format(
                     self.name, try_no, wait_time))
 
             if try_no == 5:
-                log.error(
+                LOG.error(
                     "Unable to reconnect with {} in 5 tries. Stopping.".
                     format(self.name))
                 self.retrying = False
@@ -138,9 +140,9 @@ class Device(object):
     def _reconnect_with_device_by_probing(self):
         port = probe_device(self)
         if port is None:
-            log.error('Unable to re-probe wemo at {}'.format(self.host))
+            LOG.error('Unable to re-probe wemo at {}'.format(self.host))
             return False
-        log.info('Reconnected to wemo at {} on port {}'.format(
+        LOG.info('Reconnected to wemo at {} on port {}'.format(
             self.host, port))
         self.port = port
         url = 'http://{}:{}/setup.xml'.format(self.host, self.port)
@@ -148,7 +150,7 @@ class Device(object):
         return True
 
     def reconnect_with_device(self):
-        if not self._reconnect_with_device_by_probing() and self.mac:
+        if not self._reconnect_with_device_by_probing():
             self._reconnect_with_device_by_discovery()
 
     def parse_basic_state(self, params):

--- a/pywemo/ssdp.py
+++ b/pywemo/ssdp.py
@@ -192,7 +192,7 @@ class UPNPEntry(object):
 
 
 # pylint: disable=invalid-name
-def scan(st=None, timeout=DISCOVER_TIMEOUT, max_entries=None, match_mac=None):
+def scan(st=None, timeout=DISCOVER_TIMEOUT, max_entries=None, match_mac=None, match_serial=None):
     """
     Sends a message over the network to discover upnp devices.
 
@@ -245,12 +245,15 @@ def scan(st=None, timeout=DISCOVER_TIMEOUT, max_entries=None, match_mac=None):
                 if entry.description is not None:
                     device = entry.description.get('device', {})
                     mac = device.get('macAddress')
+                    serial = device.get('serialNumber')
                 else:
                     mac = None
+                    serial = None
 
                 if ((st is None or entry.st == st) and
-                   (match_mac is None or mac == match_mac) and
-                   entry not in entries):
+                        (match_mac is None or mac == match_mac) and
+                        (match_serial is None or serial == match_serial) and
+                        entry not in entries):
                     entries.append(entry)
 
                     if max_entries and len(entries) == max_entries:

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 
 setup(name='pywemo',
-      version='0.4.29',
+      version='0.4.30',
       description='Access WeMo switches using their SOAP API',
       url='http://github.com/pavoni/pywemo',
       author='Greg Dowling',


### PR DESCRIPTION
This change allows the rediscovery logic to find a device by serial number as well as mac.