### PR TITLE
Add mention of WeMo IP-only firmware bug

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -37,7 +37,7 @@ On some networks discovery doesn't work reliably, in that case if you can find t
     >> print(device)
     <WeMo Insight "AC Insight">
 
-Please note that you need to use ip addresses as shown above, rather than hostnames, otherwise the subscription update logic won't work.
+Please note that you must use IP addresses here, rather than hostnames. First, because subscription update logic won't work properly; second, because recent versions of the WeMo firmware may not accept connections from hostnames, and will return a 500 error.
 
 Developing
 -------


### PR DESCRIPTION
## Description:

Recent versions of the WeMo firmware (as of yesterday, 2020-09-19) seem
to throw 500 errors when connected to via hostname, but work fine when
connected to by IP. Mention this in the manual documentation in case
anyone else notices this.

**Related issue (if applicable):** References #169
## Checklist:
  - [x] The code change is tested and works locally. **N/A, documentation only**
  - [x] There is no commented out code in this PR.