### PR TITLE
add db to pylint good-names

### DIFF
--- a/pylintrc
+++ b/pylintrc
@@ -36,6 +36,7 @@ good-names=
   k,
   s,
   st,
+  db,
   eventSubURL,
   uniqueID,
   do_NOTIFY,

--- a/pywemo/ouimeaux_device/api/rules_db.py
+++ b/pywemo/ouimeaux_device/api/rules_db.py
@@ -183,7 +183,7 @@ class RulesDb:
         )
 
     @property
-    def db(self) -> sqlite3.Connection:  # pylint: disable=invalid-name
+    def db(self) -> sqlite3.Connection:
         """Return the sqlite3 connection instance."""
         return self._db
 


### PR DESCRIPTION
## Description:
db is a common name to use for database and database code is being added now to support long press functionality, so it makes sense to allow this name globally.

**Related issue (if applicable):** N/A

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] There is no commented out code in this PR.