### PR TITLE
Remove calls to removed getchildren calls in python 3.9 (and update tests)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: [3.6, 3.7]
+        python-version: [3.7, 3.9]
 
     steps:
       - uses: actions/checkout@v1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pywemo"
-version = "0.5.0"
+version = "0.5.3"
 description = "Lightweight Python module to discover and control WeMo devices"
 authors = ["Greg Dowling <mail@gregdowling.com>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ homepage = "https://github.com/pavoni/pywemo"
 keywords = ['wemo', 'api']
 
 [tool.poetry.dependencies]
-python = "^3.6 || ^3.7"
+python = "^3.7 || ^3.9"
 ifaddr = ">=0.1.0"
 requests = ">=2.0"
 six = ">=1.10.0"

--- a/pywemo/ouimeaux_device/api/service.py
+++ b/pywemo/ouimeaux_device/api/service.py
@@ -67,9 +67,9 @@ class Action:
                     headers=self.headers, timeout=10)
                 response_dict = {}
                 # pylint: disable=deprecated-method
-                for response_item in et.fromstring(
+                for response_item in list(list(list(et.fromstring(
                         response.content
-                ).getchildren()[0].getchildren()[0].getchildren():
+                        )))[0])[0]:
                     response_dict[response_item.tag] = response_item.text
                 return response_dict
             except requests.exceptions.RequestException:

--- a/pywemo/ouimeaux_device/api/service.py
+++ b/pywemo/ouimeaux_device/api/service.py
@@ -66,7 +66,7 @@ class Action:
                     self.controlURL, body.strip(),
                     headers=self.headers, timeout=10)
                 response_dict = {}
-                # pylint: disable=deprecated-method
+
                 for response_item in list(list(list(et.fromstring(
                         response.content
                         )))[0])[0]:

--- a/pywemo/subscribe.py
+++ b/pywemo/subscribe.py
@@ -57,7 +57,7 @@ class RequestHandler(BaseHTTPServer.BaseHTTPRequestHandler):
             data = data.decode("UTF-8").split("\n\n")[0]
             doc = cElementTree.fromstring(data)
             for propnode in doc.findall('./{0}property'.format(NS)):
-                for property_ in propnode.getchildren():
+                for property_ in list(propnode):
                     text = property_.text
                     outer.event(device, property_.tag, text)
 


### PR DESCRIPTION
## Description:
Python 3.9 removed deprecated calls to getchildren() of classes
ElementTree switch to useing list(x) instead.

This takes @ausil's PR https://github.com/pavoni/pywemo/pull/174 and updates the tests
**Related issue (if applicable): fixes #173

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] There is no commented out code in this PR.