### PR TITLE
Add device_type property to device classes

### DIFF
--- a/pywemo/ouimeaux_device/bridge.py
+++ b/pywemo/ouimeaux_device/bridge.py
@@ -109,6 +109,11 @@ class Bridge(Device):
         # pylint: disable=maybe-no-member
         return self.bridge.SetDeviceStatus(DeviceStatusList=send_state)
 
+    @property
+    def device_type(self):
+        """Return what kind of WeMo this device is."""
+        return "Bridge"
+
 
 class LinkedDevice:
     """Representation of a device connected to the bridge."""
@@ -200,6 +205,11 @@ class LinkedDevice:
     def toggle(self):
         """Toggle the device from on to off or off to on."""
         return self._setdevicestatus(onoff=TOGGLE)
+
+    @property
+    def device_type(self):
+        """Return what kind of WeMo this device is."""
+        return "LinkedDevice"
 
 
 class Light(LinkedDevice):
@@ -326,6 +336,11 @@ class Light(LinkedDevice):
         """Start ramping the brightness up or down."""
         return self._setdevicestatus(levelcontrol_stop='')
 
+    @property
+    def device_type(self):
+        """Return what kind of WeMo this device is."""
+        return "Light"
+
 
 class Group(LinkedDevice):
     """Representation of a Group of lights connected to the Bridge."""
@@ -358,3 +373,8 @@ class Group(LinkedDevice):
     def __repr__(self):
         """Return a string representation of the device."""
         return '<GROUP "{name}">'.format(name=self.name)
+
+    @property
+    def device_type(self):
+        """Return what kind of WeMo this device is."""
+        return "Group"

--- a/pywemo/ouimeaux_device/coffeemaker.py
+++ b/pywemo/ouimeaux_device/coffeemaker.py
@@ -93,6 +93,11 @@ class CoffeeMaker(Switch):
         return Switch.subscription_update(self, _type, _params)
 
     @property
+    def device_type(self):
+        """Return what kind of WeMo this device is."""
+        return "CoffeeMaker"
+
+    @property
     def mode(self):
         """Return the mode of the device."""
         return self._attributes.get('Mode')

--- a/pywemo/ouimeaux_device/dimmer.py
+++ b/pywemo/ouimeaux_device/dimmer.py
@@ -47,3 +47,8 @@ class Dimmer(Switch):
     def __repr__(self):
         """Return a string representation of the device."""
         return '<WeMo Dimmer "{name}">'.format(name=self.name)
+
+    @property
+    def device_type(self):
+        """Return what kind of WeMo this device is."""
+        return "Dimmer"

--- a/pywemo/ouimeaux_device/humidifier.py
+++ b/pywemo/ouimeaux_device/humidifier.py
@@ -162,6 +162,11 @@ class Humidifier(Switch):
         return Switch.subscription_update(self, _type, _params)
 
     @property
+    def device_type(self):
+        """Return what kind of WeMo this device is."""
+        return "Humidifier"
+
+    @property
     def fan_mode(self):
         """Return the FanMode setting (as an int index of the IntEnum)."""
         return self._attributes.get('fan_mode')

--- a/pywemo/ouimeaux_device/insight.py
+++ b/pywemo/ouimeaux_device/insight.py
@@ -67,6 +67,11 @@ class Insight(Switch):
         return Switch.get_state(self, force_update)
 
     @property
+    def device_type(self):
+        """Return what kind of WeMo this device is."""
+        return "Insight"
+
+    @property
     def today_kwh(self):
         """Return the kwh used today."""
         return self.insight_params['todaymw'] * 1.6666667e-8

--- a/pywemo/ouimeaux_device/lightswitch.py
+++ b/pywemo/ouimeaux_device/lightswitch.py
@@ -8,3 +8,8 @@ class LightSwitch(Switch):
     def __repr__(self):
         """Return a string representation of the device."""
         return '<WeMo LightSwitch "{name}">'.format(name=self.name)
+
+    @property
+    def device_type(self):
+        """Return what kind of WeMo this device is."""
+        return "LightSwitch"

--- a/pywemo/ouimeaux_device/maker.py
+++ b/pywemo/ouimeaux_device/maker.py
@@ -58,6 +58,11 @@ class Maker(Switch):
         self.get_state(True)
 
     @property
+    def device_type(self):
+        """Return what kind of WeMo this device is."""
+        return "Maker"
+
+    @property
     def sensor_state(self):
         """Return the state of the sensor."""
         return self.maker_params['sensorstate']

--- a/pywemo/ouimeaux_device/motion.py
+++ b/pywemo/ouimeaux_device/motion.py
@@ -8,3 +8,8 @@ class Motion(Device):
     def __repr__(self):
         """Return a string representation of the device."""
         return '<WeMo Motion "{name}">'.format(name=self.name)
+
+    @property
+    def device_type(self):
+        """Return what kind of WeMo this device is."""
+        return "Motion"

--- a/pywemo/ouimeaux_device/switch.py
+++ b/pywemo/ouimeaux_device/switch.py
@@ -27,3 +27,8 @@ class Switch(Device):
     def __repr__(self):
         """Return a string representation of the device."""
         return '<WeMo Switch "{name}">'.format(name=self.name)
+
+    @property
+    def device_type(self):
+        """Return what kind of WeMo this device is."""
+        return "Humidifier"


### PR DESCRIPTION
## Description:
Add a device_type property to each device class. This will be used by Home Assistant to better map wemo devices from pywemo to Home Assistant components.

**Related issue (if applicable):** fixes #89

## Checklist:
  - [ ] The code change is tested and works locally.
  - [X] There is no commented out code in this PR.