### PR TITLE
Add long press support to LightSwitch and Dimmer devices

### DIFF
--- a/pywemo/ouimeaux_device/__init__.py
+++ b/pywemo/ouimeaux_device/__init__.py
@@ -12,6 +12,7 @@ except ImportError:
 
 import requests
 
+from .api.long_press import LongPressMixin
 from .api.service import ActionException, Service
 from .api.xsd import device as deviceParser
 
@@ -683,6 +684,11 @@ class Device:
             )
 
         return status, close_status
+
+    @classmethod
+    def supports_long_press(cls) -> bool:
+        """Return True of the device supports long press events."""
+        return issubclass(cls, LongPressMixin)
 
     @property
     def model(self):

--- a/pywemo/ouimeaux_device/dimmer.py
+++ b/pywemo/ouimeaux_device/dimmer.py
@@ -1,8 +1,9 @@
 """Representation of a WeMo Dimmer device."""
+from .api.long_press import LongPressMixin
 from .switch import Switch
 
 
-class Dimmer(Switch):
+class Dimmer(Switch, LongPressMixin):
     """Representation of a WeMo Dimmer device."""
 
     def __init__(self, *args, **kwargs):

--- a/pywemo/ouimeaux_device/lightswitch.py
+++ b/pywemo/ouimeaux_device/lightswitch.py
@@ -1,8 +1,9 @@
 """Representation of a WeMo Motion device."""
+from .api.long_press import LongPressMixin
 from .switch import Switch
 
 
-class LightSwitch(Switch):
+class LightSwitch(Switch, LongPressMixin):
     """Representation of a WeMo Motion device."""
 
     def __repr__(self):

--- a/tests/ouimeaux_device/api/unit/long_press_helpers.py
+++ b/tests/ouimeaux_device/api/unit/long_press_helpers.py
@@ -1,0 +1,70 @@
+import contextlib
+import sqlite3
+import tempfile
+from unittest.mock import create_autospec, patch
+
+import pytest
+
+from pywemo.ouimeaux_device.api import long_press, rules_db
+
+
+class TestLongPress:
+    """Test methods that are shared between devices that support long press."""
+
+    @pytest.fixture
+    def rules_db_from_device(self, device):
+        with tempfile.NamedTemporaryFile(
+            prefix="wemorules", suffix=".db"
+        ) as temp_file:
+            rules_db._create_empty_db(temp_file.name)
+            try:
+                conn = sqlite3.connect(temp_file.name)
+                conn.row_factory = sqlite3.Row
+                rdb = rules_db.RulesDb(conn, device.udn, device.name)
+
+                @contextlib.contextmanager
+                def yield_rdb(*_):
+                    yield rdb
+
+                with patch(
+                    "pywemo.ouimeaux_device.api.long_press.rules_db_from_device",
+                    side_effect=yield_rdb,
+                ):
+                    yield rdb
+            finally:
+                conn.close()
+
+    def test_supports_long_press(self, device):
+        """Verify that the device has long press support."""
+        assert device.supports_long_press()
+
+    @pytest.mark.usefixtures("rules_db_from_device")
+    def test_list_add_remove_long_press_udns(self, device):
+        """Verify that devices can be added/removed for long press control."""
+        udns = frozenset(["uuid:1", "uuid:2"])
+        device.add_long_press_udns(udns)
+        assert device.list_long_press_udns() == udns
+
+        device.remove_long_press_udns(udns)
+        assert device.list_long_press_udns() == frozenset()
+
+    @pytest.mark.usefixtures("rules_db_from_device")
+    def test_get_set_long_press_action(self, device):
+        """Test code for getting the ActionType of a long press."""
+        assert device.get_long_press_action() is None
+
+        device.set_long_press_action(long_press.ActionType.OFF)
+        assert device.get_long_press_action() == long_press.ActionType.OFF
+
+    @pytest.mark.usefixtures("rules_db_from_device")
+    def test_ensure_remove_long_press_virtual_device(self, device):
+        """Test that the virtual device can be added and removed."""
+        assert device.list_long_press_udns() == frozenset()
+
+        device.ensure_long_press_virtual_device()
+        assert device.list_long_press_udns() == frozenset(
+            [long_press.VIRTUAL_DEVICE_UDN]
+        )
+
+        device.remove_long_press_virtual_device()
+        assert device.list_long_press_udns() == frozenset()

--- a/tests/ouimeaux_device/api/unit/long_press_helpers.py
+++ b/tests/ouimeaux_device/api/unit/long_press_helpers.py
@@ -1,7 +1,7 @@
 import contextlib
 import sqlite3
 import tempfile
-from unittest.mock import create_autospec, patch
+from unittest.mock import patch
 
 import pytest
 

--- a/tests/ouimeaux_device/test_device.py
+++ b/tests/ouimeaux_device/test_device.py
@@ -369,3 +369,7 @@ class TestDevice:
         )
         device.setup('ap_open', 'password', timeout=20, connection_attempts=2)
         assert device.WiFiSetup.ConnectHomeNetwork.call_count == 4
+
+    def test_supports_long_press_is_false(self, lightspeed, device):
+        """Test that the base Device does not have support for long press."""
+        assert device.supports_long_press() == False

--- a/tests/ouimeaux_device/test_device.py
+++ b/tests/ouimeaux_device/test_device.py
@@ -372,4 +372,4 @@ class TestDevice:
 
     def test_supports_long_press_is_false(self, lightspeed, device):
         """Test that the base Device does not have support for long press."""
-        assert device.supports_long_press() == False
+        assert device.supports_long_press() is False

--- a/tests/ouimeaux_device/test_dimmer.py
+++ b/tests/ouimeaux_device/test_dimmer.py
@@ -1,0 +1,151 @@
+"""Tests for the Dimmer class."""
+
+import unittest.mock as mock
+
+import pytest
+
+from pywemo import Dimmer
+
+from .api.unit import long_press_helpers
+
+RESPONSE_SETUP = '''<?xml version="1.0"?>
+<root xmlns="urn:Belkin:device-1-0">
+  <specVersion>
+    <major>1</major>
+    <minor>0</minor>
+  </specVersion>
+  <device>
+<deviceType>urn:Belkin:device:dimmer:1</deviceType>
+<friendlyName>Wemo Dimmer</friendlyName>
+    <manufacturer>Belkin International Inc.</manufacturer>
+    <manufacturerURL>http://www.belkin.com</manufacturerURL>
+    <modelDescription>Belkin Plugin Dimmer 1.0</modelDescription>
+    <modelName>Dimmer</modelName>
+    <modelNumber>1.0</modelNumber>
+<hwVersion>v1</hwVersion>
+    <modelURL>http://www.belkin.com/plugin/</modelURL>
+<serialNumber>NNNNNNLNNNNNNN</serialNumber>
+<UDN>uuid:Dimmer-1_0-NNNNNNLNNNNNNN</UDN>
+    <UPC>123456789</UPC>
+<macAddress>XXXXXXXXXXXX</macAddress>
+<hkSetupCode>111-11-111</hkSetupCode>
+<firmwareVersion>WeMo_WW_2.00.11453.PVT-OWRT-Dimmer</firmwareVersion>
+<iconVersion>1|49153</iconVersion>
+<binaryState>0</binaryState>
+<brightness>100</brightness>
+    <new_algo>1</new_algo>
+    <iconList>
+      <icon>
+        <mimetype>jpg</mimetype>
+        <width>100</width>
+        <height>100</height>
+        <depth>100</depth>
+         <url>icon.jpg</url>
+      </icon>
+    </iconList>
+    <serviceList>
+      <service>
+        <serviceType>urn:Belkin:service:WiFiSetup:1</serviceType>
+        <serviceId>urn:Belkin:serviceId:WiFiSetup1</serviceId>
+        <controlURL>/upnp/control/WiFiSetup1</controlURL>
+        <eventSubURL>/upnp/event/WiFiSetup1</eventSubURL>
+        <SCPDURL>/setupservice.xml</SCPDURL>
+      </service>
+      <service>
+        <serviceType>urn:Belkin:service:timesync:1</serviceType>
+        <serviceId>urn:Belkin:serviceId:timesync1</serviceId>
+        <controlURL>/upnp/control/timesync1</controlURL>
+        <eventSubURL>/upnp/event/timesync1</eventSubURL>
+        <SCPDURL>/timesyncservice.xml</SCPDURL>
+      </service>
+      <service>
+        <serviceType>urn:Belkin:service:basicevent:1</serviceType>
+        <serviceId>urn:Belkin:serviceId:basicevent1</serviceId>
+        <controlURL>/upnp/control/basicevent1</controlURL>
+        <eventSubURL>/upnp/event/basicevent1</eventSubURL>
+        <SCPDURL>/eventservice.xml</SCPDURL>
+      </service>
+      <service>
+        <serviceType>urn:Belkin:service:firmwareupdate:1</serviceType>
+        <serviceId>urn:Belkin:serviceId:firmwareupdate1</serviceId>
+        <controlURL>/upnp/control/firmwareupdate1</controlURL>
+        <eventSubURL>/upnp/event/firmwareupdate1</eventSubURL>
+        <SCPDURL>/firmwareupdate.xml</SCPDURL>
+      </service>
+      <service>
+        <serviceType>urn:Belkin:service:rules:1</serviceType>
+        <serviceId>urn:Belkin:serviceId:rules1</serviceId>
+        <controlURL>/upnp/control/rules1</controlURL>
+        <eventSubURL>/upnp/event/rules1</eventSubURL>
+        <SCPDURL>/rulesservice.xml</SCPDURL>
+      </service>
+      <service>
+        <serviceType>urn:Belkin:service:metainfo:1</serviceType>
+        <serviceId>urn:Belkin:serviceId:metainfo1</serviceId>
+        <controlURL>/upnp/control/metainfo1</controlURL>
+        <eventSubURL>/upnp/event/metainfo1</eventSubURL>
+        <SCPDURL>/metainfoservice.xml</SCPDURL>
+      </service>
+      <service>
+        <serviceType>urn:Belkin:service:remoteaccess:1</serviceType>
+        <serviceId>urn:Belkin:serviceId:remoteaccess1</serviceId>
+        <controlURL>/upnp/control/remoteaccess1</controlURL>
+        <eventSubURL>/upnp/event/remoteaccess1</eventSubURL>
+        <SCPDURL>/remoteaccess.xml</SCPDURL>
+      </service>
+      <service>
+        <serviceType>urn:Belkin:service:deviceinfo:1</serviceType>
+        <serviceId>urn:Belkin:serviceId:deviceinfo1</serviceId>
+        <controlURL>/upnp/control/deviceinfo1</controlURL>
+        <eventSubURL>/upnp/event/deviceinfo1</eventSubURL>
+        <SCPDURL>/deviceinfoservice.xml</SCPDURL>
+      </service>
+      <service>
+        <serviceType>urn:Belkin:service:smartsetup:1</serviceType>
+        <serviceId>urn:Belkin:serviceId:smartsetup1</serviceId>
+        <controlURL>/upnp/control/smartsetup1</controlURL>
+        <eventSubURL>/upnp/event/smartsetup1</eventSubURL>
+        <SCPDURL>/smartsetup.xml</SCPDURL>
+      </service>
+      <service>
+        <serviceType>urn:Belkin:service:manufacture:1</serviceType>
+        <serviceId>urn:Belkin:serviceId:manufacture1</serviceId>
+        <controlURL>/upnp/control/manufacture1</controlURL>
+        <eventSubURL>/upnp/event/manufacture1</eventSubURL>
+        <SCPDURL>/manufacture.xml</SCPDURL>
+      </service>
+    </serviceList>
+   <presentationURL>/pluginpres.html</presentationURL>
+</device>
+</root>'''
+
+
+def mocked_requests_get(*args, **kwargs):
+    """Mock a response from request.get()."""
+
+    class MockResponse:
+        """Mocked requests response."""
+
+        def __init__(self, content, status_code):
+            self.content = content
+            self.status_code = status_code
+
+    if args[0] == 'http://192.168.1.100:49153/setup.xml':
+        return MockResponse(RESPONSE_SETUP.encode('utf-8'), 200)
+    return MockResponse(None, 404)
+
+
+@pytest.fixture
+@mock.patch('requests.get', side_effect=mocked_requests_get)
+def device(mock_get):
+    """Return a Device as created by some actual XML."""
+    # Note that the actions on the services will not be created since the
+    # URL(s) for them will return a 404.
+    return Dimmer('http://192.168.1.100:49153/setup.xml', '')
+
+
+#
+# No Dimmer specific tests at the moment. Only the tests from the imported
+# TestLongPress test will run.
+#
+TestLongPress = long_press_helpers.TestLongPress

--- a/tests/ouimeaux_device/test_lightswitch.py
+++ b/tests/ouimeaux_device/test_lightswitch.py
@@ -1,0 +1,150 @@
+"""Tests for the LightSwitch class."""
+
+import unittest.mock as mock
+
+import pytest
+
+from pywemo import LightSwitch
+
+from .api.unit import long_press_helpers
+
+RESPONSE_SETUP = '''<?xml version="1.0"?>
+<root xmlns="urn:Belkin:device-1-0">
+  <specVersion>
+    <major>1</major>
+    <minor>0</minor>
+  </specVersion>
+  <device>
+<deviceType>urn:Belkin:device:lightswitch:1</deviceType>
+<friendlyName>Wemo Light Switch</friendlyName>
+    <manufacturer>Belkin International Inc.</manufacturer>
+    <manufacturerURL>http://www.belkin.com</manufacturerURL>
+    <modelDescription>Belkin Plugin Socket 1.0</modelDescription>
+    <modelName>LightSwitch</modelName>
+    <modelNumber>1.0</modelNumber>
+<hwVersion>v3</hwVersion>
+    <modelURL>http://www.belkin.com/plugin/</modelURL>
+<serialNumber>NNNNLNNNLNNNNL</serialNumber>
+<UDN>uuid:Lightswitch-3_0-NNNNLNNNLNNNNL</UDN>
+    <UPC>123456789</UPC>
+<macAddress>XXXXXXXXXXXX</macAddress>
+<hkSetupCode>111-11-111</hkSetupCode>
+<firmwareVersion>WeMo_WW_2.00.11451.PVT-OWRT-LIGHTV2</firmwareVersion>
+<iconVersion>2|49152</iconVersion>
+<binaryState>0</binaryState>
+    <new_algo>1</new_algo>
+    <iconList>
+      <icon>
+        <mimetype>jpg</mimetype>
+        <width>100</width>
+        <height>100</height>
+        <depth>100</depth>
+         <url>icon.jpg</url>
+      </icon>
+    </iconList>
+    <serviceList>
+      <service>
+        <serviceType>urn:Belkin:service:WiFiSetup:1</serviceType>
+        <serviceId>urn:Belkin:serviceId:WiFiSetup1</serviceId>
+        <controlURL>/upnp/control/WiFiSetup1</controlURL>
+        <eventSubURL>/upnp/event/WiFiSetup1</eventSubURL>
+        <SCPDURL>/setupservice.xml</SCPDURL>
+      </service>
+      <service>
+        <serviceType>urn:Belkin:service:timesync:1</serviceType>
+        <serviceId>urn:Belkin:serviceId:timesync1</serviceId>
+        <controlURL>/upnp/control/timesync1</controlURL>
+        <eventSubURL>/upnp/event/timesync1</eventSubURL>
+        <SCPDURL>/timesyncservice.xml</SCPDURL>
+      </service>
+      <service>
+        <serviceType>urn:Belkin:service:basicevent:1</serviceType>
+        <serviceId>urn:Belkin:serviceId:basicevent1</serviceId>
+        <controlURL>/upnp/control/basicevent1</controlURL>
+        <eventSubURL>/upnp/event/basicevent1</eventSubURL>
+        <SCPDURL>/eventservice.xml</SCPDURL>
+      </service>
+      <service>
+        <serviceType>urn:Belkin:service:firmwareupdate:1</serviceType>
+        <serviceId>urn:Belkin:serviceId:firmwareupdate1</serviceId>
+        <controlURL>/upnp/control/firmwareupdate1</controlURL>
+        <eventSubURL>/upnp/event/firmwareupdate1</eventSubURL>
+        <SCPDURL>/firmwareupdate.xml</SCPDURL>
+      </service>
+      <service>
+        <serviceType>urn:Belkin:service:rules:1</serviceType>
+        <serviceId>urn:Belkin:serviceId:rules1</serviceId>
+        <controlURL>/upnp/control/rules1</controlURL>
+        <eventSubURL>/upnp/event/rules1</eventSubURL>
+        <SCPDURL>/rulesservice.xml</SCPDURL>
+      </service>
+      <service>
+        <serviceType>urn:Belkin:service:metainfo:1</serviceType>
+        <serviceId>urn:Belkin:serviceId:metainfo1</serviceId>
+        <controlURL>/upnp/control/metainfo1</controlURL>
+        <eventSubURL>/upnp/event/metainfo1</eventSubURL>
+        <SCPDURL>/metainfoservice.xml</SCPDURL>
+      </service>
+      <service>
+        <serviceType>urn:Belkin:service:remoteaccess:1</serviceType>
+        <serviceId>urn:Belkin:serviceId:remoteaccess1</serviceId>
+        <controlURL>/upnp/control/remoteaccess1</controlURL>
+        <eventSubURL>/upnp/event/remoteaccess1</eventSubURL>
+        <SCPDURL>/remoteaccess.xml</SCPDURL>
+      </service>
+      <service>
+        <serviceType>urn:Belkin:service:deviceinfo:1</serviceType>
+        <serviceId>urn:Belkin:serviceId:deviceinfo1</serviceId>
+        <controlURL>/upnp/control/deviceinfo1</controlURL>
+        <eventSubURL>/upnp/event/deviceinfo1</eventSubURL>
+        <SCPDURL>/deviceinfoservice.xml</SCPDURL>
+      </service>
+      <service>
+        <serviceType>urn:Belkin:service:smartsetup:1</serviceType>
+        <serviceId>urn:Belkin:serviceId:smartsetup1</serviceId>
+        <controlURL>/upnp/control/smartsetup1</controlURL>
+        <eventSubURL>/upnp/event/smartsetup1</eventSubURL>
+        <SCPDURL>/smartsetup.xml</SCPDURL>
+      </service>
+      <service>
+        <serviceType>urn:Belkin:service:manufacture:1</serviceType>
+        <serviceId>urn:Belkin:serviceId:manufacture1</serviceId>
+        <controlURL>/upnp/control/manufacture1</controlURL>
+        <eventSubURL>/upnp/event/manufacture1</eventSubURL>
+        <SCPDURL>/manufacture.xml</SCPDURL>
+      </service>
+    </serviceList>
+   <presentationURL>/pluginpres.html</presentationURL>
+</device>
+</root>'''
+
+
+def mocked_requests_get(*args, **kwargs):
+    """Mock a response from request.get()."""
+
+    class MockResponse:
+        """Mocked requests response."""
+
+        def __init__(self, content, status_code):
+            self.content = content
+            self.status_code = status_code
+
+    if args[0] == 'http://192.168.1.100:49153/setup.xml':
+        return MockResponse(RESPONSE_SETUP.encode('utf-8'), 200)
+    return MockResponse(None, 404)
+
+
+@pytest.fixture
+@mock.patch('requests.get', side_effect=mocked_requests_get)
+def device(mock_get):
+    """Return a Device as created by some actual XML."""
+    # Note that the actions on the services will not be created since the
+    # URL(s) for them will return a 404.
+    return LightSwitch('http://192.168.1.100:49153/setup.xml', '')
+
+
+#
+# No LightSwitch specific tests at the moment. Only the tests from the imported
+# TestLongPress test will run.
+#
+TestLongPress = long_press_helpers.TestLongPress


### PR DESCRIPTION
## Description:

This PR exposes the functionality to configure long press actions for the LightSwitch and Dimmer devices.

When combined with #192 & #193 it can be tested with the following script:

```
import logging
import time

import pywemo

WEMO_IP = ''  # Fill this in

def _cb(_device, _type, _params):
    logging.info(
        '%s %s %s', _device.name, _type, _params
    )

logging.basicConfig(level=logging.DEBUG)
sub = pywemo.SubscriptionRegistry()
sub.start()

responder = pywemo.ssdp.DiscoveryResponder(sub.port)
responder.start()

device = pywemo.discovery.device_from_description(
    pywemo.discovery.setup_url_for_address(WEMO_IP, 0), None
)

device.ensure_long_press_virtual_device()
sub.register(device)
sub.on(device, pywemo.subscribe.EVENT_TYPE_LONG_PRESS, _cb)

try:
    time.sleep(999999)
finally:
    responder.stop()
    sub.stop()
```

**Related issue (if applicable):** fixes #61 

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] There is no commented out code in this PR.