### PR TITLE
Make isort use the black profile

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,6 +58,6 @@ exclude = '''
 '''
 
 [tool.isort]
-profile = "hug"
+profile = "black"
 src_paths = ["pywemo", "tests"]
 


### PR DESCRIPTION
## Description:  Use black profile for isort

Should have used this from the start.

**Related issue (if applicable):** N/A

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] There is no commented out code in this PR.