### PR TITLE
Add support for discovering the new Wemo WiFi Smart Plug

### DIFF
--- a/pywemo/ssdp.py
+++ b/pywemo/ssdp.py
@@ -279,10 +279,10 @@ def scan(st=None, timeout=DISCOVER_TIMEOUT,
                     device = entry.description.get('device', {})
                     mac = device.get('macAddress')
                     serial = device.get('serialNumber')
+                    services = device.get("serviceList", {}).get("service", [])
                     service_types = [
                         service.get("serviceType")
-                        for service in device.get("serviceList", {}).get("service", [])
-                        if isinstance(service, dict)
+                        for service in services if isinstance(service, dict)
                     ]
                 else:
                     mac = None

--- a/pywemo/ssdp.py
+++ b/pywemo/ssdp.py
@@ -279,9 +279,15 @@ def scan(st=None, timeout=DISCOVER_TIMEOUT,
                     device = entry.description.get('device', {})
                     mac = device.get('macAddress')
                     serial = device.get('serialNumber')
+                    service_types = [
+                        service.get("serviceType")
+                        for service in device.get("serviceList", {}).get("service", [])
+                        if isinstance(service, dict)
+                    ]
                 else:
                     mac = None
                     serial = None
+                    service_types = []
 
                 # Search for devices
                 if (st is not None or
@@ -295,7 +301,7 @@ def scan(st=None, timeout=DISCOVER_TIMEOUT,
                             if match_serial == serial:
                                 entries.append(entry)
                         elif st is not None:
-                            if st == entry.st:
+                            if st == entry.st or st in service_types:
                                 entries.append(entry)
                 elif not entry_in_entries(entry, entries, mac, serial):
                     entries.append(entry)


### PR DESCRIPTION
## Description:

Belkin recently release a new Wemo WiFi Smart Plug. https://www.belkin.com/us/p/P-WSP080/

The SSDP discovery response for this model is a bit different from other Wemo devices

```
HTTP/1.1 200 OK
CACHE-CONTROL: max-age=86400
DATE: Fri, 24 Jul 2020 08:38:40 GMT
EXT:
LOCATION: http://[snip-ip]:49152/setup.xml
OPT: "http://schemas.upnp.org/upnp/1/0"; ns=01
SERVER: Unspecified, UPnP/1.0, Unspecified
X-User-Agent: redsonic
ST: upnp:rootdevice
USN: uuid:Socket-1_0-M15[snip-serial]::upnp:rootdevice
```

In particular, the value for the `ST` header is not the typical `urn:Belkin:service:basicevent:1`. This causes ssdp discovery to filter out the device, as `upnp:rootdevice` does not match the typical expected value.

To fix, and allow the new Wemo Smart Plug to be included in the list of discovered devices, this PR parses the serviceType XML fields from /setup.xml and compares them with the expected `st` value.

This PR was tested locally by calling `pywemo.discover_devices()` in a simple script as well as tested with Home Assistant.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] There is no commented out code in this PR.