### PR TITLE
Device type is a switch not a humidifier

### DIFF
--- a/pywemo/ouimeaux_device/switch.py
+++ b/pywemo/ouimeaux_device/switch.py
@@ -31,4 +31,4 @@ class Switch(Device):
     @property
     def device_type(self):
         """Return what kind of WeMo this device is."""
-        return "Humidifier"
+        return "Switch"


### PR DESCRIPTION
Set the device type string to a more correct value for this type of device.

## Description:


**Related issue (if applicable):** fixes #<pywemo issue number goes here>

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] There is no commented out code in this PR.