### PR TITLE
Verify device IDs when probing

### DIFF
--- a/pywemo/ouimeaux_device/__init__.py
+++ b/pywemo/ouimeaux_device/__init__.py
@@ -191,13 +191,20 @@ class Device:
             LOG.error('Unable to re-probe wemo at %s', self.host)
             return False
 
+        url = f'http://{self.host}:{port}/setup.xml'
+        device = self.__class__(url, None)
+        if self.udn != device.udn:
+            LOG.error(
+                'Reconnected to a different WeMo. Expected %s / Received %s',
+                self.udn,
+                device.udn,
+            )
+            return False
+
         LOG.info('Reconnected to wemo at %s on port %i', self.host, port)
 
-        self.port = port
-        url = 'http://{}:{}/setup.xml'.format(self.host, self.port)
-
         # pylint: disable=attribute-defined-outside-init
-        self.__dict__ = self.__class__(url, None).__dict__
+        self.__dict__ = device.__dict__
 
         return True
 

--- a/tests/ouimeaux_device/test_device.py
+++ b/tests/ouimeaux_device/test_device.py
@@ -387,9 +387,7 @@ class TestDevice:
         get.assert_called_once()
 
     @mock.patch('requests.get', side_effect=requests.Timeout)
-    def test_reconnect_with_device_by_probing_ConnectTimeout(
-        self, get, device
-    ):
+    def test_reconnect_with_device_by_probing_Timeout(self, get, device):
         with mock.patch.object(device, '_reconnect_with_device_by_discovery'):
             device.reconnect_with_device()
         assert get.mock_calls == [


### PR DESCRIPTION
## Description:

Verify device IDs when probing. This is to avoid an [edge case](https://github.com/pavoni/pywemo/issues/114#issuecomment-450521329) with device IPs changing.

**Related issue (if applicable):** #114

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] There is no commented out code in this PR.