### PR TITLE
do not try to install 'tests' package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setup(name='pywemo',
       author_email='mail@gregdowling.com',
       license='MIT',
       install_requires=['ifaddr>=0.1.0', 'requests>=2.0', 'six>=1.10.0'],
-      packages=find_packages(exclude=['tests','tests.*']),
+      packages=find_packages(exclude=['tests', 'tests.*']),
       zip_safe=True,
       classifiers=[
           "Programming Language :: Python :: 2",

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setup(name='pywemo',
       author_email='mail@gregdowling.com',
       license='MIT',
       install_requires=['ifaddr>=0.1.0', 'requests>=2.0', 'six>=1.10.0'],
-      packages=find_packages(),
+      packages=find_packages(exclude=['tests','tests.*']),
       zip_safe=True,
       classifiers=[
           "Programming Language :: Python :: 2",


### PR DESCRIPTION
https://git.edevau.net/onkelbeh/HomeAssistantRepository/issues/70

## Description:
setup.py tries to install 'tests' package.
This should be avoided.
Patch adds an exclude to find_packages()

**Related issue (if applicable):** fixes #<pywemo issue number goes here>

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] There is no commented out code in this PR.