### PR TITLE
Test urn fix

### DIFF
--- a/pywemo/discovery.py
+++ b/pywemo/discovery.py
@@ -21,7 +21,7 @@ LOG = logging.getLogger(__name__)
 
 def discover_devices(st=None, max_devices=None, match_mac=None, match_serial=None):
     """ Finds WeMo devices on the local network. """
-    st = st or ssdp.ST_ROOTDEVICE
+    st = st or ssdp.ST
     ssdp_entries = ssdp.scan(st, max_entries=max_devices,
                              match_mac=match_mac, match_serial=match_serial)
 

--- a/pywemo/ssdp.py
+++ b/pywemo/ssdp.py
@@ -198,16 +198,9 @@ def build_ssdp_request(st, ssdp_mx):
         '', '']).encode('ascii')
 
 
-def entry_in_entries(entry, entries):
-    if entry.description is not None:
-        device = entry.description.get('device', {})
-        mac = device.get('macAddress')
-        serial = device.get('serialNumber')
-    else:
-        mac = None
-        serial = None
+def entry_in_entries(entry, entries, mac, serial):
     # If we don't have a mac or serial, let's just compare objects instead:
-    if mac == None and serial == None:
+    if mac is None and serial is None:
         return entry in entries
     for e in entries:
         if e.description is not None:
@@ -282,7 +275,7 @@ def scan(st=None, timeout=DISCOVER_TIMEOUT, max_entries=None, match_mac=None, ma
 
                 # Search for devices
                 if st is not None or match_mac is not None or match_serial is not None:
-                    if not entry_in_entries(entry, entries):
+                    if not entry_in_entries(entry, entries, mac, serial):
                         if match_mac is not None:
                             if match_mac == mac:
                                 entries.append(entry)
@@ -292,7 +285,7 @@ def scan(st=None, timeout=DISCOVER_TIMEOUT, max_entries=None, match_mac=None, ma
                         elif st is not None:
                             if st == entry.st:
                                 entries.append(entry)
-                elif not entry_in_entries(entry, entries):
+                elif not entry_in_entries(entry, entries, mac, serial):
                     entries.append(entry)
 
                 # Return if we've found the max number of devices

--- a/pywemo/ssdp.py
+++ b/pywemo/ssdp.py
@@ -8,23 +8,19 @@ import logging
 from datetime import datetime, timedelta
 import threading
 import xml.etree.ElementTree as ElementTree
-
+import time
 import requests
 
 from .util import etree_to_dict, interface_addresses
 
-DISCOVER_TIMEOUT = SSDP_MX = 5
+DISCOVER_TIMEOUT = 5
 
 RESPONSE_REGEX = re.compile(r'\n(.*)\: (.*)\r')
 
 MIN_TIME_BETWEEN_SCANS = timedelta(seconds=59)
 
-# Devices and services
-ST_ALL = "ssdp:all"
-
-# Devices only, some devices will only respond to this query
-ST_ROOTDEVICE = "upnp:rootdevice"
-
+# Wemo specific urn:
+ST = "urn:Belkin:service:basicevent:1"
 
 class SSDP(object):
     """
@@ -83,7 +79,7 @@ class SSDP(object):
                 # Wemo does not respond to a query for all devices+services
                 # but only to a query for just root devices.
                 self.entries.extend(
-                    entry for entry in scan() + scan(ST_ROOTDEVICE)
+                    entry for entry in scan() + scan(ST)
                     if entry not in self.entries)
 
                 self.last_scan = datetime.now()
@@ -191,6 +187,43 @@ class UPNPEntry(object):
             self.values.get('st', ''), self.values.get('location', ''))
 
 
+def build_ssdp_request(st, ssdp_mx):
+    ssdp_st = st or ST
+    return "\r\n".join([
+        'M-SEARCH * HTTP/1.1',
+        'ST: {}'.format(ssdp_st),
+        'MX: {:d}'.format(ssdp_mx),
+        'MAN: "ssdp:discover"',
+        'HOST: 239.255.255.250:1900',
+        '', '']).encode('ascii')
+
+
+def entry_in_entries(entry, entries):
+    if entry.description is not None:
+        device = entry.description.get('device', {})
+        mac = device.get('macAddress')
+        serial = device.get('serialNumber')
+    else:
+        mac = None
+        serial = None
+    # If we don't have a mac or serial, let's just compare objects instead:
+    if mac == None and serial == None:
+        return entry in entries
+    for e in entries:
+        if e.description is not None:
+            e_device = e.description.get('device', {})
+            e_mac = e_device.get('macAddress')
+            e_serial = e_device.get('serialNumber')
+        else:
+            e_mac = None
+            e_serial = None
+        if e_mac == mac and \
+           e_serial == serial and \
+           e.st == entry.st:
+            return True
+    return False
+
+
 # pylint: disable=invalid-name
 def scan(st=None, timeout=DISCOVER_TIMEOUT, max_entries=None, match_mac=None, match_serial=None):
     """
@@ -199,15 +232,7 @@ def scan(st=None, timeout=DISCOVER_TIMEOUT, max_entries=None, match_mac=None, ma
     Inspired by Crimsdings
     https://github.com/crimsdings/ChromeCast/blob/master/cc_discovery.py
     """
-    ssdp_st = st or ST_ALL
     ssdp_target = ("239.255.255.250", 1900)
-    ssdp_request = "\r\n".join([
-        'M-SEARCH * HTTP/1.1',
-        'HOST: 239.255.255.250:1900',
-        'MAN: "ssdp:discover"',
-        'MX: {:d}'.format(SSDP_MX),
-        'ST: {}'.format(ssdp_st),
-        '', '']).encode('ascii')
 
     entries = []
 
@@ -221,6 +246,11 @@ def scan(st=None, timeout=DISCOVER_TIMEOUT, max_entries=None, match_mac=None, ma
                 s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
                 sockets.append(s)
                 s.bind((addr, 0))
+                # Send 2 separate ssdp requests to mimic wemo app behavior:
+                ssdp_request = build_ssdp_request(st, ssdp_mx=1)
+                s.sendto(ssdp_request, ssdp_target)
+                time.sleep(0.5)
+                ssdp_request = build_ssdp_request(st, ssdp_mx=2)
                 s.sendto(ssdp_request, ssdp_target)
                 s.setblocking(0)
             except socket.error:
@@ -252,7 +282,7 @@ def scan(st=None, timeout=DISCOVER_TIMEOUT, max_entries=None, match_mac=None, ma
 
                 # Search for devices
                 if st is not None or match_mac is not None or match_serial is not None:
-                    if entry not in entries:
+                    if not entry_in_entries(entry, entries):
                         if match_mac is not None:
                             if match_mac == mac:
                                 entries.append(entry)
@@ -262,7 +292,7 @@ def scan(st=None, timeout=DISCOVER_TIMEOUT, max_entries=None, match_mac=None, ma
                         elif st is not None:
                             if st == entry.st:
                                 entries.append(entry)
-                elif entry not in entries:
+                elif not entry_in_entries(entry, entries):
                     entries.append(entry)
 
                 # Return if we've found the max number of devices

--- a/pywemo/ssdp.py
+++ b/pywemo/ssdp.py
@@ -252,14 +252,16 @@ def scan(st=None, timeout=DISCOVER_TIMEOUT, max_entries=None, match_mac=None, ma
 
                 # Search for devices
                 if st is not None or match_mac is not None or match_serial is not None:
-                    if st is not None and st == entry.st:
-                        entries.append(entry)
-
-                    if entry not in entries and match_mac is not None and match_mac == mac:
-                        entries.append(entry)
-
-                    if entry not in entries and match_serial is not None and match_serial == serial:
-                        entries.append(entry)
+                    if entry not in entries:
+                        if match_mac is not None:
+                            if match_mac == mac:
+                                entries.append(entry)
+                        elif match_serial is not None:
+                            if match_serial == serial:
+                                entries.append(entry)
+                        elif st is not None:
+                            if st == entry.st:
+                                entries.append(entry)
                 elif entry not in entries:
                     entries.append(entry)
 


### PR DESCRIPTION
So here's my stab at implementing https://github.com/pavoni/pywemo/issues/112. 

Using the urn of "urn:Belkin:service:basicevent:1" seems to work nicely in my environment. I currently have several wall switches, wall dimmers, plugin wemos (the old-style original) and insight plugins.

All of them are detected correctly using this code.

Note that detection is not perfect every time. I did implement the 2 successive M-SEARCH requests (as I discussed earlier). This mimics what I was seeing in the packet capture from the official app. If this is a concern I can remove it. However for my use case it seems to do a better job at detection.

I managed to avoid duplicate entries by comparing the mac and serial of the entry instead of doing an `entry in entries` comparison.

You'll note that the MX is set to 1 and 2 respectively. This also matches what I was seeing. From my (admittedly limited) understanding of ssdp, MX tells the remote device "respond within this number of seconds". So in the original implementation we were saying "respond within 5 seconds" but we were also timing out in 5 seconds. I imagine if a device decided to respond at the 5 seconds mark and we timed out at 5 seconds then we'd miss the response from said device. So maybe that also explains why I'm seeing more reliability now.