### PR TITLE
Reliability improvements for SSDP discovery.

### DIFF
--- a/pywemo/ssdp.py
+++ b/pywemo/ssdp.py
@@ -237,7 +237,6 @@ def scan(st=None, timeout=DISCOVER_TIMEOUT,
     entries = []
 
     calc_now = datetime.now
-    start = calc_now()
 
     ssdp_request = build_ssdp_request(st, ssdp_mx=1)
     sockets = []
@@ -251,6 +250,7 @@ def scan(st=None, timeout=DISCOVER_TIMEOUT,
             except socket.error:
                 pass
 
+        start = calc_now()
         while sockets:
             time_diff = calc_now() - start
 

--- a/pywemo/ssdp.py
+++ b/pywemo/ssdp.py
@@ -4,7 +4,6 @@ import re
 import select
 import socket
 import threading
-import time
 
 from datetime import datetime, timedelta
 import xml.etree.ElementTree as XMLElementTree
@@ -260,7 +259,8 @@ def scan(st=None, timeout=DISCOVER_TIMEOUT,
 
             ready = select.select(sockets, [], [], min(1, seconds_left))[0]
             if not ready:
-                # No more results. Exit if the time has expired, or probe again.
+                # No more results. Exit if the time has expired,
+                # or probe again.
                 if seconds_left <= 0:
                     return entries
                 for s in sockets:

--- a/pywemo/ssdp.py
+++ b/pywemo/ssdp.py
@@ -142,6 +142,7 @@ class UPNPEntry:
                                 etree_to_dict(tree).get('root', {})
                         else:
                             UPNPEntry.DESCRIPTION_CACHE[url] = {}
+                        break
 
                     except requests.RequestException:
                         logging.getLogger(__name__).warning(
@@ -259,8 +260,9 @@ def scan(st=None, timeout=DISCOVER_TIMEOUT,
 
             ready = select.select(sockets, [], [], min(1, seconds_left))[0]
             if not ready:
-                # No more results. Exit if the time has expired,
-                # or probe again.
+                # Only check for timeout when there are no more results. Exit
+                # if the time has expired, or probe again if there is more
+                # time remaining.
                 if seconds_left <= 0:
                     return entries
                 for s in sockets:


### PR DESCRIPTION
## Description:

- Retry fetching the xml description from the device.
- Always process all received data before exiting. This handle the case where a single device can take too long and prevent other devices from being discovered.
- Eliminate the 0.5 second delay before processing the first device.
- Probe more than twice if time allows.
- Don't start the timer until after the initial SSDP requests are sent.

**Related issue:** https://github.com/home-assistant/core/issues/36771

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] There is no commented out code in this PR.