### PR TITLE
Allow Disabling Rediscovery

### DIFF
--- a/pywemo/discovery.py
+++ b/pywemo/discovery.py
@@ -18,7 +18,8 @@ LOG = logging.getLogger(__name__)
 
 
 def discover_devices(ssdp_st=None, max_devices=None,
-                     match_mac=None, match_serial=None):
+                     match_mac=None, match_serial=None,
+                     rediscovery_enabled=True):
     """Find WeMo devices on the local network."""
     ssdp_st = ssdp_st or ssdp.ST
     ssdp_entries = ssdp.scan(ssdp_st, max_entries=max_devices,
@@ -30,7 +31,9 @@ def discover_devices(ssdp_st=None, max_devices=None,
         if entry.match_device_description(
                 {'manufacturer': 'Belkin International Inc.'}):
             mac = entry.description.get('device').get('macAddress')
-            device = device_from_description(entry.location, mac)
+            device = device_from_description(
+                description_url=entry.location, mac=mac,
+                rediscovery_enabled=rediscovery_enabled)
 
             if device is not None:
                 wemos.append(device)
@@ -38,7 +41,7 @@ def discover_devices(ssdp_st=None, max_devices=None,
     return wemos
 
 
-def device_from_description(description_url, mac):
+def device_from_description(description_url, mac, rediscovery_enabled=True):
     """Return object representing WeMo device running at host, else None."""
     xml = requests.get(description_url, timeout=10)
     uuid = deviceParser.parseString(xml.content).device.UDN
@@ -49,30 +52,42 @@ def device_from_description(description_url, mac):
             'No MAC address was supplied or found in setup xml at: %s.',
             description_url)
 
-    return device_from_uuid_and_location(uuid, device_mac, description_url)
+    return device_from_uuid_and_location(
+        uuid, device_mac, description_url,
+        rediscovery_enabled=rediscovery_enabled)
 
 
-def device_from_uuid_and_location(uuid, mac, location):
+def device_from_uuid_and_location(uuid, mac, location,
+                                  rediscovery_enabled=True):
     """Determine device class based on the device uuid."""
     if uuid is None:
         return None
     if uuid.startswith('uuid:Socket'):
-        return Switch(location, mac)
+        return Switch(url=location, mac=mac,
+                      rediscovery_enabled=rediscovery_enabled)
     if uuid.startswith('uuid:Lightswitch'):
-        return LightSwitch(location, mac)
+        return LightSwitch(url=location, mac=mac,
+                           rediscovery_enabled=rediscovery_enabled)
     if uuid.startswith('uuid:Dimmer'):
-        return Dimmer(location, mac)
+        return Dimmer(url=location, mac=mac,
+                      rediscovery_enabled=rediscovery_enabled)
     if uuid.startswith('uuid:Insight'):
-        return Insight(location, mac)
+        return Insight(url=location, mac=mac,
+                       rediscovery_enabled=rediscovery_enabled)
     if uuid.startswith('uuid:Sensor'):
-        return Motion(location, mac)
+        return Motion(url=location, mac=mac,
+                      rediscovery_enabled=rediscovery_enabled)
     if uuid.startswith('uuid:Maker'):
-        return Maker(location, mac)
+        return Maker(url=location, mac=mac,
+                     rediscovery_enabled=rediscovery_enabled)
     if uuid.startswith('uuid:Bridge'):
-        return Bridge(location, mac)
+        return Bridge(url=location, mac=mac,
+                      rediscovery_enabled=rediscovery_enabled)
     if uuid.startswith('uuid:CoffeeMaker'):
-        return CoffeeMaker(location, mac)
+        return CoffeeMaker(url=location, mac=mac,
+                           rediscovery_enabled=rediscovery_enabled)
     if uuid.startswith('uuid:Humidifier'):
-        return Humidifier(location, mac)
+        return Humidifier(url=location, mac=mac,
+                          rediscovery_enabled=rediscovery_enabled)
 
     return None

--- a/pywemo/ouimeaux_device/__init__.py
+++ b/pywemo/ouimeaux_device/__init__.py
@@ -73,7 +73,7 @@ class UnknownService(Exception):
 class Device(object):
     """Base object for WeMo devices."""
 
-    def __init__(self, url, mac):
+    def __init__(self, url, mac, rediscovery_enabled=True):
         """Create a WeMo device."""
         self._state = None
         self.basic_state_params = {}
@@ -83,6 +83,7 @@ class Device(object):
         self.port = parsed_url.port
         self.retrying = False
         self.mac = mac
+        self.rediscovery_enabled = rediscovery_enabled
         xml = requests.get(url, timeout=10)
         self._config = deviceParser.parseString(xml.content).device
         service_list = self._config.serviceList
@@ -147,6 +148,7 @@ class Device(object):
             try_no += 1
 
     def _reconnect_with_device_by_probing(self):
+        """Attempt to reconnect to the device on the existing port."""
         port = probe_device(self)
 
         if port is None:
@@ -166,9 +168,14 @@ class Device(object):
 
     def reconnect_with_device(self):
         """Re-probe & scan network to rediscover a disconnected device."""
-        if (not self._reconnect_with_device_by_probing() and
-                (self.mac or self.serialnumber)):
-            self._reconnect_with_device_by_discovery()
+        if self.rediscovery_enabled:
+            if (not self._reconnect_with_device_by_probing() and
+                    (self.mac or self.serialnumber)):
+                self._reconnect_with_device_by_discovery()
+        else:
+            LOG.warning("Rediscovery was requested for device %s, "
+                        "but rediscovery is disabled. Ignoring request.",
+                        self.name)
 
     def parse_basic_state(self, params):
         """Parse the basic state response from the device."""

--- a/pywemo/ouimeaux_device/api/__init__.py
+++ b/pywemo/ouimeaux_device/api/__init__.py
@@ -1,0 +1,1 @@
+"""WeMo device API."""

--- a/pywemo/ouimeaux_device/api/service.py
+++ b/pywemo/ouimeaux_device/api/service.py
@@ -77,8 +77,9 @@ class Action:
                     response_dict[response_item.tag] = response_item.text
                 return response_dict
             except requests.exceptions.RequestException:
-                LOG.warning("Error communicating with %s, retry %i",
-                            self._device.name, attempt)
+                LOG.warning("Error communicating with %s at %s:%i, retry %i",
+                            self._device.name, self._device.host,
+                            self._device.port, attempt)
 
                 if self._device.rediscovery_enabled:
                     self._device.reconnect_with_device()

--- a/pywemo/ouimeaux_device/api/service.py
+++ b/pywemo/ouimeaux_device/api/service.py
@@ -1,4 +1,5 @@
 """Representation of Services and Actions for WeMo devices."""
+# flake8: noqa E501
 import logging
 from xml.etree import cElementTree as et
 

--- a/pywemo/ouimeaux_device/api/service.py
+++ b/pywemo/ouimeaux_device/api/service.py
@@ -1,3 +1,4 @@
+"""Representation of Services and Actions for WeMo devices."""
 import logging
 from xml.etree import cElementTree as et
 
@@ -6,25 +7,41 @@ import requests
 from .xsd import service as serviceParser
 
 
-log = logging.getLogger(__name__)
+LOG = logging.getLogger(__name__)
+MAX_RETRIES = 3
 
+# The formatting here is a very hacky way around a too-long line flake8 error
+# I'm sorry.
 REQUEST_TEMPLATE = """
 <?xml version="1.0" encoding="utf-8"?>
-<s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/" s:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/">
+<s:Envelope xmlns:s="{envelope}" s:encodingStyle="{encoding}">
  <s:Body>
   <u:{action} xmlns:u="{service}">
    {args}
   </u:{action}>
  </s:Body>
 </s:Envelope>
-"""
+""".format(
+    envelope="http://schemas.xmlsoap.org/soap/envelope/",
+    encoding="http://schemas.xmlsoap.org/soap/encoding/",
+    action="{action}", service="{service}", args="{args}")
 
 
-class Action(object):
+class ActionException(Exception):
+    """Generic exceptions when dealing with Actions."""
+
+    pass
+
+
+class Action:
+    """Representation of an Action for a WeMo device."""
+
     def __init__(self, device, service, action_config):
+        """Create an instance of an Action."""
         self._device = device
         self._action_config = action_config
         self.name = action_config.get_name()
+        # pylint: disable=invalid-name
         self.serviceType = service.serviceType
         self.controlURL = service.controlURL
         self.args = {}
@@ -32,13 +49,14 @@ class Action(object):
             'Content-Type': 'text/xml',
             'SOAPACTION': '"%s#%s"' % (self.serviceType, self.name)
         }
+
         arglist = action_config.get_argumentList()
         if arglist is not None:
             for arg in arglist.get_argument():
-                # TODO: Get type instead of setting 0
                 self.args[arg.get_name()] = 0
 
     def __call__(self, **kwargs):
+        """Representations a method or function call."""
         arglist = '\n'.join('<{0}>{1}</{0}>'.format(arg, value)
                             for arg, value in kwargs.items())
         body = REQUEST_TEMPLATE.format(
@@ -51,37 +69,47 @@ class Action(object):
                 response = requests.post(
                     self.controlURL, body.strip(),
                     headers=self.headers, timeout=10)
-                d = {}
-                for r in et.fromstring(response.content).getchildren()[0].getchildren()[0].getchildren():
-                    d[r.tag] = r.text
-                return d
+                response_dict = {}
+                # pylint: disable=deprecated-method
+                for response_item in et.fromstring(
+                        response.content
+                ).getchildren()[0].getchildren()[0].getchildren():
+                    response_dict[response_item.tag] = response_item.text
+                return response_dict
             except requests.exceptions.RequestException:
-                log.warning(
-                    "Error communicating with {}, retry {}".format(
-                        self._device.name, attempt))
-                self._device.reconnect_with_device()
+                LOG.warning("Error communicating with %s, retry %i",
+                            self._device.name, attempt)
 
-        log.error(
-            "Error communicating with {}. Giving up".format(self._device.name))
-        return
+                if self._device.rediscovery_enabled:
+                    self._device.reconnect_with_device()
+
+        LOG.error("Error communicating with %s after %i attempts. Giving up.",
+                  self._device.name, MAX_RETRIES)
+
+        raise ActionException(
+            "Error communicating with {0} after {1} attempts."
+            "Giving up.".format(self._device.name, MAX_RETRIES))
 
     def __repr__(self):
+        """Return a string representation of the Action."""
         return "<Action %s(%s)>" % (self.name, ", ".join(self.args))
 
 
-class Service(object):
-    """
-    Represents an instance of a service on a device.
-    """
+class Service:
+    """Representation of a service for a WeMo device."""
 
     def __init__(self, device, service, base_url):
+        """Create an instance of a Service."""
         self._base_url = base_url.rstrip('/')
         self._config = service
+        self.name = self._config.get_serviceType().split(':')[-2]
+        self.actions = {}
+
         url = '%s/%s' % (base_url, service.get_SCPDURL().strip('/'))
         xml = requests.get(url, timeout=10)
         if xml.status_code != 200:
             return
-        self.actions = {}
+
         self._svc_config = serviceParser.parseString(xml.content).actionList
         for action in self._svc_config.get_action():
             act = Action(device, self, action)
@@ -91,13 +119,21 @@ class Service(object):
 
     @property
     def hostname(self):
+        """Get the hostname from the base URL."""
         return self._base_url.split('/')[-1]
 
+    # pylint: disable=invalid-name
     @property
     def controlURL(self):
+        """Get the controlURL for interacting with this Service."""
         return '%s/%s' % (self._base_url,
                           self._config.get_controlURL().strip('/'))
 
     @property
     def serviceType(self):
+        """Get the type of this Service."""
         return self._config.get_serviceType()
+
+    def __repr__(self):
+        """Return a string representation of the Service."""
+        return "<Service %s(%s)>" % (self.name, ", ".join(self.actions))

--- a/pywemo/ouimeaux_device/api/service.py
+++ b/pywemo/ouimeaux_device/api/service.py
@@ -10,21 +10,16 @@ from .xsd import service as serviceParser
 LOG = logging.getLogger(__name__)
 MAX_RETRIES = 3
 
-# The formatting here is a very hacky way around a too-long line flake8 error
-# I'm sorry.
 REQUEST_TEMPLATE = """
 <?xml version="1.0" encoding="utf-8"?>
-<s:Envelope xmlns:s="{envelope}" s:encodingStyle="{encoding}">
- <s:Body>
-  <u:{action} xmlns:u="{service}">
-   {args}
-  </u:{action}>
- </s:Body>
+<s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/" s:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/">
+<s:Body>
+<u:{action} xmlns:u="{service}">
+{args}
+</u:{action}>
+</s:Body>
 </s:Envelope>
-""".format(
-    envelope="http://schemas.xmlsoap.org/soap/envelope/",
-    encoding="http://schemas.xmlsoap.org/soap/encoding/",
-    action="{action}", service="{service}", args="{args}")
+"""
 
 
 class ActionException(Exception):

--- a/pywemo/ouimeaux_device/bridge.py
+++ b/pywemo/ouimeaux_device/bridge.py
@@ -116,8 +116,8 @@ class LinkedDevice:
     def __init__(self, bridge, info):
         """Create a Linked Device."""
         self.bridge = bridge
-        self.host = bridge.host
-        self.port = bridge.port
+        self.host = self.bridge.host
+        self.port = self.bridge.port
         self.state = {}
         self.capabilities = []
         self._values = []

--- a/pywemo/ouimeaux_device/bridge.py
+++ b/pywemo/ouimeaux_device/bridge.py
@@ -52,7 +52,7 @@ class Bridge(Device):
                     name=self.name, lights=len(self.Lights),
                     groups=len(self.Groups))
 
-    def bridge_update(self, force_update=False):
+    def bridge_update(self, force_update=True):
         """Get updated status information for the bridge and its lights."""
         # pylint: disable=maybe-no-member
         if force_update or self.Lights is None or self.Groups is None:

--- a/tox.ini
+++ b/tox.ini
@@ -34,7 +34,7 @@ exclude =
     .tox,
     .git,
     __pycache__,
-    pywemo/ouimeaux_device/api/*,
+    pywemo/ouimeaux_device/api/xsd/*,
     *.pyc,
     *.egg-info,
     .cache,


### PR DESCRIPTION
## Description:
This change allows a user to disable pywemo's rediscovery feature. This will be used by a future change to Home Assistant so that Home Assistant can use its own rediscovery logic.

## BREAKING CHANGE:
If calling a device action (such as to get the state, set the state, etc. fails, it will now raise an ActionException that will be returned to the caller (even outside of pywemo). This was needed so that Home Assistant can catch the error and know that a device action\update has failed.

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] There is no commented out code in this PR.