### PR TITLE
update build-system to user poetry-core

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,8 +31,8 @@ generateDS = "2.37.11"
 rstcheck = "^3.3.1"
 
 [build-system]
-requires = ["poetry>=0.12"]
-build-backend = "poetry.masonry.api"
+requires = ["poetry-core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"
 
 [tool.black]
 line-length = 79


### PR DESCRIPTION
## Description:
Update the `pyproject.toml` build section to be consistent with the newer recommendation from the poetry docs 
[here](https://python-poetry.org/docs/pyproject/#poetry-and-pep-517): 

"If your pyproject.toml file still references poetry directly as a build backend, you should update it to reference poetry_core instead."

**Related issue (if applicable):** N/A

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] There is no commented out code in this PR.