### PR TITLE
Do not allow the ssdp seconds_left to become a negative value

### DIFF
--- a/pywemo/ssdp.py
+++ b/pywemo/ssdp.py
@@ -256,7 +256,7 @@ def scan(st=None, timeout=DISCOVER_TIMEOUT,
             time_diff = calc_now() - start
 
             # pylint: disable=maybe-no-member
-            seconds_left = timeout - time_diff.seconds
+            seconds_left = max(timeout - time_diff.seconds, 0)
 
             ready = select.select(sockets, [], [], min(1, seconds_left))[0]
             if not ready:


### PR DESCRIPTION
## Description:

```
2020-08-09 20:26:33 ERROR (MainThread) [homeassistant.config_entries] Error setting up entry Wemo for wemo
Traceback (most recent call last):
  File "/usr/src/homeassistant/homeassistant/config_entries.py", line 219, in async_setup
    result = await component.async_setup_entry(  # type: ignore
  File "/usr/src/homeassistant/homeassistant/components/wemo/__init__.py", line 122, in async_setup_entry
    for device in await hass.async_add_executor_job(pywemo.discover_devices):
  File "/usr/local/lib/python3.8/concurrent/futures/thread.py", line 57, in run
    result = self.fn(*self.args, **self.kwargs)
  File "/usr/local/lib/python3.8/site-packages/pywemo/discovery.py", line 25, in discover_devices
    ssdp_entries = ssdp.scan(ssdp_st, max_entries=max_devices,
  File "/usr/local/lib/python3.8/site-packages/pywemo/ssdp.py", line 261, in scan
    ready = select.select(sockets, [], [], min(1, seconds_left))[0]
ValueError: timeout must be non-negative
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] There is no commented out code in this PR.