### PR TITLE
Reset UPnP description cache each scan

### DIFF
--- a/pywemo/ssdp.py
+++ b/pywemo/ssdp.py
@@ -223,6 +223,11 @@ class UPNPEntry:
             }
         )
 
+    @classmethod
+    def reset_cache(cls):
+        """Clear the internal cache of device descriptions."""
+        cls.DESCRIPTION_CACHE = {'_NO_LOCATION': {}}
+
     def __eq__(self, other):
         """Equality operator."""
         return (
@@ -290,6 +295,7 @@ def scan(
     ssdp_target = (MULTICAST_GROUP, MULTICAST_PORT)
 
     entries = []
+    UPNPEntry.reset_cache()
 
     calc_now = datetime.now
 


### PR DESCRIPTION
## Description:

Connectivity issues can cause a SSDP scan to fail to read a device's /setup.xml file. Because of the way the /setup.xml is cached, this can make it so that a device can never be discovered.
https://github.com/pavoni/pywemo/blob/820f29cba1a1939da62fce5ff028e3d3eadf5911/pywemo/ssdp.py#L186-L190

Multiple SSDP M-SEARCH messages are sent as part of the discovery scan. I believe the original intent of the `DESCRIPTION_CACHE` was to avoid polling the same device more than once during the same discovery scan call. That behavior is preserved here. The new behavior is to use a fresh cache for each scan.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] There is no commented out code in this PR.