### PR TITLE
remove calls to removed getchildren calls in python 3.9

### DIFF
--- a/pywemo/ouimeaux_device/api/service.py
+++ b/pywemo/ouimeaux_device/api/service.py
@@ -67,9 +67,9 @@ class Action:
                     headers=self.headers, timeout=10)
                 response_dict = {}
                 # pylint: disable=deprecated-method
-                for response_item in et.fromstring(
+                for response_item in list(list(list(et.fromstring(
                         response.content
-                ).getchildren()[0].getchildren()[0].getchildren():
+                        )))[0])[0]:
                     response_dict[response_item.tag] = response_item.text
                 return response_dict
             except requests.exceptions.RequestException:

--- a/pywemo/subscribe.py
+++ b/pywemo/subscribe.py
@@ -57,7 +57,7 @@ class RequestHandler(BaseHTTPServer.BaseHTTPRequestHandler):
             data = data.decode("UTF-8").split("\n\n")[0]
             doc = cElementTree.fromstring(data)
             for propnode in doc.findall('./{0}property'.format(NS)):
-                for property_ in propnode.getchildren():
+                for property_ in list(propnode):
                     text = property_.text
                     outer.event(device, property_.tag, text)
 


### PR DESCRIPTION
Python 3.9 removed deprecated calls to getchildren() of classes
ElementTree switch to useing list(x) instead.


Signed-off-by: Dennis Gilmore <dennis@ausil.us>

## Description:


**Related issue (if applicable):** fixes #173

## Checklist:
  - [ ] The code change is tested and works locally.
  - [x] There is no commented out code in this PR.