### PR TITLE
fixed a bug with rescanning devices when a port number changes

### DIFF
--- a/pywemo/ssdp.py
+++ b/pywemo/ssdp.py
@@ -252,14 +252,16 @@ def scan(st=None, timeout=DISCOVER_TIMEOUT, max_entries=None, match_mac=None, ma
 
                 # Search for devices
                 if st is not None or match_mac is not None or match_serial is not None:
-                    if st is not None and st == entry.st:
-                        entries.append(entry)
-
-                    if entry not in entries and match_mac is not None and match_mac == mac:
-                        entries.append(entry)
-
-                    if entry not in entries and match_serial is not None and match_serial == serial:
-                        entries.append(entry)
+                    if entry not in entries:
+                        if match_mac is not None:
+                            if match_mac == mac:
+                                entries.append(entry)
+                        elif match_serial is not None:
+                            if match_serial == serial:
+                                entries.append(entry)
+                        elif st is not None:
+                            if st == entry.st:
+                                entries.append(entry)
                 elif entry not in entries:
                     entries.append(entry)
 


### PR DESCRIPTION
See here for a discussion of the issue:

https://github.com/home-assistant/home-assistant/issues/19153

Here's how I can trigger the bug with the current code:
```
>>> import pywemo
>>> ip = '192.168.1.206'
>>> port = pywemo.ouimeaux_device.probe_wemo(ip)
>>> url = f"http://{ip}:{port}/setup.xml"
>>> device = pywemo.discovery.device_from_description(url,None)
>>> device._reconnect_with_device_by_discovery()
Unable to reconnect with Kitchen lights in 5 tries. Stopping.
```

With this PR it now behaves as I would expect:
```
>>> import pywemo
>>> wemo = pywemo.SubscriptionRegistry()
>>> wemo.start()
>>> ip = '192.168.1.206'
>>> port = pywemo.ouimeaux_device.probe_wemo(ip)
>>> url = f"http://{ip}:{port}/setup.xml"
>>> device = pywemo.discovery.device_from_description(url,None)
# force a bad port to duplicate what happens when the port changes:
>>> device.port = 49152
>>> device._reconnect_with_device_by_discovery()
>>> device.port
49153
```