### PR TITLE
Switch from netifaces to ifaddr.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -6,7 +6,7 @@ This is a stripped down version of the Python API for WeMo devices [ouimeaux](ht
 
 Dependencies
 ------------
-pyWeMo depends on Python packages requests, netifaces and six.
+pyWeMo depends on Python packages requests, ifaddr and six.
 
 How to use
 ----------

--- a/pylintrc
+++ b/pylintrc
@@ -2,11 +2,6 @@
 ignore=ouimeaux_device
 reports=no
 
-# A comma-separated list of package or module names from where C extensions may
-# be loaded. Extensions are loading into the active Python interpreter and may
-# run arbitrary code
-extension-pkg-whitelist=netifaces
-
 disable=
   abstract-class-little-used,
   abstract-method,

--- a/pywemo/util.py
+++ b/pywemo/util.py
@@ -1,6 +1,6 @@
 """Miscellaneous utility functions."""
 from collections import defaultdict
-import netifaces
+import ifaddr
 
 
 # Taken from http://stackoverflow.com/a/10077069
@@ -34,14 +34,20 @@ def etree_to_dict(tree):
     return tree_dict
 
 
-def interface_addresses(family=netifaces.AF_INET):
+def interface_addresses():
     """
     Return local address for broadcast/multicast.
 
     Return local address of any network associated with a local interface
     that has broadcast (and probably multicast) capability.
     """
-    return [addr['addr']
-            for i in netifaces.interfaces()
-            for addr in netifaces.ifaddresses(i).get(family) or []
-            if 'broadcast' in addr]
+    addresses = []
+
+    for iface in ifaddr.get_adapters():
+        for addr in iface.ips:
+            if not addr.is_IPv4 or addr.ip == '127.0.0.1':
+                continue
+
+            addresses.append(addr.ip)
+
+    return addresses

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-netifaces>=0.10.0
+ifaddr>=0.1.0
 requests>=2.0
 six>=1.10.0

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setup(name='pywemo',
       author='Greg Dowling',
       author_email='mail@gregdowling.com',
       license='MIT',
-      install_requires=['netifaces>=0.10.0', 'requests>=2.0', 'six>=1.10.0'],
+      install_requires=['ifaddr>=0.1.0', 'requests>=2.0', 'six>=1.10.0'],
       packages=find_packages(),
       zip_safe=True,
       classifiers=[


### PR DESCRIPTION
ifaddr is pure Python and does not require a toolchain to be
installed.