### PR TITLE
Consider the request body in VCR tests

### DIFF
--- a/pywemo/ouimeaux_device/bridge.py
+++ b/pywemo/ouimeaux_device/bridge.py
@@ -107,7 +107,7 @@ class Bridge(Device):
         et.SubElement(req, 'CapabilityValue').text = ','.join(values)
 
         buf = io.BytesIO()
-        et.ElementTree(req).write(buf, encoding='utf-8', xml_declaration=True)
+        et.ElementTree(req).write(buf, encoding='UTF-8', xml_declaration=True)
         send_state = escape(buf.getvalue().decode(), quote=True)
 
         # pylint: disable=maybe-no-member

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -46,13 +46,9 @@ def vcr_config():
         response['body']['string'] = body
         return response
 
-    def remove_request_body(request):
-        request.body = None
-        return request
-
     return {
-        'before_record_request': remove_request_body,
         'before_record_response': scrub_identifiers,
+        'match_on': ['method', 'path', 'body'],
     }
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -48,7 +48,15 @@ def vcr_config():
 
     return {
         'before_record_response': scrub_identifiers,
-        'match_on': ['method', 'path', 'body'],
+        'match_on': [
+            'method',
+            'scheme',
+            'host',
+            'port',
+            'path',
+            'query',
+            'body',
+        ],
     }
 
 

--- a/tests/vcr/tests.ouimeaux_device.test_bridge/WeMo_WW_2.00.11057.PVT-OWRT-Link.yaml
+++ b/tests/vcr/tests.ouimeaux_device.test_bridge/WeMo_WW_2.00.11057.PVT-OWRT-Link.yaml
@@ -1281,7 +1281,7 @@ interactions:
 
       <u:GetEndDevicesWithStatus xmlns:u="urn:Belkin:service:bridge:1">
 
-      <DevUDN>uuid:Bridge-1_0-231438B01000D9</DevUDN>
+      <DevUDN>uuid:Bridge-1_0-SERIALNUMBER</DevUDN>
 
       <ReqListType>PAIRED_LIST</ReqListType>
 

--- a/tests/vcr/tests.ouimeaux_device.test_bridge/test_light_turn_off.yaml
+++ b/tests/vcr/tests.ouimeaux_device.test_bridge/test_light_turn_off.yaml
@@ -63,7 +63,7 @@ interactions:
 
       <u:GetEndDevicesWithStatus xmlns:u="urn:Belkin:service:bridge:1">
 
-      <DevUDN>uuid:Bridge-1_0-231438B01000D9</DevUDN>
+      <DevUDN>uuid:Bridge-1_0-SERIALNUMBER</DevUDN>
 
       <ReqListType>PAIRED_LIST</ReqListType>
 
@@ -123,7 +123,7 @@ interactions:
 
       <u:SetDeviceStatus xmlns:u="urn:Belkin:service:bridge:1">
 
-      <DeviceStatusList>&lt;?xml version=&#x27;1.0&#x27; encoding=&#x27;utf-8&#x27;?&gt;
+      <DeviceStatusList>&lt;?xml version=&#x27;1.0&#x27; encoding=&#x27;UTF-8&#x27;?&gt;
 
       &lt;DeviceStatus&gt;&lt;IsGroupAction&gt;NO&lt;/IsGroupAction&gt;&lt;DeviceID
       available=&quot;YES&quot;&gt;0017880108DA898B&lt;/DeviceID&gt;&lt;CapabilityID&gt;10006&lt;/CapabilityID&gt;&lt;CapabilityValue&gt;0&lt;/CapabilityValue&gt;&lt;/DeviceStatus&gt;</DeviceStatusList>
@@ -236,7 +236,7 @@ interactions:
 
       <u:GetEndDevicesWithStatus xmlns:u="urn:Belkin:service:bridge:1">
 
-      <DevUDN>uuid:Bridge-1_0-231438B01000D9</DevUDN>
+      <DevUDN>uuid:Bridge-1_0-SERIALNUMBER</DevUDN>
 
       <ReqListType>PAIRED_LIST</ReqListType>
 

--- a/tests/vcr/tests.ouimeaux_device.test_bridge/test_light_turn_on.yaml
+++ b/tests/vcr/tests.ouimeaux_device.test_bridge/test_light_turn_on.yaml
@@ -63,7 +63,7 @@ interactions:
 
       <u:GetEndDevicesWithStatus xmlns:u="urn:Belkin:service:bridge:1">
 
-      <DevUDN>uuid:Bridge-1_0-231438B01000D9</DevUDN>
+      <DevUDN>uuid:Bridge-1_0-SERIALNUMBER</DevUDN>
 
       <ReqListType>PAIRED_LIST</ReqListType>
 
@@ -123,7 +123,7 @@ interactions:
 
       <u:SetDeviceStatus xmlns:u="urn:Belkin:service:bridge:1">
 
-      <DeviceStatusList>&lt;?xml version=&#x27;1.0&#x27; encoding=&#x27;utf-8&#x27;?&gt;
+      <DeviceStatusList>&lt;?xml version=&#x27;1.0&#x27; encoding=&#x27;UTF-8&#x27;?&gt;
 
       &lt;DeviceStatus&gt;&lt;IsGroupAction&gt;NO&lt;/IsGroupAction&gt;&lt;DeviceID
       available=&quot;YES&quot;&gt;0017880108DA898B&lt;/DeviceID&gt;&lt;CapabilityID&gt;10008&lt;/CapabilityID&gt;&lt;CapabilityValue&gt;255:0&lt;/CapabilityValue&gt;&lt;/DeviceStatus&gt;</DeviceStatusList>
@@ -236,7 +236,7 @@ interactions:
 
       <u:GetEndDevicesWithStatus xmlns:u="urn:Belkin:service:bridge:1">
 
-      <DevUDN>uuid:Bridge-1_0-231438B01000D9</DevUDN>
+      <DevUDN>uuid:Bridge-1_0-SERIALNUMBER</DevUDN>
 
       <ReqListType>PAIRED_LIST</ReqListType>
 

--- a/tests/vcr/tests.ouimeaux_device.test_dimmer/Test_PVT_OWRT_Dimmer_v1.test_turn_off.yaml
+++ b/tests/vcr/tests.ouimeaux_device.test_dimmer/Test_PVT_OWRT_Dimmer_v1.test_turn_off.yaml
@@ -1,6 +1,20 @@
 interactions:
 - request:
-    body: null
+    body: '<?xml version="1.0" encoding="utf-8"?>
+
+      <s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/" s:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/">
+
+      <s:Body>
+
+      <u:SetBinaryState xmlns:u="urn:Belkin:service:basicevent:1">
+
+      <BinaryState>0</BinaryState>
+
+      </u:SetBinaryState>
+
+      </s:Body>
+
+      </s:Envelope>'
     headers:
       Accept:
       - '*/*'
@@ -42,7 +56,20 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: null
+    body: '<?xml version="1.0" encoding="utf-8"?>
+
+      <s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/" s:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/">
+
+      <s:Body>
+
+      <u:GetBinaryState xmlns:u="urn:Belkin:service:basicevent:1">
+
+
+      </u:GetBinaryState>
+
+      </s:Body>
+
+      </s:Envelope>'
     headers:
       Accept:
       - '*/*'

--- a/tests/vcr/tests.ouimeaux_device.test_dimmer/Test_PVT_OWRT_Dimmer_v1.test_turn_on.yaml
+++ b/tests/vcr/tests.ouimeaux_device.test_dimmer/Test_PVT_OWRT_Dimmer_v1.test_turn_on.yaml
@@ -1,6 +1,20 @@
 interactions:
 - request:
-    body: null
+    body: '<?xml version="1.0" encoding="utf-8"?>
+
+      <s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/" s:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/">
+
+      <s:Body>
+
+      <u:SetBinaryState xmlns:u="urn:Belkin:service:basicevent:1">
+
+      <BinaryState>1</BinaryState>
+
+      </u:SetBinaryState>
+
+      </s:Body>
+
+      </s:Envelope>'
     headers:
       Accept:
       - '*/*'
@@ -42,7 +56,20 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: null
+    body: '<?xml version="1.0" encoding="utf-8"?>
+
+      <s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/" s:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/">
+
+      <s:Body>
+
+      <u:GetBinaryState xmlns:u="urn:Belkin:service:basicevent:1">
+
+
+      </u:GetBinaryState>
+
+      </s:Body>
+
+      </s:Envelope>'
     headers:
       Accept:
       - '*/*'

--- a/tests/vcr/tests.ouimeaux_device.test_lightswitch/Test_PVT_OWRT_LS_v1.test_turn_off.yaml
+++ b/tests/vcr/tests.ouimeaux_device.test_lightswitch/Test_PVT_OWRT_LS_v1.test_turn_off.yaml
@@ -1,6 +1,20 @@
 interactions:
 - request:
-    body: null
+    body: '<?xml version="1.0" encoding="utf-8"?>
+
+      <s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/" s:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/">
+
+      <s:Body>
+
+      <u:SetBinaryState xmlns:u="urn:Belkin:service:basicevent:1">
+
+      <BinaryState>0</BinaryState>
+
+      </u:SetBinaryState>
+
+      </s:Body>
+
+      </s:Envelope>'
     headers:
       Accept:
       - '*/*'
@@ -42,7 +56,20 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: null
+    body: '<?xml version="1.0" encoding="utf-8"?>
+
+      <s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/" s:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/">
+
+      <s:Body>
+
+      <u:GetBinaryState xmlns:u="urn:Belkin:service:basicevent:1">
+
+
+      </u:GetBinaryState>
+
+      </s:Body>
+
+      </s:Envelope>'
     headers:
       Accept:
       - '*/*'

--- a/tests/vcr/tests.ouimeaux_device.test_lightswitch/Test_PVT_OWRT_LS_v1.test_turn_on.yaml
+++ b/tests/vcr/tests.ouimeaux_device.test_lightswitch/Test_PVT_OWRT_LS_v1.test_turn_on.yaml
@@ -1,6 +1,20 @@
 interactions:
 - request:
-    body: null
+    body: '<?xml version="1.0" encoding="utf-8"?>
+
+      <s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/" s:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/">
+
+      <s:Body>
+
+      <u:SetBinaryState xmlns:u="urn:Belkin:service:basicevent:1">
+
+      <BinaryState>1</BinaryState>
+
+      </u:SetBinaryState>
+
+      </s:Body>
+
+      </s:Envelope>'
     headers:
       Accept:
       - '*/*'
@@ -42,7 +56,20 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: null
+    body: '<?xml version="1.0" encoding="utf-8"?>
+
+      <s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/" s:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/">
+
+      <s:Body>
+
+      <u:GetBinaryState xmlns:u="urn:Belkin:service:basicevent:1">
+
+
+      </u:GetBinaryState>
+
+      </s:Body>
+
+      </s:Envelope>'
     headers:
       Accept:
       - '*/*'

--- a/tests/vcr/tests.ouimeaux_device.test_switch/Test_F7C027.test_turn_off.yaml
+++ b/tests/vcr/tests.ouimeaux_device.test_switch/Test_F7C027.test_turn_off.yaml
@@ -1,6 +1,20 @@
 interactions:
 - request:
-    body: null
+    body: '<?xml version="1.0" encoding="utf-8"?>
+
+      <s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/" s:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/">
+
+      <s:Body>
+
+      <u:SetBinaryState xmlns:u="urn:Belkin:service:basicevent:1">
+
+      <BinaryState>0</BinaryState>
+
+      </u:SetBinaryState>
+
+      </s:Body>
+
+      </s:Envelope>'
     headers:
       Accept:
       - '*/*'
@@ -41,7 +55,20 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: null
+    body: '<?xml version="1.0" encoding="utf-8"?>
+
+      <s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/" s:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/">
+
+      <s:Body>
+
+      <u:GetBinaryState xmlns:u="urn:Belkin:service:basicevent:1">
+
+
+      </u:GetBinaryState>
+
+      </s:Body>
+
+      </s:Envelope>'
     headers:
       Accept:
       - '*/*'

--- a/tests/vcr/tests.ouimeaux_device.test_switch/Test_F7C027.test_turn_on.yaml
+++ b/tests/vcr/tests.ouimeaux_device.test_switch/Test_F7C027.test_turn_on.yaml
@@ -1,6 +1,20 @@
 interactions:
 - request:
-    body: null
+    body: '<?xml version="1.0" encoding="utf-8"?>
+
+      <s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/" s:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/">
+
+      <s:Body>
+
+      <u:SetBinaryState xmlns:u="urn:Belkin:service:basicevent:1">
+
+      <BinaryState>1</BinaryState>
+
+      </u:SetBinaryState>
+
+      </s:Body>
+
+      </s:Envelope>'
     headers:
       Accept:
       - '*/*'
@@ -41,7 +55,20 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: null
+    body: '<?xml version="1.0" encoding="utf-8"?>
+
+      <s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/" s:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/">
+
+      <s:Body>
+
+      <u:GetBinaryState xmlns:u="urn:Belkin:service:basicevent:1">
+
+
+      </u:GetBinaryState>
+
+      </s:Body>
+
+      </s:Envelope>'
     headers:
       Accept:
       - '*/*'

--- a/tests/vcr/tests.ouimeaux_device.test_switch/Test_F7C063.test_turn_off.yaml
+++ b/tests/vcr/tests.ouimeaux_device.test_switch/Test_F7C063.test_turn_off.yaml
@@ -1,6 +1,20 @@
 interactions:
 - request:
-    body: null
+    body: '<?xml version="1.0" encoding="utf-8"?>
+
+      <s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/" s:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/">
+
+      <s:Body>
+
+      <u:SetBinaryState xmlns:u="urn:Belkin:service:basicevent:1">
+
+      <BinaryState>0</BinaryState>
+
+      </u:SetBinaryState>
+
+      </s:Body>
+
+      </s:Envelope>'
     headers:
       Accept:
       - '*/*'
@@ -42,7 +56,20 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: null
+    body: '<?xml version="1.0" encoding="utf-8"?>
+
+      <s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/" s:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/">
+
+      <s:Body>
+
+      <u:GetBinaryState xmlns:u="urn:Belkin:service:basicevent:1">
+
+
+      </u:GetBinaryState>
+
+      </s:Body>
+
+      </s:Envelope>'
     headers:
       Accept:
       - '*/*'

--- a/tests/vcr/tests.ouimeaux_device.test_switch/Test_F7C063.test_turn_on.yaml
+++ b/tests/vcr/tests.ouimeaux_device.test_switch/Test_F7C063.test_turn_on.yaml
@@ -1,6 +1,20 @@
 interactions:
 - request:
-    body: null
+    body: '<?xml version="1.0" encoding="utf-8"?>
+
+      <s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/" s:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/">
+
+      <s:Body>
+
+      <u:SetBinaryState xmlns:u="urn:Belkin:service:basicevent:1">
+
+      <BinaryState>1</BinaryState>
+
+      </u:SetBinaryState>
+
+      </s:Body>
+
+      </s:Envelope>'
     headers:
       Accept:
       - '*/*'
@@ -42,7 +56,20 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: null
+    body: '<?xml version="1.0" encoding="utf-8"?>
+
+      <s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/" s:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/">
+
+      <s:Body>
+
+      <u:GetBinaryState xmlns:u="urn:Belkin:service:basicevent:1">
+
+
+      </u:GetBinaryState>
+
+      </s:Body>
+
+      </s:Envelope>'
     headers:
       Accept:
       - '*/*'

--- a/tests/vcr/tests.ouimeaux_device.test_switch/Test_WSP080.test_turn_off.yaml
+++ b/tests/vcr/tests.ouimeaux_device.test_switch/Test_WSP080.test_turn_off.yaml
@@ -1,6 +1,20 @@
 interactions:
 - request:
-    body: null
+    body: '<?xml version="1.0" encoding="utf-8"?>
+
+      <s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/" s:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/">
+
+      <s:Body>
+
+      <u:SetBinaryState xmlns:u="urn:Belkin:service:basicevent:1">
+
+      <BinaryState>0</BinaryState>
+
+      </u:SetBinaryState>
+
+      </s:Body>
+
+      </s:Envelope>'
     headers:
       Accept:
       - '*/*'
@@ -35,7 +49,20 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: null
+    body: '<?xml version="1.0" encoding="utf-8"?>
+
+      <s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/" s:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/">
+
+      <s:Body>
+
+      <u:GetBinaryState xmlns:u="urn:Belkin:service:basicevent:1">
+
+
+      </u:GetBinaryState>
+
+      </s:Body>
+
+      </s:Envelope>'
     headers:
       Accept:
       - '*/*'

--- a/tests/vcr/tests.ouimeaux_device.test_switch/Test_WSP080.test_turn_on.yaml
+++ b/tests/vcr/tests.ouimeaux_device.test_switch/Test_WSP080.test_turn_on.yaml
@@ -1,6 +1,20 @@
 interactions:
 - request:
-    body: null
+    body: '<?xml version="1.0" encoding="utf-8"?>
+
+      <s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/" s:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/">
+
+      <s:Body>
+
+      <u:SetBinaryState xmlns:u="urn:Belkin:service:basicevent:1">
+
+      <BinaryState>1</BinaryState>
+
+      </u:SetBinaryState>
+
+      </s:Body>
+
+      </s:Envelope>'
     headers:
       Accept:
       - '*/*'
@@ -35,7 +49,20 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: null
+    body: '<?xml version="1.0" encoding="utf-8"?>
+
+      <s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/" s:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/">
+
+      <s:Body>
+
+      <u:GetBinaryState xmlns:u="urn:Belkin:service:basicevent:1">
+
+
+      </u:GetBinaryState>
+
+      </s:Body>
+
+      </s:Envelope>'
     headers:
       Accept:
       - '*/*'


### PR DESCRIPTION
## Description:

Consider the request ['method', 'scheme', 'host', 'port', 'path', 'query', 'body'] in VCR tests.

The previous default was ['method', 'scheme', 'host', 'port', 'path', 'query']

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] There is no commented out code in this PR.