### PR TITLE
add UnsupportedWemo

### DIFF
--- a/pywemo/discovery.py
+++ b/pywemo/discovery.py
@@ -6,7 +6,7 @@ from socket import gaierror, gethostbyname
 import requests
 
 from . import ssdp
-from .ouimeaux_device import probe_wemo
+from .ouimeaux_device import UnsupportedDevice, probe_wemo
 from .ouimeaux_device.api.xsd import device as deviceParser
 from .ouimeaux_device.bridge import Bridge
 from .ouimeaux_device.coffeemaker import CoffeeMaker
@@ -121,6 +121,19 @@ def device_from_uuid_and_location(
         )
     if uuid.startswith('uuid:OutdoorPlug'):
         return OutdoorPlug(
+            url=location, mac=mac, rediscovery_enabled=rediscovery_enabled
+        )
+    if uuid.startswith('uuid:'):
+        # unsupported device, but if this function was called from
+        # discover_devices then this should be a Belkin product and is probably
+        # a WeMo product without a custom class yet.  So attempt to return a
+        # basic object to allow manual interaction.
+        LOG.info(
+            'Device with %s is not supported by pywemo, returning '
+            'UnsupportedDevice object to allow manual interaction',
+            uuid,
+        )
+        return UnsupportedDevice(
             url=location, mac=mac, rediscovery_enabled=rediscovery_enabled
         )
 

--- a/pywemo/ouimeaux_device/__init__.py
+++ b/pywemo/ouimeaux_device/__init__.py
@@ -701,3 +701,22 @@ class Device:
     def serialnumber(self):
         """Return the serial number of the device."""
         return self._config.get_serialNumber()
+
+
+class UnsupportedDevice(Device):
+    """Representation of a WeMo device without a definition in pywemo.
+
+    This class is used if an apparent WeMo device is found on the network via
+    upnp discovery, but the device does not yet exist in pywemo.  This will
+    allow a user to see that something is discovered and manually interact with
+    it as well as aide in creating a permenant class for the new product.
+    """
+
+    def __repr__(self):
+        """Return a string representation of the device."""
+        return '<WeMo UnsupportedDevice "{name}">'.format(name=self.name)
+
+    @property
+    def device_type(self):
+        """Return what kind of WeMo this device is."""
+        return 'UnsupportedDevice'


### PR DESCRIPTION
## Description:  Return an ~~UnknownDevice~~ UnsupportedWemo if pywemo doesn't recognize an expected Wemo device

New Wemo products won't yet exist in pywemo and currently discovery would return `None` for those devices.  This PR adds a mechanism to allow a user to manually interact with the product, assuming that it "looks" like other wemo products.  The idea for this was prompted by #177 and I'll re-post a few of those thoughts here.

If a devices does not exist in pywemo, then `device_from_uuid_and_location` returns `None`, so the device is never "discovered".  This PR would add an `UnknownDevice` which is basically the same as the base `Device` class.  This would allow some future Wemo device to still be discovered, just not directly usable since it wouldn't have the helper methods like `on`, `off`, etc defined for it.  But at least it would let a user know that something was discovered on the network.

I'm not sure if there would be downstream effects to this (i.e. in Home Assistant).  Downstream users could though easily ignore devices that return `True` for `isinstance(object, UnknownDevice)`.  Home Assistant may want to do this since the unknown device can't be easily controlled.

**Related issue (if applicable):**  N/A

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] There is no commented out code in this PR.