### PR TITLE
Increase the scanned port range

### DIFF
--- a/pywemo/ouimeaux_device/__init__.py
+++ b/pywemo/ouimeaux_device/__init__.py
@@ -17,7 +17,7 @@ from .api.xsd import device as deviceParser
 LOG = logging.getLogger(__name__)
 
 # Start with the most commonly used port
-PROBE_PORTS = (49151, 49152, 49153, 49154, 49155, 49156, 49157, 49158, 49159)
+PROBE_PORTS = (49153, 49152, 49154, 49151, 49155, 49156, 49157, 49158, 49159)
 
 
 def probe_wemo(host, ports=PROBE_PORTS, probe_timeout=10):

--- a/pywemo/ouimeaux_device/__init__.py
+++ b/pywemo/ouimeaux_device/__init__.py
@@ -17,7 +17,7 @@ from .api.xsd import device as deviceParser
 LOG = logging.getLogger(__name__)
 
 # Start with the most commonly used port
-PROBE_PORTS = (49153, 49152, 49154, 49151, 49155)
+PROBE_PORTS = (49151, 49152, 49153, 49154, 49155, 49156, 49157, 49158, 49159)
 
 
 def probe_wemo(host, ports=PROBE_PORTS, probe_timeout=10):


### PR DESCRIPTION
After the firmware bump last night (WeMo_WW_2.00.11215.PVT-OWRT-Dimmer) my wemo dimmers are definitely responding on additional ports.