### PR TITLE
Port setup_url_for_address and resolve hostnames to IPs

### DIFF
--- a/pywemo/discovery.py
+++ b/pywemo/discovery.py
@@ -1,9 +1,9 @@
 """Module to discover WeMo devices."""
-import logging
-import requests
-
 from socket import gethostbyname, gaierror
 from ipaddress import ip_address
+
+import logging
+import requests
 
 from . import ssdp
 from .ouimeaux_device.bridge import Bridge
@@ -111,7 +111,8 @@ def setup_url_for_address(host, port):
 
     if is_hostname:
         try:
-            # The {host} must be resolved to an IP address; if this fails, this will throw a socket.gaierror.
+            # The {host} must be resolved to an IP address; if this fails, this will
+            # throw a socket.gaierror.
             host_address = gethostbyname(host)
 
             # Reset {host} to the resolved address.

--- a/pywemo/discovery.py
+++ b/pywemo/discovery.py
@@ -115,7 +115,7 @@ def hostname_lookup(hostname):
         LOG.debug(
             'Could not resolve hostname %s to an IP address.',
             hostname)
-        return None
+        return hostname
 
 
 def setup_url_for_address(host, port):
@@ -128,11 +128,7 @@ def setup_url_for_address(host, port):
         ip_address(host)
     except ValueError:
         # The provided {host} should be treated as a hostname.
-        host_address = hostname_lookup(host)
-        if host_address is not None:
-            host = host_address
-        else:
-            return None
+        host = hostname_lookup(host)
 
     # Automatically determine the port if not provided.
     if not port:

--- a/pywemo/discovery.py
+++ b/pywemo/discovery.py
@@ -126,12 +126,8 @@ def setup_url_for_address(host, port):
         # Attempt to register {host} as an IP address; if this fails ({host} is not an IP address),
         # this will throw a ValueError.
         ip_address(host)
-        is_hostname = False
     except ValueError:
         # The provided {host} should be treated as a hostname.
-        is_hostname = True
-
-    if is_hostname:
         host_address = hostname_lookup(host)
         if host_address is not None:
             host = host_address

--- a/pywemo/discovery.py
+++ b/pywemo/discovery.py
@@ -96,6 +96,7 @@ def device_from_uuid_and_location(uuid, mac, location,
 
     return None
 
+
 def setup_url_for_address(host, port):
     """Determine setup.xml url for a given host and port pair."""
 

--- a/pywemo/discovery.py
+++ b/pywemo/discovery.py
@@ -105,6 +105,7 @@ def setup_url_for_address(host, port):
         # Attempt to register {host} as an IP address; if this fails ({host} is not an IP address),
         # this will throw a ValueError.
         ip_address(host)
+        is_hostname = False
     except ValueError:
         # The provided {host} should be treated as a hostname.
         is_hostname = True

--- a/pywemo/discovery.py
+++ b/pywemo/discovery.py
@@ -13,6 +13,7 @@ from .ouimeaux_device.maker import Maker
 from .ouimeaux_device.coffeemaker import CoffeeMaker
 from .ouimeaux_device.humidifier import Humidifier
 from .ouimeaux_device.api.xsd import device as deviceParser
+from .ouimeaux_device import probe_wemo
 
 LOG = logging.getLogger(__name__)
 
@@ -91,3 +92,14 @@ def device_from_uuid_and_location(uuid, mac, location,
                           rediscovery_enabled=rediscovery_enabled)
 
     return None
+
+
+def setup_url_for_address(host, port):
+    """Determine setup.xml url for given host and port pair."""
+    if not port:
+        port = probe_wemo(host)
+
+    if not port:
+        return None
+
+    return "http://%s:%s/setup.xml" % (host, port)

--- a/pywemo/discovery.py
+++ b/pywemo/discovery.py
@@ -97,6 +97,27 @@ def device_from_uuid_and_location(uuid, mac, location,
     return None
 
 
+def hostname_lookup(hostname):
+    """Resolve a hostname into an IP address"""
+    try:
+        # The {host} must be resolved to an IP address; if this fails, this will
+        # throw a socket.gaierror.
+        host_address = gethostbyname(hostname)
+
+        # Reset {host} to the resolved address.
+        LOG.debug(
+            'Resolved hostname %s to IP address %s.',
+            hostname, host_address)
+        return host_address
+
+    except gaierror:
+        # The {host}-as-hostname did not resolve to an IP address.
+        LOG.debug(
+            'Could not resolve hostname %s to an IP address.',
+            hostname)
+        return None
+
+
 def setup_url_for_address(host, port):
     """Determine setup.xml url for a given host and port pair."""
 
@@ -111,22 +132,10 @@ def setup_url_for_address(host, port):
         is_hostname = True
 
     if is_hostname:
-        try:
-            # The {host} must be resolved to an IP address; if this fails, this will
-            # throw a socket.gaierror.
-            host_address = gethostbyname(host)
-
-            # Reset {host} to the resolved address.
-            LOG.debug(
-                'Resolved hostname %s to IP address %s.',
-                host, host_address)
+        host_address = hostname_lookup(host)
+        if host_address is not None:
             host = host_address
-
-        except gaierror:
-            # The {host}-as-hostname did not resolve to an IP address.
-            LOG.debug(
-                'Could not resolve hostname %s to an IP address.',
-                host)
+        else:
             return None
 
     # Automatically determine the port if not provided.

--- a/pywemo/discovery.py
+++ b/pywemo/discovery.py
@@ -98,7 +98,7 @@ def device_from_uuid_and_location(uuid, mac, location,
 
 
 def hostname_lookup(hostname):
-    """Resolve a hostname into an IP address"""
+    """Resolve a hostname into an IP address."""
     try:
         # The {host} must be resolved to an IP address; if this fails, this will
         # throw a socket.gaierror.


### PR DESCRIPTION
## Description:

1. Ports in the `setup_url_for_address` function from the HomeAssistant WeMo component.
2. Fixes #169 by resolving a provided hostname string (non-IP-address `{host}` value) into an IP address before crafting the URL in the `setup_url_for_address` function.

Will require an updated release containing this change before https://github.com/home-assistant/core/pull/42722 can be accepted.

**Related issue (if applicable):** fixes #169

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] There is no commented out code in this PR.