### PR TITLE
Device setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -87,6 +87,7 @@ virtualization/vagrant/config
 
 # Visual Studio Code
 .vscode
+*.code-workspace
 
 # Built docs
 docs/build

--- a/README.rst
+++ b/README.rst
@@ -48,7 +48,7 @@ Reset can be performed with the `reset` method, which has 2 boolean input argume
 Setting `data=True` will reset data ("Clear Personalized Info" in the Wemo app), which resets the device name and cleans the icon and rules.
 Setting `wifi=True` will clear wifi information ("Change Wi-Fi" in the Wemo app), which does not clear the rules, name, etc.
 Setting both to true is equivalent to a "Factory Restore" from the app.
-It should also be noted that devices contain a hardware reset procuedure as well, so using the software is for convience.
+It should also be noted that devices contain a hardware reset procuedure as well, so using the software is for convience or if physical access is not available.
 
 Device setup is through the `setup` method.
 The user must first connect to the devices locally broadcast access point, then discover the device there.

--- a/README.rst
+++ b/README.rst
@@ -48,13 +48,13 @@ Reset can be performed with the `reset` method, which has 2 boolean input argume
 Setting `data=True` will reset data ("Clear Personalized Info" in the Wemo app), which resets the device name and cleans the icon and rules.
 Setting `wifi=True` will clear wifi information ("Change Wi-Fi" in the Wemo app), which does not clear the rules, name, etc.
 Setting both to true is equivalent to a "Factory Restore" from the app.
-It should also be noted that devices contain a hardware reset procuedure as well, so using the software is for convience or if physical access is not available.
+It should also be noted that devices contain a hardware reset procedure as well, so using the software is for convenience or if physical access is not available.
 
 Device setup is through the `setup` method.
 The user must first connect to the devices locally broadcast access point, then discover the device there.
 Once done, pass the desired SSID and password (AES encryption only) to the `setup` method to connect it to your wifi network.
 
-Impotant Note for Device Setup - OpenSSL is Required!
+Important Note for Device Setup - OpenSSL is Required!
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 OpenSSL is used to encrypt the password by the pywemo library.

--- a/README.rst
+++ b/README.rst
@@ -61,6 +61,7 @@ OpenSSL is used to encrypt the password by the pywemo library.
 It must be installed and available on the path via calling `openssl` with a terminal (or command prompt, if on Windows).
 This is not required if connecting the device to an open network, since that requires no password, although an open network certainly isn't recommended.
 
+
 Firmware Warning
 ----------------
 Starting in May of 2020, Belkin started requiring users to create an account and login to the app (Android app version 1.25).

--- a/README.rst
+++ b/README.rst
@@ -39,6 +39,28 @@ Please note that `discovery.device_from_description` call requires a `url` with 
 
 The `setup_url_for_address` function will lookup a hostname and provide a suitable `url` with an IP address.
 
+Device Reset and Setup
+----------------------
+pywemo includes the ability to reset and setup devices, without the use of the Belkin app nor need to create a Belkin account.
+This can be particularly useful if the intended use is fully local control, such as using Home Assistant.
+
+Reset can be performed with the `reset` method, which has 2 boolean input arguments, `data` and `wifi`.
+Setting `data=True` will reset data ("Clear Personalized Info" in the Wemo app), which resets the device name and cleans the icon and rules.
+Setting `wifi=True` will clear wifi information ("Change Wi-Fi" in the Wemo app), which does not clear the rules, name, etc.
+Setting both to true is equivalent to a "Factory Restore" from the app.
+It should also be noted that devices contain a hardware reset procuedure as well, so using the software is for convience.
+
+Device setup is through the `setup` method.
+The user must first connect to the devices locally broadcast access point, then discover the device there.
+Once done, pass the desired SSID and password (AES encryption only) to the `setup` method to connect it to your wifi network.
+
+Impotant note for setup method
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+OpenSSL is used to encrypt the password by the pywemo library.
+It must be installed and available on the path via calling `openssl` with a terminal (or command prompt, if on Windows).
+This is not required if connecting the device to an open network, since that requires no password, although an open network certainly isn't recommended.
+
 Firmware Warning
 ----------------
 Starting in May of 2020, Belkin started requiring users to create an account and login to the app (Android app version 1.25).

--- a/README.rst
+++ b/README.rst
@@ -54,8 +54,8 @@ Device setup is through the `setup` method.
 The user must first connect to the devices locally broadcast access point, then discover the device there.
 Once done, pass the desired SSID and password (AES encryption only) to the `setup` method to connect it to your wifi network.
 
-Impotant note for setup method
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Impotant Note for Device Setup - OpenSSL is Required!
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 OpenSSL is used to encrypt the password by the pywemo library.
 It must be installed and available on the path via calling `openssl` with a terminal (or command prompt, if on Windows).

--- a/README.rst
+++ b/README.rst
@@ -21,7 +21,6 @@ How to use
 
     >> devices[0].toggle()
 
-
 If discovery doesn't work on your network
 -----------------------------------------
 On some networks discovery doesn't work reliably, in that case if you can find the ip address of your Wemo device you can use the following code.
@@ -38,7 +37,16 @@ On some networks discovery doesn't work reliably, in that case if you can find t
 
 Please note that `discovery.device_from_description` call requires a `url` with an IP address, rather than a hostnames. This is needed for the subscription update logic to work properly. In addition recent versions of the WeMo firmware may not accept connections from hostnames, and will return a 500 error.
 
-The `setup_url_for_address` function will lookup a hostname and provide a suitable `url` with an IP addesss.
+The `setup_url_for_address` function will lookup a hostname and provide a suitable `url` with an IP address.
+
+Firmware Warning
+----------------
+Starting in May of 2020, Belkin started requiring users to create an account and login to the app (Android app version 1.25).
+In addition to the account, most of the app functionality now requires a connection to the cloud (internet access), even for simple actions such as toggling a switch.
+All of the commands that go through the cloud are encrypted and cannot be easily inspected.
+This raises the possibility that Belkin could, in the future, update Wemo device firmware and make breaking API changes that can not longer be deciphered.
+If this happens, pywemo may no longer function on that device.
+It would be prudent to upgrade firmware cautiously and preferably only after confirming that breaking API changes have not been introduced.
 
 Developing
 ----------

--- a/README.rst
+++ b/README.rst
@@ -61,7 +61,6 @@ OpenSSL is used to encrypt the password by the pywemo library.
 It must be installed and available on the path via calling `openssl` with a terminal (or command prompt, if on Windows).
 This is not required if connecting the device to an open network, since that requires no password, although an open network certainly isn't recommended.
 
-
 Firmware Warning
 ----------------
 Starting in May of 2020, Belkin started requiring users to create an account and login to the app (Android app version 1.25).

--- a/pywemo/ouimeaux_device/__init__.py
+++ b/pywemo/ouimeaux_device/__init__.py
@@ -424,9 +424,9 @@ class Device(object):
         access_points = wifisetup.GetApList()['ApList']
 
         selected_ap = None
-        for access_point in access_points.split('\n'):
+        for access_point in access_points.split('\n')[1:]:
             access_point = access_point.strip().rstrip(',')
-            if not access_point.strip():
+            if not access_point.strip() or '|' not in access_point:
                 continue
             LOG.debug('found AP: %s', access_point)
             if access_point.startswith(f'{ssid}|'):
@@ -511,7 +511,8 @@ class Device(object):
         except KeyError:
             # print entire dictionary if status doesn't exist
             close_status = result
-        LOG.info('close status: %s', close_status)
+        LOG.debug('network status: %s', status)
+        LOG.debug('close status: %s', close_status)
 
         if status == '1' and close_status == 'success':
             try:

--- a/pywemo/ouimeaux_device/__init__.py
+++ b/pywemo/ouimeaux_device/__init__.py
@@ -546,8 +546,8 @@ class Device(object):
             LOG.info('starting status checks (%s second timeout)', timeout)
             status = None
 
-            # Make an initial, quick check
-            time.sleep(0.50)
+            # Make an initial, quicker check
+            time.sleep(min(0.50, status_delay / 3.0))
             status = wifisetup.GetNetworkStatus()['NetworkStatus']
             LOG.debug('initial status check: %s', status)
 

--- a/pywemo/ouimeaux_device/__init__.py
+++ b/pywemo/ouimeaux_device/__init__.py
@@ -299,7 +299,7 @@ class Device(object):
 
     def factory_reset(self):
         """Convenience method to perform a full factory reset."""
-        self.reset(data=True, wifi=True)
+        return self.reset(data=True, wifi=True)
 
     @staticmethod
     def encrypt_aes128(password, wemo_metadata):

--- a/pywemo/ouimeaux_device/__init__.py
+++ b/pywemo/ouimeaux_device/__init__.py
@@ -329,7 +329,6 @@ class Device(object):
                     '-aes-128-cbc',
                     '-md',
                     'md5',
-                    '-salt',
                     '-S',
                     salt.encode('utf-8').hex(),
                     '-iv',

--- a/pywemo/ouimeaux_device/__init__.py
+++ b/pywemo/ouimeaux_device/__init__.py
@@ -389,7 +389,7 @@ class Device(object):
         """Interface method for device setup."""
         try:
             return self._setup(*args, **kwargs)
-        except (AttributeError, KeyError) as exc:
+        except (UnknownService, AttributeError, KeyError) as exc:
             #    Exception      | Reason to catch it
             #    --------------------------------------------------------------
             #    UnknownService | some devices or firmwares may not have the

--- a/pywemo/ouimeaux_device/__init__.py
+++ b/pywemo/ouimeaux_device/__init__.py
@@ -90,6 +90,12 @@ class APNotFound(SetupException):
     pass
 
 
+class BadPassword(SetupException):
+    """Exception raised whe the AP requested is not found."""
+
+    pass
+
+
 class Device(object):
     """Base object for WeMo devices."""
 
@@ -597,7 +603,7 @@ class Device(object):
         LOG.debug('close status: %s', close_status)
 
         if status == '2':
-            raise SetupException(f'Wrong password provided for SSID {ssid}.')
+            raise BadPassword(f'Wrong password provided for SSID {ssid}.')
 
         if status == '1' and close_status == 'success':
             try:

--- a/pywemo/ouimeaux_device/__init__.py
+++ b/pywemo/ouimeaux_device/__init__.py
@@ -460,7 +460,7 @@ class Device(object):
             #                    | lost power (been unplugged).
             #    --------------------------------------------------------------
             raise SetupException(
-                f'pywemo lost device {self} and was unable to re-connect.  '
+                f'pywemo lost device {self} and was unable to reconnect.  '
                 'Setup status is uncertain, re-probing and checking is '
                 'required.'
             ) from exc

--- a/pywemo/ouimeaux_device/__init__.py
+++ b/pywemo/ouimeaux_device/__init__.py
@@ -290,7 +290,7 @@ class Device(object):
             )
 
         if data and wifi:
-            LOG.info('Clearing data and wifi (factor reset)')
+            LOG.info('Clearing data and wifi (factory reset)')
             result = action(Reset=2)
         elif data:
             LOG.info('Clearing data (icon, rules, etc)')

--- a/pywemo/ouimeaux_device/__init__.py
+++ b/pywemo/ouimeaux_device/__init__.py
@@ -425,7 +425,7 @@ class Device(object):
         connection_attempts : int, optional
             Number of times to try connecting a debice to the network, if it
             has failed to connect within `timeout` seconds.
-        status_delay : float
+        status_delay : float, optional
             Number of seconds to delay between each called to the connection
             status of the device.  Generally should prefer this to be as short
             as possible, but not too quick to overload the devive with

--- a/pywemo/ouimeaux_device/__init__.py
+++ b/pywemo/ouimeaux_device/__init__.py
@@ -461,19 +461,18 @@ class Device(object):
         status_delay=1.0,
     ):
         """
-        Setup Wemo device (connect device to wifi/AP).
+        Setup a Wemo device (connect to wifi/AP).
 
         See the setup method for details.
         """
-        # find all access points that the device can see, and select the one
-        # matching the desired SSID
-
         # a timeoiut of less than 20 is too short for many devices, so require
         # at least 20 seconds.
         timeout = min(timeout, 15.0)
         status_delay = min(status_delay, timeout / 2.0)
         connection_attempts = int(max(1, connection_attempts))
 
+        # find all access points that the device can see, and select the one
+        # matching the desired SSID
         LOG.info('scanning for AP\'s...')
         wifisetup = self.get_service('WiFiSetup')
         access_points = wifisetup.GetApList()['ApList']

--- a/pywemo/ouimeaux_device/__init__.py
+++ b/pywemo/ouimeaux_device/__init__.py
@@ -539,7 +539,7 @@ class Device(object):
                     status = result
                 LOG.debug('pairing status (second %s): %s', result, i + 1)
                 if i == 0:
-                    # skip this sleep on the second send
+                    # only delay on the first call
                     time.sleep(0.10)
 
             timeout_start = time.time()
@@ -566,8 +566,8 @@ class Device(object):
         try:
             result = wifisetup.CloseSetup()
         except AttributeError:
-            # if CloseSetup fails, it might have still been successful?
-            result = {'status': 'CloseSetup action not found'}
+            # if CloseSetup doesn't exist, it may still work
+            result = {'status': 'CloseSetup action not available'}
 
         try:
             close_status = result['status']
@@ -582,12 +582,12 @@ class Device(object):
                 self.basicevent.SetSetupDoneStatus()
             except AttributeError:
                 LOG.debug(
-                    'SetSetupDoneStatus not able to be set (some devices do '
-                    'not have this method)'
+                    'SetSetupDoneStatus not available (some devices do not '
+                    'have this method)'
                 )
             LOG.info(
-                'Wemo device connected to "%s", which took %.2f total seconds '
-                'over %s connection attempt(s)',
+                'Wemo device connected to "%s" in %.2f seconds (%s connection '
+                'attempts(s))',
                 ssid,
                 time.time() - start_time,
                 attempt + 1,

--- a/pywemo/ouimeaux_device/__init__.py
+++ b/pywemo/ouimeaux_device/__init__.py
@@ -295,12 +295,14 @@ class Device(object):
             # "success", but it appears to still reset successfully
             LOG.warning('result of reset (may be successful): %s', status)
 
+        return status
+
     def factory_reset(self):
         """Convenience method to perform a full factory reset."""
         self.reset(data=True, wifi=True)
 
     @staticmethod
-    def encrypt_aes128( password, wemo_metadata):
+    def encrypt_aes128(password, wemo_metadata):
         """
         Encrypt a password using OpenSSL.
 
@@ -386,7 +388,7 @@ class Device(object):
     def setup(self, *args, **kwargs):
         """Interface method for device setup."""
         try:
-            self._setup(*args, **kwargs)
+            return self._setup(*args, **kwargs)
         except (AttributeError, KeyError) as exc:
             #    Exception      | Reason to catch it
             #    --------------------------------------------------------------
@@ -538,6 +540,8 @@ class Device(object):
             raise SetupException(
                 f'Wemo device failed to connect to "{ssid}", please try again.'
             )
+
+        return status, close_status
 
     @property
     def model(self):


### PR DESCRIPTION
## Description: Add support to reset and setup pywemo devices

This is a subset of the closed PR #178 where only the essential reset and setup methods are created for the Device class.

**Related issue (if applicable):** fixes #171, #161

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] There is no commented out code in this PR.