### PR TITLE
Fix hyperlink in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -2,7 +2,8 @@ pyWeMo |Build Status|
 =====================
 Lightweight Python 2 and Python 3 module to discover and control WeMo devices.
 
-This is a stripped down version of the Python API for WeMo devices [ouimeaux](https://github.com/iancmcc/ouimeaux) with simpler dependencies.
+This is a stripped down version of the Python API for WeMo devices, `ouimeaux
+<https://github.com/iancmcc/ouimeaux>`_, with simpler dependencies.
 
 Dependencies
 ------------

--- a/README.rst
+++ b/README.rst
@@ -2,8 +2,7 @@ pyWeMo |Build Status|
 =====================
 Lightweight Python 2 and Python 3 module to discover and control WeMo devices.
 
-This is a stripped down version of the Python API for WeMo devices, `ouimeaux
-<https://github.com/iancmcc/ouimeaux>`_, with simpler dependencies.
+This is a stripped down version of the Python API for WeMo devices, `ouimeaux <https://github.com/iancmcc/ouimeaux>`_, with simpler dependencies.
 
 Dependencies
 ------------


### PR DESCRIPTION
## Description:
Fixed hyperlink to ouimeaux's github repository in the README. The hyperlink was in Markdown, but the file is ReST.

**Related issue (if applicable):** n/a

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] There is no commented out code in this PR.