### PR TITLE
remove python2 urlparse reference

### DIFF
--- a/pywemo/ouimeaux_device/__init__.py
+++ b/pywemo/ouimeaux_device/__init__.py
@@ -4,11 +4,7 @@ import base64
 import logging
 import subprocess
 import time
-
-try:
-    from urllib.parse import urlparse
-except ImportError:
-    from urlparse import urlparse
+from urllib.parse import urlparse
 
 import requests
 


### PR DESCRIPTION
## Description:  Remove python2 reference to urlparse


**Related issue (if applicable):** N/A
## Checklist:
  - [x] The code change is tested and works locally.
  - [x] There is no commented out code in this PR.