### PR TITLE
Fix false-positive in rediscovery

### DIFF
--- a/pywemo/ssdp.py
+++ b/pywemo/ssdp.py
@@ -251,16 +251,16 @@ def scan(st=None, timeout=DISCOVER_TIMEOUT, max_entries=None, match_mac=None, ma
                     serial = None
 
                 # Search for devices
-                if st:
-                    if st == entry.st:
+                if st is not None or match_mac is not None or match_serial is not None:
+                    if st is not None and st == entry.st:
                         entries.append(entry)
-                elif match_mac:
-                    if match_mac == mac:
+
+                    if entry not in entries and match_mac is not None and match_mac == mac:
                         entries.append(entry)
-                elif match_serial:
-                    if match_serial == serial:
+
+                    if entry not in entries and match_serial is not None and match_serial == serial:
                         entries.append(entry)
-                else:
+                elif entry not in entries:
                     entries.append(entry)
 
                 # Return if we've found the max number of devices

--- a/pywemo/ssdp.py
+++ b/pywemo/ssdp.py
@@ -250,14 +250,22 @@ def scan(st=None, timeout=DISCOVER_TIMEOUT, max_entries=None, match_mac=None, ma
                     mac = None
                     serial = None
 
-                if ((st is None or entry.st == st) and
-                        ((match_mac is None or mac == match_mac) or
-                        (match_serial is None or serial == match_serial)) and
-                        entry not in entries):
+                # Search for devices
+                if st:
+                    if st == entry.st:
+                        entries.append(entry)
+                elif match_mac:
+                    if match_mac == mac:
+                        entries.append(entry)
+                elif match_serial:
+                    if match_serial == serial:
+                        entries.append(entry)
+                else:
                     entries.append(entry)
 
-                    if max_entries and len(entries) == max_entries:
-                        return entries
+                # Return if we've found the max number of devices
+                if max_entries and len(entries) == max_entries:
+                    return entries
 
     except socket.error:
         logging.getLogger(__name__).exception(

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 
 setup(name='pywemo',
-      version='0.4.31',
+      version='0.4.32',
       description='Access WeMo switches using their SOAP API',
       url='http://github.com/pavoni/pywemo',
       author='Greg Dowling',

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 
 setup(name='pywemo',
-      version='0.4.30',
+      version='0.4.31',
       description='Access WeMo switches using their SOAP API',
       url='http://github.com/pavoni/pywemo',
       author='Greg Dowling',


### PR DESCRIPTION
Fixing a false-positive search condition. The logic will now to matching correctly and still match all devices if no search parameters are passed