### PR TITLE
Update the dimmer attributes due to a subscription update event

### DIFF
--- a/pywemo/ouimeaux_device/dimmer.py
+++ b/pywemo/ouimeaux_device/dimmer.py
@@ -43,7 +43,7 @@ class Dimmer(Switch, LongPressMixin):
 
     def subscription_update(self, _type, _param):
         """Update the dimmer attributes due to a subscription update event."""
-        if _type == "Brightness":
+        if _type == "Brightness" and self._state:
             self._brightness = int(_param)
             return True
         return super().subscription_update(_type, _param)

--- a/pywemo/ouimeaux_device/dimmer.py
+++ b/pywemo/ouimeaux_device/dimmer.py
@@ -42,8 +42,11 @@ class Dimmer(Switch, LongPressMixin):
         self._brightness = int(brightness)
 
     def subscription_update(self, _type, _param):
-        """Disable subscription updates."""
-        return False
+        """Update the dimmer attributes due to a subscription update event."""
+        if _type == "Brightness":
+            self._brightness = int(_param)
+            return True
+        return super().subscription_update(_type, _param)
 
     def __repr__(self):
         """Return a string representation of the device."""

--- a/tests/ouimeaux_device/test_dimmer.py
+++ b/tests/ouimeaux_device/test_dimmer.py
@@ -22,11 +22,14 @@ class Base:
         assert dimmer.get_state(force_update=True) == 0
 
     def test_subscription_update_brightness(self, dimmer):
-        assert dimmer.subscription_update('Brightness', '23') == True
-        assert dimmer.get_brightness() == 23
+        # Does not update when the light is off.
+        assert dimmer.subscription_update('Brightness', '23') == False
 
         assert dimmer.subscription_update('BinaryState', '1') == True
         assert dimmer.get_state() == 1
+
+        assert dimmer.subscription_update('Brightness', '52') == True
+        assert dimmer.get_brightness() == 52
 
 
 class Test_PVT_OWRT_Dimmer_v1(Base, long_press_helpers.TestLongPress):

--- a/tests/ouimeaux_device/test_dimmer.py
+++ b/tests/ouimeaux_device/test_dimmer.py
@@ -21,6 +21,13 @@ class Base:
         dimmer.off()
         assert dimmer.get_state(force_update=True) == 0
 
+    def test_subscription_update_brightness(self, dimmer):
+        assert dimmer.subscription_update('Brightness', '23') == True
+        assert dimmer.get_brightness() == 23
+
+        assert dimmer.subscription_update('BinaryState', '1') == True
+        assert dimmer.get_state() == 1
+
 
 class Test_PVT_OWRT_Dimmer_v1(Base, long_press_helpers.TestLongPress):
     """Tests for the WeMo Dimmer, hardware version v1."""


### PR DESCRIPTION
## Description:

Update the _state & _brightness cached attributes based on a subscription update.

**Related issue (if applicable):** #67

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] There is no commented out code in this PR.