### PR TITLE
add OutdoorPlug

### DIFF
--- a/pywemo/discovery.py
+++ b/pywemo/discovery.py
@@ -16,6 +16,7 @@ from .ouimeaux_device.insight import Insight
 from .ouimeaux_device.lightswitch import LightSwitch
 from .ouimeaux_device.maker import Maker
 from .ouimeaux_device.motion import Motion
+from .ouimeaux_device.outdoor_plug import OutdoorPlug
 from .ouimeaux_device.switch import Switch
 
 LOG = logging.getLogger(__name__)
@@ -118,6 +119,10 @@ def device_from_uuid_and_location(
         return Humidifier(
             url=location, mac=mac, rediscovery_enabled=rediscovery_enabled
         )
+    if uuid.startswith('uuid:OutdoorPlug'):
+        return OutdoorPlug(
+            url=location, mac=mac, rediscovery_enabled=rediscovery_enabled
+        )
 
     return None
 
@@ -125,8 +130,8 @@ def device_from_uuid_and_location(
 def hostname_lookup(hostname):
     """Resolve a hostname into an IP address."""
     try:
-        # The {host} must be resolved to an IP address; if this fails, this will
-        # throw a socket.gaierror.
+        # The {host} must be resolved to an IP address; if this fails, this
+        # will throw a socket.gaierror.
         host_address = gethostbyname(hostname)
 
         # Reset {host} to the resolved address.
@@ -146,8 +151,8 @@ def setup_url_for_address(host, port):
 
     # Force hostnames into IP addresses
     try:
-        # Attempt to register {host} as an IP address; if this fails ({host} is not an IP address),
-        # this will throw a ValueError.
+        # Attempt to register {host} as an IP address; if this fails ({host} is
+        # not an IP address), this will throw a ValueError.
         ip_address(host)
     except ValueError:
         # The provided {host} should be treated as a hostname.

--- a/pywemo/ouimeaux_device/outdoor_plug.py
+++ b/pywemo/ouimeaux_device/outdoor_plug.py
@@ -1,0 +1,15 @@
+"""Representation of a WeMo OutdoorPlug device."""
+from .switch import Switch
+
+
+class OutdoorPlug(Switch):
+    """Representation of a WeMo Motion device."""
+
+    def __repr__(self):
+        """Return a string representation of the device."""
+        return '<WeMo OutdoorPlug "{name}">'.format(name=self.name)
+
+    @property
+    def device_type(self):
+        """Return what kind of WeMo this device is."""
+        return "OutdoorPlug"


### PR DESCRIPTION
## Description:  Add support for the Outdoor Plug (Testers Needed)

Based on findings in #177, I've added initial support for the outdoor plug, but this should not be merged until it has been tested by someone as I do not have the device and cannot test it.

I'm assuming that this plug just turns "on" and "off" like a switch, so I copied the `LightSwitch` file and changed `LightSwitch` to `OutdoorPlug`, so it is essentially an identical device right now.  If there are other special things this plug can do, then it may need some more methods added.

**Related issue (if applicable):** fixes #177

## Checklist:
  - [ ] The code change is tested and works locally.
  - [x] There is no commented out code in this PR.