### PR TITLE
Support multiple subscriptions for the Insight device

### DIFF
--- a/pywemo/subscribe.py
+++ b/pywemo/subscribe.py
@@ -17,6 +17,7 @@ from .util import get_ip_address
 
 # Subscription event types.
 EVENT_TYPE_BINARY_STATE = "BinaryState"
+EVENT_TYPE_INSIGHT_PARAMS = "InsightParams"
 EVENT_TYPE_LONG_PRESS = "LongPress"
 
 LOG = logging.getLogger(__name__)
@@ -79,6 +80,11 @@ def _start_server():
 def _basic_event_subscription_url(device: Device) -> str:
     """Return the basic event subscription URL."""
     return device.basicevent.eventSubURL
+
+
+def _insight_event_subscription_url(device: Device) -> str:
+    """Return the insight event subscription URL."""
+    return device.insight.eventSubURL
 
 
 def _cancel_events(
@@ -266,6 +272,9 @@ class SubscriptionRegistry:
             self._events[device.serialnumber] = {}
             # Basic events
             self._schedule(0, device, _basic_event_subscription_url)
+            # Insight events
+            if hasattr(device, 'insight'):
+                self._schedule(0, device, _insight_event_subscription_url)
             self._event_thread_cond.notify()
 
     def unregister(self, device):
@@ -311,10 +320,6 @@ class SubscriptionRegistry:
             )
         try:
             self._url_resubscribe(device, headers, sid, url_fn)
-            # Insight events
-            # if hasattr(device, 'insight'):
-            #     self._url_resubscribe(
-            #         device, headers, sid, device.insight.eventSubURL)
         except requests.exceptions.RequestException as exc:
             LOG.warning(
                 "Resubscribe error for %s %s (%s), will retry in %ss",

--- a/tests/ouimeaux_device/test_insight.py
+++ b/tests/ouimeaux_device/test_insight.py
@@ -1,13 +1,17 @@
+"""Integration tests for the Insight class."""
+
 import datetime
 import threading
 
 import pytest
 
-from pywemo import Insight, SubscriptionRegistry
+from pywemo import Insight
 from pywemo.subscribe import EVENT_TYPE_BINARY_STATE, EVENT_TYPE_INSIGHT_PARAMS
 
 
 class Test_Insight:
+    """Integration tests for the Insight class."""
+
     @pytest.fixture
     def insight(self, vcr):
         with vcr.use_cassette('WeMo_WW_2.00.11408.PVT-OWRT-Insight.yaml'):

--- a/tests/ouimeaux_device/test_insight.py
+++ b/tests/ouimeaux_device/test_insight.py
@@ -1,0 +1,86 @@
+import datetime
+import threading
+
+import pytest
+
+from pywemo import Insight, SubscriptionRegistry
+from pywemo.subscribe import EVENT_TYPE_BINARY_STATE, EVENT_TYPE_INSIGHT_PARAMS
+
+
+class Test_Insight:
+    @pytest.fixture
+    def insight(self, vcr):
+        with vcr.use_cassette('WeMo_WW_2.00.11408.PVT-OWRT-Insight.yaml'):
+            return Insight('http://192.168.1.100:49153/setup.xml', '')
+
+    @pytest.mark.vcr()
+    def test_turn_on(self, insight):
+        """Turn on the insight switch."""
+        insight.on()
+        assert insight.get_state(force_update=True) == 8
+
+    @pytest.mark.vcr()
+    def test_turn_off(self, insight):
+        """Turn off the insight switch."""
+        insight.off()
+        assert insight.get_state(force_update=True) == 0
+
+    @pytest.mark.vcr()
+    def test_insight_params(self, insight):
+        insight.update_insight_params()
+        assert insight.today_kwh == pytest.approx(0.0194118)
+        assert insight.current_power == 0
+        assert insight.wifi_power == 8
+        assert insight.threshold_power == 8000
+        assert insight.today_on_time == 300
+        assert insight.on_for == 231
+        assert insight.last_change.astimezone(datetime.timezone.utc) == (
+            datetime.datetime(
+                2021, 1, 25, 0, 2, 4, tzinfo=datetime.timezone.utc
+            )
+        )
+        assert insight.today_standby_time == 300
+        assert insight.get_standby_state == 'off'
+
+    @pytest.mark.vcr()
+    def test_subscribe(self, insight, subscription_registry):
+        subscription_registry.register(insight)
+
+        # Wait for registry to be ready to make sure the Insight device has
+        # been registered.
+        ready = threading.Event()
+        subscription_registry._sched.enter(0.1, 0, ready.set)
+        ready.wait()
+
+        # Subscribe to all events.
+        subscription_registry.on(
+            insight, None, lambda a, b, c: insight.subscription_update(b, c)
+        )
+
+        subscription_registry.event(
+            insight,
+            EVENT_TYPE_BINARY_STATE,
+            '1',
+        )
+        assert insight.get_state() == 1
+
+        subscription_registry.event(
+            insight,
+            EVENT_TYPE_INSIGHT_PARAMS,
+            '8|1611105078|2607|0|12416|1209600|328|500|457600|69632638|9500',
+        )
+        assert insight.today_kwh == pytest.approx(0.0076266668)
+        assert insight.current_power == 500
+        assert insight.wifi_power == 328
+        assert insight.threshold_power == 9500
+        assert insight.today_on_time == 0
+        assert insight.on_for == 2607
+        assert insight.last_change.astimezone(datetime.timezone.utc) == (
+            datetime.datetime(
+                2021, 1, 20, 1, 11, 18, tzinfo=datetime.timezone.utc
+            )
+        )
+        assert insight.today_standby_time == 0
+        assert insight.get_standby_state == 'standby'
+
+        subscription_registry.unregister(insight)

--- a/tests/test_subscribe.py
+++ b/tests/test_subscribe.py
@@ -190,6 +190,17 @@ class Test_SubscriptionRegistry:
             'sid': 'uuid:84915076-1dd2-11b2-b5fd-dcf7b6ec9aaa'
         }
 
+        insight = subscription_registry._sched.queue[1]
+        assert insight.time == pytest.approx(time.time() + 225, abs=2)
+        assert insight.action == subscription_registry._resubscribe
+        assert insight.argument == (
+            device,
+            subscribe._insight_event_subscription_url,
+        )
+        assert insight.kwargs == {
+            'sid': 'uuid:849c1a56-1dd2-11b2-b5fd-dcf7b6ec9aaa'
+        }
+
         subscription_registry.unregister(device)
 
         assert len(subscription_registry._sched.queue) == 0

--- a/tests/test_subscribe.py
+++ b/tests/test_subscribe.py
@@ -182,10 +182,13 @@ class Test_SubscriptionRegistry:
         basic = subscription_registry._sched.queue[0]
         assert basic.time == pytest.approx(time.time() + 225, abs=2)
         assert basic.action == subscription_registry._resubscribe
-        assert basic.argument == [
+        assert basic.argument == (
             device,
-            'uuid:84915076-1dd2-11b2-b5fd-dcf7b6ec9aaa',
-        ]
+            subscribe._basic_event_subscription_url,
+        )
+        assert basic.kwargs == {
+            'sid': 'uuid:84915076-1dd2-11b2-b5fd-dcf7b6ec9aaa'
+        }
 
         subscription_registry.unregister(device)
 
@@ -206,7 +209,11 @@ class Test_SubscriptionRegistry:
             time.time() + subscribe.SUBSCRIPTION_RETRY, abs=2
         )
         assert basic.action == subscription_registry._resubscribe
-        assert basic.argument == [device, None, 1]
+        assert basic.argument == (
+            device,
+            subscribe._basic_event_subscription_url,
+        )
+        assert basic.kwargs == {'retry': 1, 'sid': None}
 
         # Simulate a second failure to trigger a reconnect with the device.
         subscription_registry._sched.cancel(basic)
@@ -217,12 +224,12 @@ class Test_SubscriptionRegistry:
 
             reconnect.side_effect = change_url
 
-            basic.action(*basic.argument)
+            basic.action(*basic.argument, **basic.kwargs)
 
             # Fail one more time to see that the correct changed URL is used.
             basic = subscription_registry._sched.queue[-1]
             subscription_registry._sched.cancel(basic)
-            basic.action(*basic.argument)
+            basic.action(*basic.argument, **basic.kwargs)
 
         mock_request.assert_called_with(
             method='SUBSCRIBE',

--- a/tests/vcr/tests.ouimeaux_device.test_insight/Test_Insight.test_insight_params.yaml
+++ b/tests/vcr/tests.ouimeaux_device.test_insight/Test_Insight.test_insight_params.yaml
@@ -1,0 +1,56 @@
+interactions:
+- request:
+    body: '<?xml version="1.0" encoding="utf-8"?>
+
+      <s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/" s:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/">
+
+      <s:Body>
+
+      <u:GetInsightParams xmlns:u="urn:Belkin:service:insight:1">
+
+
+      </u:GetInsightParams>
+
+      </s:Body>
+
+      </s:Envelope>'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '279'
+      Content-Type:
+      - text/xml
+      SOAPACTION:
+      - '"urn:Belkin:service:insight:1#GetInsightParams"'
+      User-Agent:
+      - python-requests/2.25.1
+    method: POST
+    uri: http://192.168.1.100:49153/upnp/control/insight1
+  response:
+    body:
+      string: "<s:Envelope xmlns:s=\"http://schemas.xmlsoap.org/soap/envelope/\" s:encodingStyle=\"\
+        http://schemas.xmlsoap.org/soap/encoding/\"><s:Body>\n<u:GetInsightParamsResponse\
+        \ xmlns:u=\"urn:Belkin:service:metainfo:1\">\r\n<InsightParams>0|1611532924|231|300|183183|1209600|8|0|1164707|99830512.000000|8000</InsightParams>\r\
+        \n</u:GetInsightParamsResponse>\r\n</s:Body> </s:Envelope>"
+    headers:
+      CONTENT-LENGTH:
+      - '358'
+      CONTENT-TYPE:
+      - text/xml; charset="utf-8"
+      DATE:
+      - Mon, 25 Jan 2021 00:02:13 GMT
+      EXT:
+      - ''
+      SERVER:
+      - Unspecified, UPnP/1.0, Unspecified
+      X-User-Agent:
+      - redsonic
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/vcr/tests.ouimeaux_device.test_insight/Test_Insight.test_subscribe.yaml
+++ b/tests/vcr/tests.ouimeaux_device.test_insight/Test_Insight.test_subscribe.yaml
@@ -1,0 +1,82 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CALLBACK:
+      - <http://192.168.100.1:8989/basicevent1>
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      NT:
+      - upnp:event
+      TIMEOUT:
+      - '300'
+      User-Agent:
+      - python-requests/2.25.1
+    method: SUBSCRIBE
+    uri: http://192.168.1.100:49153/upnp/event/basicevent1
+  response:
+    body:
+      string: ''
+    headers:
+      CONTENT-LENGTH:
+      - '0'
+      DATE:
+      - Mon, 25 Jan 2021 00:22:58 GMT
+      SERVER:
+      - Unspecified, UPnP/1.0, Unspecified
+      SID:
+      - uuid:7a5218fe-1dd2-11b2-849c-b527ba18a01e
+      TIMEOUT:
+      - Second-1801
+      X-User-Agent:
+      - redsonic
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CALLBACK:
+      - <http://192.168.100.1:8989/insight1>
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      NT:
+      - upnp:event
+      TIMEOUT:
+      - '300'
+      User-Agent:
+      - python-requests/2.25.1
+    method: SUBSCRIBE
+    uri: http://192.168.1.100:49153/upnp/event/insight1
+  response:
+    body:
+      string: ''
+    headers:
+      CONTENT-LENGTH:
+      - '0'
+      DATE:
+      - Mon, 25 Jan 2021 00:22:59 GMT
+      SERVER:
+      - Unspecified, UPnP/1.0, Unspecified
+      SID:
+      - uuid:7a59e192-1dd2-11b2-849c-b527ba18a01e
+      TIMEOUT:
+      - Second-1801
+      X-User-Agent:
+      - redsonic
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/vcr/tests.ouimeaux_device.test_insight/Test_Insight.test_turn_off.yaml
+++ b/tests/vcr/tests.ouimeaux_device.test_insight/Test_Insight.test_turn_off.yaml
@@ -1,0 +1,166 @@
+interactions:
+- request:
+    body: '<?xml version="1.0" encoding="utf-8"?>
+
+      <s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/" s:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/">
+
+      <s:Body>
+
+      <u:SetBinaryState xmlns:u="urn:Belkin:service:basicevent:1">
+
+      <BinaryState>0</BinaryState>
+
+      </u:SetBinaryState>
+
+      </s:Body>
+
+      </s:Envelope>'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '306'
+      Content-Type:
+      - text/xml
+      SOAPACTION:
+      - '"urn:Belkin:service:basicevent:1#SetBinaryState"'
+      User-Agent:
+      - python-requests/2.25.1
+    method: POST
+    uri: http://192.168.1.100:49153/upnp/control/basicevent1
+  response:
+    body:
+      string: "<s:Envelope xmlns:s=\"http://schemas.xmlsoap.org/soap/envelope/\" s:encodingStyle=\"\
+        http://schemas.xmlsoap.org/soap/encoding/\"><s:Body>\n<u:SetBinaryStateResponse\
+        \ xmlns:u=\"urn:Belkin:service:basicevent:1\">\r\n<BinaryState>0|1611532923|231|300|183183|1209600|8|1170|1164707|99830512</BinaryState>\r\
+        \n<CountdownEndTime>0</CountdownEndTime>\r\n<deviceCurrentTime>1611532923</deviceCurrentTime>\r\
+        \n</u:SetBinaryStateResponse>\r\n</s:Body> </s:Envelope>"
+    headers:
+      CONTENT-LENGTH:
+      - '434'
+      CONTENT-TYPE:
+      - text/xml; charset="utf-8"
+      DATE:
+      - Mon, 25 Jan 2021 00:02:03 GMT
+      EXT:
+      - ''
+      SERVER:
+      - Unspecified, UPnP/1.0, Unspecified
+      X-User-Agent:
+      - redsonic
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '<?xml version="1.0" encoding="utf-8"?>
+
+      <s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/" s:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/">
+
+      <s:Body>
+
+      <u:GetInsightParams xmlns:u="urn:Belkin:service:insight:1">
+
+
+      </u:GetInsightParams>
+
+      </s:Body>
+
+      </s:Envelope>'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '279'
+      Content-Type:
+      - text/xml
+      SOAPACTION:
+      - '"urn:Belkin:service:insight:1#GetInsightParams"'
+      User-Agent:
+      - python-requests/2.25.1
+    method: POST
+    uri: http://192.168.1.100:49153/upnp/control/insight1
+  response:
+    body:
+      string: "<s:Envelope xmlns:s=\"http://schemas.xmlsoap.org/soap/envelope/\" s:encodingStyle=\"\
+        http://schemas.xmlsoap.org/soap/encoding/\"><s:Body>\n<u:GetInsightParamsResponse\
+        \ xmlns:u=\"urn:Belkin:service:metainfo:1\">\r\n<InsightParams>0|1611532923|231|300|183183|1209600|8|1170|1164707|99830512.000000|8000</InsightParams>\r\
+        \n</u:GetInsightParamsResponse>\r\n</s:Body> </s:Envelope>"
+    headers:
+      CONTENT-LENGTH:
+      - '361'
+      CONTENT-TYPE:
+      - text/xml; charset="utf-8"
+      DATE:
+      - Mon, 25 Jan 2021 00:02:03 GMT
+      EXT:
+      - ''
+      SERVER:
+      - Unspecified, UPnP/1.0, Unspecified
+      X-User-Agent:
+      - redsonic
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '<?xml version="1.0" encoding="utf-8"?>
+
+      <s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/" s:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/">
+
+      <s:Body>
+
+      <u:GetBinaryState xmlns:u="urn:Belkin:service:basicevent:1">
+
+
+      </u:GetBinaryState>
+
+      </s:Body>
+
+      </s:Envelope>'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '278'
+      Content-Type:
+      - text/xml
+      SOAPACTION:
+      - '"urn:Belkin:service:basicevent:1#GetBinaryState"'
+      User-Agent:
+      - python-requests/2.25.1
+    method: POST
+    uri: http://192.168.1.100:49153/upnp/control/basicevent1
+  response:
+    body:
+      string: "<s:Envelope xmlns:s=\"http://schemas.xmlsoap.org/soap/envelope/\" s:encodingStyle=\"\
+        http://schemas.xmlsoap.org/soap/encoding/\"><s:Body>\n<u:GetBinaryStateResponse\
+        \ xmlns:u=\"urn:Belkin:service:basicevent:1\">\r\n<BinaryState>0</BinaryState>\r\
+        \n</u:GetBinaryStateResponse>\r\n</s:Body> </s:Envelope>"
+    headers:
+      CONTENT-LENGTH:
+      - '285'
+      CONTENT-TYPE:
+      - text/xml; charset="utf-8"
+      DATE:
+      - Mon, 25 Jan 2021 00:02:03 GMT
+      EXT:
+      - ''
+      SERVER:
+      - Unspecified, UPnP/1.0, Unspecified
+      X-User-Agent:
+      - redsonic
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/vcr/tests.ouimeaux_device.test_insight/Test_Insight.test_turn_on.yaml
+++ b/tests/vcr/tests.ouimeaux_device.test_insight/Test_Insight.test_turn_on.yaml
@@ -1,0 +1,166 @@
+interactions:
+- request:
+    body: '<?xml version="1.0" encoding="utf-8"?>
+
+      <s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/" s:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/">
+
+      <s:Body>
+
+      <u:SetBinaryState xmlns:u="urn:Belkin:service:basicevent:1">
+
+      <BinaryState>1</BinaryState>
+
+      </u:SetBinaryState>
+
+      </s:Body>
+
+      </s:Envelope>'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '306'
+      Content-Type:
+      - text/xml
+      SOAPACTION:
+      - '"urn:Belkin:service:basicevent:1#SetBinaryState"'
+      User-Agent:
+      - python-requests/2.25.1
+    method: POST
+    uri: http://192.168.1.100:49153/upnp/control/basicevent1
+  response:
+    body:
+      string: "<s:Envelope xmlns:s=\"http://schemas.xmlsoap.org/soap/envelope/\" s:encodingStyle=\"\
+        http://schemas.xmlsoap.org/soap/encoding/\"><s:Body>\n<u:SetBinaryStateResponse\
+        \ xmlns:u=\"urn:Belkin:service:basicevent:1\">\r\n<BinaryState>8|1611530424|231|300|183183|1209600|8|1190|1164707|99830512</BinaryState>\r\
+        \n<CountdownEndTime>0</CountdownEndTime>\r\n<deviceCurrentTime>1611532922</deviceCurrentTime>\r\
+        \n</u:SetBinaryStateResponse>\r\n</s:Body> </s:Envelope>"
+    headers:
+      CONTENT-LENGTH:
+      - '434'
+      CONTENT-TYPE:
+      - text/xml; charset="utf-8"
+      DATE:
+      - Mon, 25 Jan 2021 00:02:02 GMT
+      EXT:
+      - ''
+      SERVER:
+      - Unspecified, UPnP/1.0, Unspecified
+      X-User-Agent:
+      - redsonic
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '<?xml version="1.0" encoding="utf-8"?>
+
+      <s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/" s:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/">
+
+      <s:Body>
+
+      <u:GetInsightParams xmlns:u="urn:Belkin:service:insight:1">
+
+
+      </u:GetInsightParams>
+
+      </s:Body>
+
+      </s:Envelope>'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '279'
+      Content-Type:
+      - text/xml
+      SOAPACTION:
+      - '"urn:Belkin:service:insight:1#GetInsightParams"'
+      User-Agent:
+      - python-requests/2.25.1
+    method: POST
+    uri: http://192.168.1.100:49153/upnp/control/insight1
+  response:
+    body:
+      string: "<s:Envelope xmlns:s=\"http://schemas.xmlsoap.org/soap/envelope/\" s:encodingStyle=\"\
+        http://schemas.xmlsoap.org/soap/encoding/\"><s:Body>\n<u:GetInsightParamsResponse\
+        \ xmlns:u=\"urn:Belkin:service:metainfo:1\">\r\n<InsightParams>8|1611530424|231|300|183183|1209600|8|1190|1164707|99830512.000000|8000</InsightParams>\r\
+        \n</u:GetInsightParamsResponse>\r\n</s:Body> </s:Envelope>"
+    headers:
+      CONTENT-LENGTH:
+      - '361'
+      CONTENT-TYPE:
+      - text/xml; charset="utf-8"
+      DATE:
+      - Mon, 25 Jan 2021 00:02:02 GMT
+      EXT:
+      - ''
+      SERVER:
+      - Unspecified, UPnP/1.0, Unspecified
+      X-User-Agent:
+      - redsonic
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '<?xml version="1.0" encoding="utf-8"?>
+
+      <s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/" s:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/">
+
+      <s:Body>
+
+      <u:GetBinaryState xmlns:u="urn:Belkin:service:basicevent:1">
+
+
+      </u:GetBinaryState>
+
+      </s:Body>
+
+      </s:Envelope>'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '278'
+      Content-Type:
+      - text/xml
+      SOAPACTION:
+      - '"urn:Belkin:service:basicevent:1#GetBinaryState"'
+      User-Agent:
+      - python-requests/2.25.1
+    method: POST
+    uri: http://192.168.1.100:49153/upnp/control/basicevent1
+  response:
+    body:
+      string: "<s:Envelope xmlns:s=\"http://schemas.xmlsoap.org/soap/envelope/\" s:encodingStyle=\"\
+        http://schemas.xmlsoap.org/soap/encoding/\"><s:Body>\n<u:GetBinaryStateResponse\
+        \ xmlns:u=\"urn:Belkin:service:basicevent:1\">\r\n<BinaryState>8</BinaryState>\r\
+        \n</u:GetBinaryStateResponse>\r\n</s:Body> </s:Envelope>"
+    headers:
+      CONTENT-LENGTH:
+      - '285'
+      CONTENT-TYPE:
+      - text/xml; charset="utf-8"
+      DATE:
+      - Mon, 25 Jan 2021 00:02:02 GMT
+      EXT:
+      - ''
+      SERVER:
+      - Unspecified, UPnP/1.0, Unspecified
+      X-User-Agent:
+      - redsonic
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/vcr/tests.ouimeaux_device.test_insight/WeMo_WW_2.00.11408.PVT-OWRT-Insight.yaml
+++ b/tests/vcr/tests.ouimeaux_device.test_insight/WeMo_WW_2.00.11408.PVT-OWRT-Insight.yaml
@@ -1,0 +1,1288 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.25.1
+    method: GET
+    uri: http://192.168.1.100:49153/setup.xml
+  response:
+    body:
+      string: "<?xml version=\"1.0\"?>\n<root xmlns=\"urn:Belkin:device-1-0\">\n \
+        \ <specVersion>\n    <major>1</major>\n    <minor>0</minor>\n  </specVersion>\n\
+        \  <device>\n<deviceType>urn:Belkin:device:insight:1</deviceType>\n<friendlyName>WeMo\
+        \ Device</friendlyName>\n    <manufacturer>Belkin International Inc.</manufacturer>\n\
+        \    <manufacturerURL>http://www.belkin.com</manufacturerURL>\n    <modelDescription>Belkin\
+        \ Insight 1.0</modelDescription>\n    <modelName>Insight</modelName>\n   \
+        \ <modelNumber>1.0</modelNumber>\n    <modelURL>http://www.belkin.com/plugin/</modelURL>\n\
+        <serialNumber>SERIALNUMBER</serialNumber>\n<UDN>uuid:Insight-1_0-SERIALNUMBER</UDN>\n\
+        \    <UPC>123456789</UPC>\n<macAddress>001122334455</macAddress>\n<firmwareVersion>WeMo_WW_2.00.11408.PVT-OWRT-Insight</firmwareVersion>\n\
+        <iconVersion>1|49153</iconVersion>\n<binaryState>0</binaryState>\n    <new_algo>1</new_algo>\n\
+        \    <iconList> \n      <icon> \n        <mimetype>jpg</mimetype> \n     \
+        \   <width>100</width> \n        <height>100</height> \n        <depth>100</depth>\
+        \ \n         <url>icon.jpg</url> \n      </icon> \n    </iconList>\n    <serviceList>\n\
+        \      <service>\n        <serviceType>urn:Belkin:service:WiFiSetup:1</serviceType>\n\
+        \        <serviceId>urn:Belkin:serviceId:WiFiSetup1</serviceId>\n        <controlURL>/upnp/control/WiFiSetup1</controlURL>\n\
+        \        <eventSubURL>/upnp/event/WiFiSetup1</eventSubURL>\n        <SCPDURL>/setupservice.xml</SCPDURL>\n\
+        \      </service>\n      <service>\n        <serviceType>urn:Belkin:service:timesync:1</serviceType>\n\
+        \        <serviceId>urn:Belkin:serviceId:timesync1</serviceId>\n        <controlURL>/upnp/control/timesync1</controlURL>\n\
+        \        <eventSubURL>/upnp/event/timesync1</eventSubURL>\n        <SCPDURL>/timesyncservice.xml</SCPDURL>\n\
+        \      </service>\n      <service>\n        <serviceType>urn:Belkin:service:basicevent:1</serviceType>\n\
+        \        <serviceId>urn:Belkin:serviceId:basicevent1</serviceId>\n       \
+        \ <controlURL>/upnp/control/basicevent1</controlURL>\n        <eventSubURL>/upnp/event/basicevent1</eventSubURL>\n\
+        \        <SCPDURL>/eventservice.xml</SCPDURL>\n      </service>\n      <service>\n\
+        \        <serviceType>urn:Belkin:service:firmwareupdate:1</serviceType>\n\
+        \        <serviceId>urn:Belkin:serviceId:firmwareupdate1</serviceId>\n   \
+        \     <controlURL>/upnp/control/firmwareupdate1</controlURL>\n        <eventSubURL>/upnp/event/firmwareupdate1</eventSubURL>\n\
+        \        <SCPDURL>/firmwareupdate.xml</SCPDURL>\n      </service>\n      <service>\n\
+        \        <serviceType>urn:Belkin:service:rules:1</serviceType>\n        <serviceId>urn:Belkin:serviceId:rules1</serviceId>\n\
+        \        <controlURL>/upnp/control/rules1</controlURL>\n        <eventSubURL>/upnp/event/rules1</eventSubURL>\n\
+        \        <SCPDURL>/rulesservice.xml</SCPDURL>\n      </service>\n\t  \n  \
+        \    <service>\n        <serviceType>urn:Belkin:service:metainfo:1</serviceType>\n\
+        \        <serviceId>urn:Belkin:serviceId:metainfo1</serviceId>\n        <controlURL>/upnp/control/metainfo1</controlURL>\n\
+        \        <eventSubURL>/upnp/event/metainfo1</eventSubURL>\n        <SCPDURL>/metainfoservice.xml</SCPDURL>\n\
+        \      </service>\n\n      <service>\n        <serviceType>urn:Belkin:service:remoteaccess:1</serviceType>\n\
+        \        <serviceId>urn:Belkin:serviceId:remoteaccess1</serviceId>\n     \
+        \   <controlURL>/upnp/control/remoteaccess1</controlURL>\n        <eventSubURL>/upnp/event/remoteaccess1</eventSubURL>\n\
+        \        <SCPDURL>/remoteaccess.xml</SCPDURL>\n      </service>\n\t   \n \
+        \     <service>\n        <serviceType>urn:Belkin:service:deviceinfo:1</serviceType>\n\
+        \        <serviceId>urn:Belkin:serviceId:deviceinfo1</serviceId>\n       \
+        \ <controlURL>/upnp/control/deviceinfo1</controlURL>\n        <eventSubURL>/upnp/event/deviceinfo1</eventSubURL>\n\
+        \        <SCPDURL>/deviceinfoservice.xml</SCPDURL>\n      </service>\n\n \
+        \     <service>\n        <serviceType>urn:Belkin:service:insight:1</serviceType>\n\
+        \        <serviceId>urn:Belkin:serviceId:insight1</serviceId>\n        <controlURL>/upnp/control/insight1</controlURL>\n\
+        \        <eventSubURL>/upnp/event/insight1</eventSubURL>\n        <SCPDURL>/insightservice.xml</SCPDURL>\n\
+        \      </service>\n\n      <service>\n        <serviceType>urn:Belkin:service:smartsetup:1</serviceType>\n\
+        \        <serviceId>urn:Belkin:serviceId:smartsetup1</serviceId>\n       \
+        \ <controlURL>/upnp/control/smartsetup1</controlURL>\n        <eventSubURL>/upnp/event/smartsetup1</eventSubURL>\n\
+        \        <SCPDURL>/smartsetup.xml</SCPDURL>\n      </service>\n      \n  \
+        \    <service>\n        <serviceType>urn:Belkin:service:manufacture:1</serviceType>\n\
+        \        <serviceId>urn:Belkin:serviceId:manufacture1</serviceId>\n      \
+        \  <controlURL>/upnp/control/manufacture1</controlURL>\n        <eventSubURL>/upnp/event/manufacture1</eventSubURL>\n\
+        \        <SCPDURL>/manufacture.xml</SCPDURL>\n      </service>\n\n    </serviceList>\n\
+        \   <presentationURL>/pluginpres.html</presentationURL>\n</device>\n</root>\n"
+    headers:
+      CONNECTION:
+      - close
+      CONTENT-LENGTH:
+      - '4785'
+      CONTENT-TYPE:
+      - text/xml
+      DATE:
+      - Mon, 25 Jan 2021 00:02:00 GMT
+      LAST-MODIFIED:
+      - Sat, 01 Jan 2000 00:01:07 GMT
+      SERVER:
+      - Unspecified, UPnP/1.0, Unspecified
+      X-User-Agent:
+      - redsonic
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.25.1
+    method: GET
+    uri: http://192.168.1.100:49153/setupservice.xml
+  response:
+    body:
+      string: "<?xml version=\"1.0\"?>\n<scpd xmlns=\"urn:Belkin:service-1-0\">\n\n\
+        \  <specVersion>\n    <major>1</major>\n    <minor>0</minor>\n  </specVersion>\n\
+        \  \n<actionList>\n    <action>\n        <name>GetApList</name>\n        <argumentList>\n\
+        \         <argument>\n         <retval />\n         <name>ApList</name>\n\
+        \         <relatedStateVariable>ApList</relatedStateVariable>\n         <direction>out</direction>\n\
+        \         </argument>\n         </argumentList>\n    </action>\n    \n   \
+        \ <action>\n        <name>GetNetworkList</name>\n        <argumentList>\n\
+        \         <argument>\n         <retval />\n         <name>NetworkList</name>\n\
+        \         <relatedStateVariable>NetworkList</relatedStateVariable>\n     \
+        \    <direction>out</direction>\n         </argument>\n         </argumentList>\n\
+        \    </action>\n    \n    <action>\n      <name>ConnectHomeNetwork</name>\
+        \    \n      <argumentList>\n\n         <argument>\n           <name>ssid</name>\n\
+        \           <relatedStateVariable>ssid</relatedStateVariable>\n          \
+        \ <direction>in</direction>\n          </argument>\n          \n         \
+        \ <argument>\n        <name>auth</name>\n        <relatedStateVariable>auth</relatedStateVariable>\n\
+        \        <direction>in</direction>\n        </argument>\n\n       <argument>\n\
+        \             <name>password</name>\n             <relatedStateVariable>password</relatedStateVariable>\n\
+        \             <direction>in</direction>\n       </argument>\n\n       <argument>\n\
+        \             <name>encrypt</name>\n             <relatedStateVariable>encrypt</relatedStateVariable>\n\
+        \             <direction>in</direction>\n       </argument>\n\n       <argument>\n\
+        \             <name>channel</name>\n             <relatedStateVariable>channel</relatedStateVariable>\n\
+        \             <direction>in</direction>\n       </argument>\n       \n   \
+        \   </argumentList>\n          \n    </action>\n    \n        <action>\n \
+        \         <name>GetNetworkStatus</name>    \n          <argumentList>\n  \
+        \           <argument>\n               <retval />\n               <name>NetworkStatus</name>\n\
+        \               <relatedStateVariable>NetworkStatus</relatedStateVariable>\n\
+        \               <direction>out</direction>\n              </argument>\n  \
+        \        </argumentList>\n    </action>\n\n    <action>\n          <name>CloseSetup</name>\
+        \    \n          <argumentList>\n          </argumentList>\n    </action>\n\
+        \t\n\t<action>\n          <name>StopPair</name>    \n          <argumentList>\n\
+        \          </argumentList>\n    </action>\n    \n</actionList>\n\n  <serviceStateTable>\n\
+        \  \n  <!-- connected, connecting, disconnected, time out error -->\n  <stateVariable\
+        \ sendEvents=\"yes\">\n      <name>NetworkStatus</name>\n      <dataType>string</dataType>\n\
+        \      <defaultValue>Disconnected</defaultValue>\n    </stateVariable>\n \
+        \ <stateVariable sendEvents=\"yes\">\t\n\t<name>PairingStatus</name>\n   \
+        \   <dataType>string</dataType>\n      <defaultValue>Connecting</defaultValue>\n\
+        \    </stateVariable>\n    \n    <stateVariable sendEvents=\"yes\">\n    \
+        \  <name>ApList</name>\n      <dataType>string</dataType>\n      <defaultValue></defaultValue>\n\
+        \    </stateVariable>\n\t\n    <stateVariable sendEvents=\"yes\">\n      <name>NetworkList</name>\n\
+        \      <dataType>string</dataType>\n      <defaultValue></defaultValue>\n\
+        \    </stateVariable>\n    <stateVariable sendEvents=\"yes\">\n      <name>ssid</name>\n\
+        \      <dataType>string</dataType>\n      <defaultValue></defaultValue>\n\
+        \    </stateVariable>\n\n    <stateVariable sendEvents=\"yes\">\n      <name>auth</name>\n\
+        \      <dataType>string</dataType>\n      <defaultValue></defaultValue>\n\
+        \    </stateVariable>\n\n    <stateVariable sendEvents=\"yes\">\n      <name>password</name>\n\
+        \      <dataType>string</dataType>\n      <defaultValue></defaultValue>\n\
+        \    </stateVariable>\n\n    <stateVariable sendEvents=\"yes\">\n      <name>encrypt</name>\n\
+        \      <dataType>string</dataType>\n      <defaultValue></defaultValue>\n\
+        \    </stateVariable>\n\n    <stateVariable sendEvents=\"yes\">\n      <name>channel</name>\n\
+        \      <dataType>string</dataType>\n      <defaultValue></defaultValue>\n\
+        \    </stateVariable>\n\n    <stateVariable sendEvents=\"yes\">\n      <name>ssid</name>\n\
+        \      <dataType>string</dataType>\n      <defaultValue></defaultValue>\n\
+        \    </stateVariable>\n\t\n  </serviceStateTable>\n  \n  </scpd>\n"
+    headers:
+      CONNECTION:
+      - close
+      CONTENT-LENGTH:
+      - '4091'
+      CONTENT-TYPE:
+      - text/xml
+      DATE:
+      - Mon, 25 Jan 2021 00:02:01 GMT
+      LAST-MODIFIED:
+      - Sat, 01 Jan 2000 00:00:33 GMT
+      SERVER:
+      - Unspecified, UPnP/1.0, Unspecified
+      X-User-Agent:
+      - redsonic
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.25.1
+    method: GET
+    uri: http://192.168.1.100:49153/timesyncservice.xml
+  response:
+    body:
+      string: "\uFEFF<?xml version=\"1.0\"?>\n<scpd xmlns=\"urn:Belkin:service-1-0\"\
+        >\n  <specVersion>\n    <major>1</major>\n    <minor>0</minor>\n  </specVersion>\n\
+        \  \n  <actionList>  \n    <action>    \n      <name>TimeSync</name>    \n\
+        \      <argumentList>\n         <argument>\n\t\t   <!-- UTC value, long -->\n\
+        \           <name>UTC</name>\n           <relatedStateVariable>UTC</relatedStateVariable>\n\
+        \           <direction>in</direction>\n          </argument>\n         <argument>\n\
+        \           <name>TimeZone</name>\n           <relatedStateVariable>TimeZone</relatedStateVariable>\n\
+        \           <direction>in</direction>\n          </argument>\n         <argument>\n\
+        \           <name>dst</name>\n           <relatedStateVariable>dst</relatedStateVariable>\n\
+        \           <direction>in</direction>\n          </argument>\n\t\t  <argument>\n\
+        \           <name>DstSupported</name>\n           <relatedStateVariable>DstSupported</relatedStateVariable>\n\
+        \           <direction>in</direction>\n          </argument>\n      </argumentList>\
+        \      \n    </action>\n\t\n    <action>\n      <name>GetTime</name> \n  \
+        \  </action>\n    \n</actionList>\n\n  <serviceStateTable>\n    \n       \
+        \ <stateVariable sendEvents=\"no\">\n        <!-- UTC seconds-->\n      <name>UTC</name>\n\
+        \      <dataType>long</dataType>\n      <defaultValue>0</defaultValue>\n \
+        \   </stateVariable>\n    \n    \n    <stateVariable sendEvents=\"no\">\n\
+        \      <name>TimeZone</name>\n      <dataType>int</dataType>\n      <defaultValue>0</defaultValue>\n\
+        \    </stateVariable>\n\t\n\t<stateVariable sendEvents=\"no\">\n      <name>dst</name>\n\
+        \      <dataType>Boolean</dataType>\n      <defaultValue>0</defaultValue>\n\
+        \    </stateVariable>\n    \n  </serviceStateTable>\n  \n  </scpd>"
+    headers:
+      CONNECTION:
+      - close
+      CONTENT-LENGTH:
+      - '1630'
+      CONTENT-TYPE:
+      - text/xml
+      DATE:
+      - Mon, 25 Jan 2021 00:02:01 GMT
+      LAST-MODIFIED:
+      - Sat, 01 Jan 2000 00:00:33 GMT
+      SERVER:
+      - Unspecified, UPnP/1.0, Unspecified
+      X-User-Agent:
+      - redsonic
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.25.1
+    method: GET
+    uri: http://192.168.1.100:49153/eventservice.xml
+  response:
+    body:
+      string: "<?xml version=\"1.0\"?>\r\n<scpd xmlns=\"urn:Belkin:service-1-0\">\r\
+        \n\r\n  <specVersion>\r\n    <major>1</major>\r\n    <minor>0</minor>\r\n\
+        \  </specVersion>\r\n  \r\n  <actionList>\r\n  \r\n    <action>\r\n      <name>SetBinaryState</name>\r\
+        \n      <argumentList>\r\n         <argument>\r\n           <retval />\r\n\
+        \           <name>BinaryState</name>\r\n           <relatedStateVariable>BinaryState</relatedStateVariable>\r\
+        \n           <direction>in</direction>\r\n          </argument>\r\n\t<argument>\r\
+        \n           <retval />\r\n           <name>Duration</name>\r\n          \
+        \ <relatedStateVariable>Duration</relatedStateVariable>\r\n           <direction>in</direction>\r\
+        \n          </argument>\r\n         <argument>\r\n           <retval />\r\n\
+        \           <name>EndAction</name>\r\n           <relatedStateVariable>EndAction</relatedStateVariable>\r\
+        \n           <direction>in</direction>\r\n          </argument>\r\n      \
+        \   <argument>\r\n           <retval />\r\n           <name>UDN</name>\r\n\
+        \           <relatedStateVariable>UDN</relatedStateVariable>\r\n         \
+        \  <direction>in</direction>\r\n          </argument>\r\n         <argument>\r\
+        \n           <retval />\r\n           <name>CountdownEndTime</name>\r\n  \
+        \         <relatedStateVariable>CountdownEndTime</relatedStateVariable>\r\n\
+        \           <direction>out</direction>\r\n          </argument>\r\n      \
+        \   <argument>\r\n           <retval />\r\n           <name>deviceCurrentTime</name>\r\
+        \n           <relatedStateVariable>deviceCurrentTime</relatedStateVariable>\r\
+        \n           <direction>out</direction>\r\n          </argument>\r\n     \
+        \ </argumentList>\r\n    </action>\r\n\r\n<action>\r\n  <name>UpdateInsightHomeSettings</name>\r\
+        \n  <argumentList>\r\n     <argument>\r\n       <retval />\r\n       <name>EnergyPerUnitCost</name>\r\
+        \n       <relatedStateVariable>EnergyPerUnitCost</relatedStateVariable>\r\n\
+        \       <direction>in</direction>\r\n     </argument>\r\n     <argument>\r\
+        \n       <retval />\r\n       <name>Currency</name>\r\n       <relatedStateVariable>Currency</relatedStateVariable>\r\
+        \n       <direction>in</direction>\r\n     </argument>\r\n     <argument>\r\
+        \n       <retval />\r\n       <name>EnergyPerUnitCostVersion</name>\r\n  \
+        \     <relatedStateVariable>EnergyPerUnitCostVersion</relatedStateVariable>\r\
+        \n       <direction>in</direction>\r\n     </argument>\r\n  </argumentList>\r\
+        \n</action>\r\n\r\n<action>\r\n  <name>SetInsightHomeSettings</name>\r\n \
+        \ <argumentList>\r\n     <argument>\r\n       <retval />\r\n       <name>EnergyPerUnitCost</name>\r\
+        \n       <relatedStateVariable>EnergyPerUnitCost</relatedStateVariable>\r\n\
+        \       <direction>in</direction>\r\n     </argument>\r\n     <argument>\r\
+        \n       <retval />\r\n       <name>Currency</name>\r\n       <relatedStateVariable>Currency</relatedStateVariable>\r\
+        \n       <direction>in</direction>\r\n     </argument>\r\n  </argumentList>\r\
+        \n</action>\r\n\r\n<action>\r\n  <name>GetInsightHomeSettings</name>\r\n \
+        \ <argumentList>\r\n     <argument>\r\n       <retval />\r\n       <name>HomeSettingsVersion</name>\r\
+        \n       <relatedStateVariable>HomeSettingsVersion</relatedStateVariable>\r\
+        \n       <direction>out</direction>\r\n     </argument>\r\n     <argument>\r\
+        \n       <retval />\r\n       <name>EnergyPerUnitCost</name>\r\n       <relatedStateVariable>EnergyPerUnitCost</relatedStateVariable>\r\
+        \n       <direction>out</direction>\r\n     </argument>\r\n     <argument>\r\
+        \n       <retval />\r\n       <name>Currency</name>\r\n       <relatedStateVariable>Currency</relatedStateVariable>\r\
+        \n       <direction>out</direction>\r\n     </argument>\r\n  </argumentList>\r\
+        \n</action>\r\n\r\n    <action>\r\n      <name>SetLogLevelOption</name>\r\n\
+        \      <argumentList>\r\n         <argument>\r\n           <retval />\r\n\
+        \           <name>Level</name>\r\n           <relatedStateVariable>Level</relatedStateVariable>\r\
+        \n           <direction>in</direction>\r\n          </argument>\r\n      \
+        \   <argument>\r\n           <retval />\r\n           <name>Option</name>\r\
+        \n           <relatedStateVariable>Option</relatedStateVariable>\r\n     \
+        \      <direction>in</direction>\r\n          </argument>\r\n      </argumentList>\r\
+        \n    </action>\r\n\r\n    <action>\r\n      <name>GetFriendlyName</name>\r\
+        \n  \t  <argumentList>\r\n      <argument>\r\n      <retval />\r\n      <name>FriendlyName</name>\r\
+        \n      <relatedStateVariable>FriendlyName</relatedStateVariable>\r\n    \
+        \  <direction>in</direction>\r\n       </argument>\r\n       </argumentList>\r\
+        \n    </action>\r\n    <action>\r\n      <name>ReSetup</name>\r\n      <argumentList>\r\
+        \n         <argument>\r\n           <retval />\r\n           <name>Reset</name>\r\
+        \n           <relatedStateVariable>Reset</relatedStateVariable>\r\n      \
+        \     <direction>in</direction>\r\n          </argument>\r\n      </argumentList>\r\
+        \n    </action>\r\n\t<action>\r\n      <name>SetHomeId</name>\r\n      <argumentList>\r\
+        \n         <argument>\r\n           <retval />\r\n           <name>HomeId</name>\r\
+        \n           <relatedStateVariable>HomeId</relatedStateVariable>\r\n     \
+        \      <direction>in</direction>\r\n          </argument>\r\n      </argumentList>\r\
+        \n    </action>\r\n\t<action>\r\n      <name>GetHomeId</name>\r\n    </action>\r\
+        \n    <action>\r\n      <name>GetHomeInfo</name>\r\n      <argumentList>\r\
+        \n \t<retval />\r\n           <name>GetHomeInfo</name>\r\n           <relatedStateVariable>HomeInfo</relatedStateVariable>\r\
+        \n           <direction>out</direction>\r\n      </argumentList>\r\n    </action>\r\
+        \n\t<action>\r\n      <name>SetDeviceId</name>\r\n      <argumentList>\r\n\
+        \         <argument>\r\n           <retval />\r\n           <name>SetDeviceId</name>\r\
+        \n           <relatedStateVariable>DeviceId</relatedStateVariable>\r\n   \
+        \        <direction>in</direction>\r\n          </argument>\r\n      </argumentList>\r\
+        \n    </action>\r\n    <action>\r\n      <name>GetDeviceId</name>\r\n    </action>\r\
+        \n\t <action>\r\n      <name>GetMacAddr</name>\r\n    </action>\r\n    <action>\r\
+        \n      <name>GetSerialNo</name>\r\n    </action>\r\n    <action>\r\n    \
+        \  <name>GetPluginUDN</name>\r\n    </action>\r\n    <action>\r\n      <name>GetSmartDevInfo</name>\r\
+        \n    </action>\r\n    <action>\r\n      <name>ShareHWInfo</name>\r\n    \
+        \  <argumentList>\r\n         <argument>\r\n           <retval />\r\n    \
+        \       <name>Mac</name>\r\n           <relatedStateVariable>Mac</relatedStateVariable>\r\
+        \n           <direction>in</direction>\r\n          </argument>\r\n      \
+        \   <argument>\r\n           <retval />\r\n           <name>Serial</name>\r\
+        \n           <relatedStateVariable>Serial</relatedStateVariable>\r\n     \
+        \      <direction>in</direction>\r\n          </argument>\r\n         <argument>\r\
+        \n           <retval />\r\n           <name>Udn</name>\r\n           <relatedStateVariable>Udn</relatedStateVariable>\r\
+        \n           <direction>in</direction>\r\n          </argument>\r\n      \
+        \   <argument>\r\n           <retval />\r\n           <name>RestoreState</name>\r\
+        \n           <relatedStateVariable>RestoreState</relatedStateVariable>\r\n\
+        \           <direction>in</direction>\r\n          </argument>\r\n       \
+        \  <argument>\r\n           <retval />\r\n           <name>HomeId</name>\r\
+        \n           <relatedStateVariable>HomeId</relatedStateVariable>\r\n     \
+        \      <direction>in</direction>\r\n          </argument>\r\n         <argument>\r\
+        \n           <retval />\r\n           <name>PluginKey</name>\r\n         \
+        \  <relatedStateVariable>PluginKey</relatedStateVariable>\r\n           <direction>in</direction>\r\
+        \n          </argument>\r\n      </argumentList>\r\n    </action>\r\n    <action>\r\
+        \n      <name>ChangeFriendlyName</name>\r\n      <argumentList>\r\n      \
+        \   <argument>\r\n           <retval />\r\n           <name>FriendlyName</name>\r\
+        \n           <relatedStateVariable>FriendlyName</relatedStateVariable>\r\n\
+        \           <direction>in</direction>\r\n          </argument>\r\n      </argumentList>\r\
+        \n    </action>\r\n\t\r\n    <action>\r\n      <name>SetSmartDevInfo</name>\r\
+        \n      <argumentList>\r\n         <argument>\r\n           <retval />\r\n\
+        \           <name>SmartDevURL</name>\r\n           <relatedStateVariable>SmartDevURL</relatedStateVariable>\r\
+        \n           <direction>in</direction>\r\n          </argument>\r\n      </argumentList>\r\
+        \n    </action>\r\n\t<action>\r\n      <name>GetRuleOverrideStatus</name>\r\
+        \n      <argumentList>\r\n         <argument>\r\n           <retval />\r\n\
+        \           <name>RuleOverrideStatus</name>\r\n           <relatedStateVariable>RuleOverrideStatus</relatedStateVariable>\r\
+        \n           <direction>in</direction>\r\n          </argument>\r\n      </argumentList>\r\
+        \n    </action>\r\n\r\n\t<action>\r\n      <name>GetDeviceIcon</name>\r\n\
+        \      <argumentList>\r\n         <argument>\r\n           <retval />\r\n\
+        \           <name>DeviceIcon</name>\r\n           <relatedStateVariable>DeviceIcon</relatedStateVariable>\r\
+        \n           <direction>in</direction>\r\n          </argument>\r\n      </argumentList>\r\
+        \n    </action>\r\n\r\n\t<action>\r\n      <name>GetIconURL</name>\r\n   \
+        \   <argumentList>\r\n      <argument>\r\n      <retval />\r\n\t<name>URL</name>\r\
+        \n\t<relatedStateVariable>URL</relatedStateVariable>\r\n\t<direction>out</direction>\r\
+        \n\t</argument>\r\n      </argumentList>\r\n    </action>\r\n\t\r\n\t<action>\r\
+        \n      <name>GetLogFileURL</name>\r\n      <argumentList>\r\n      <argument>\r\
+        \n      <retval />\r\n\t<name>LOGURL</name>\r\n\t<relatedStateVariable>LOGURL</relatedStateVariable>\r\
+        \n\t<direction>out</direction>\r\n\t</argument>\r\n      </argumentList>\r\
+        \n    </action>\r\n\r\n\t<action>\r\n      <name>ChangeDeviceIcon</name>\r\
+        \n      <argumentList>\r\n         <argument>\r\n           <retval />\r\n\
+        \           <name>PictureSize</name>\r\n           <relatedStateVariable>PictureSize</relatedStateVariable>\r\
+        \n           <direction>in</direction>\r\n          </argument>\r\n\t\t  <argument>\r\
+        \n           <retval />\r\n           <name>PictureHeight</name>\r\n     \
+        \      <relatedStateVariable>PictureWidth</relatedStateVariable>\r\n     \
+        \      <direction>in</direction>\r\n          </argument>\r\n\t\t  \r\n\t\t\
+        \  <argument>\r\n           <retval />\r\n           <name>PictureColorDeep</name>\r\
+        \n           <relatedStateVariable>PictureColorDeep</relatedStateVariable>\r\
+        \n           <direction>in</direction>\r\n          </argument>\r\n      </argumentList>\r\
+        \n    </action>\r\n  \r\n    <action>\r\n    <name>GetBinaryState</name>\r\
+        \n    <argumentList>\r\n    <argument>\r\n    <retval />\r\n    <name>BinaryState</name>\r\
+        \n    <relatedStateVariable>BinaryState</relatedStateVariable>\r\n    <direction>out</direction>\r\
+        \n    </argument>\r\n    </argumentList>\r\n    </action>\r\n\t\r\n\t<action>\r\
+        \n      <name>SetMultiState</name>\r\n      <argumentList>\r\n         <argument>\r\
+        \n           <retval />\r\n           <name>state</name>\r\n           <relatedStateVariable>StateList</relatedStateVariable>\r\
+        \n           <direction>in</direction>\r\n          </argument>\r\n\r\n\t\t\
+        \  <argument>\r\n           <retval />\r\n           <name>state</name>\r\n\
+        \           <relatedStateVariable>StateList</relatedStateVariable>\r\n   \
+        \        <direction>in</direction>\r\n          </argument>\t\t  \r\n\t\r\n\
+        \         <argument>\r\n           <retval />\r\n           <name>state</name>\r\
+        \n           <relatedStateVariable>StateList</relatedStateVariable>\r\n  \
+        \         <direction>in</direction>\r\n          </argument>\r\n\t\t  \r\n\
+        \      </argumentList>\r\n    </action>\r\n\t\r\n\t<action>\r\n          <name>SetCrockpotState</name>\r\
+        \n          <argumentList>\r\n              <argument>\r\n               \
+        \   <retval />\r\n                  <name>mode</name>\r\n                \
+        \  <relatedStateVariable>mode</relatedStateVariable>\r\n                 \
+        \ <direction>in</direction>\r\n              </argument>\r\n             \
+        \ <argument>\r\n                  <retval />\r\n                  <name>time</name>\r\
+        \n                  <relatedStateVariable>timeVariable</relatedStateVariable>\r\
+        \n                  <direction>in</direction>\r\n              </argument>\r\
+        \n          </argumentList>\r\n      </action>\r\n\r\n    <action>\r\n   \
+        \       <name>GetCrockpotState</name>\r\n          <argumentList>\r\n    \
+        \          <argument>\r\n                  <retval />\r\n                \
+        \  <name>mode</name>\r\n                  <relatedStateVariable>mode</relatedStateVariable>\r\
+        \n                  <direction>out</direction>\r\n              </argument>\r\
+        \n              <argument>\r\n                  <retval />\r\n           \
+        \       <name>time</name>\r\n                  <relatedStateVariable>timeVariable</relatedStateVariable>\r\
+        \n                  <direction>out</direction>\r\n              </argument>\r\
+        \n          </argumentList>\r\n      </action>\r\n\t\r\n    <action>\r\n \
+        \     <name>GetWatchdogFile</name>\r\n      <argumentList>\r\n        <argument>\r\
+        \n          <retval />\r\n            <name>WDFile</name>\r\n            <relatedStateVariable>WDFile</relatedStateVariable>\r\
+        \n            <direction>out</direction>\r\n        </argument>\r\n      </argumentList>\r\
+        \n    </action>\r\n\r\n    <action>\r\n      <name>GetSignalStrength</name>\r\
+        \n      <argumentList>\r\n        <argument>\r\n          <retval />\r\n \
+        \           <name>SignalStrength</name>\r\n            <relatedStateVariable>SignalStrength</relatedStateVariable>\r\
+        \n            <direction>in</direction>\r\n        </argument>\r\n      </argumentList>\r\
+        \n    </action>\r\n\r\n    <action>\r\n      <name>SetServerEnvironment</name>\r\
+        \n      <argumentList>\r\n        <argument>\r\n          <retval />\r\n \
+        \           <name>ServerEnvironment</name>\r\n            <relatedStateVariable>ServerEnvironment</relatedStateVariable>\r\
+        \n            <direction>in</direction>\r\n        </argument>\r\n       \
+        \ <argument>\r\n          <retval />\r\n            <name>TurnServerEnvironment</name>\r\
+        \n            <relatedStateVariable>TurnServerEnvironment</relatedStateVariable>\r\
+        \n            <direction>in</direction>\r\n        </argument>\r\n\t<argument>\r\
+        \n          <retval />\r\n            <name>ServerEnvironmentType</name>\r\
+        \n            <relatedStateVariable>ServerEnvironmentType</relatedStateVariable>\r\
+        \n            <direction>in</direction>\r\n        </argument>\r\n      </argumentList>\r\
+        \n    </action>\r\n\r\n    <action>\r\n      <name>GetServerEnvironment</name>\r\
+        \n      <argumentList>\r\n        <argument>\r\n          <retval />\r\n \
+        \           <name>ServerEnvironment</name>\r\n            <relatedStateVariable>ServerEnvironment</relatedStateVariable>\r\
+        \n            <direction>out</direction>\r\n        </argument>\r\n      \
+        \  <argument>\r\n          <retval />\r\n            <name>TurnServerEnvironment</name>\r\
+        \n            <relatedStateVariable>TurnServerEnvironment</relatedStateVariable>\r\
+        \n            <direction>out</direction>\r\n        </argument>\r\n      \
+        \  <argument>\r\n          <retval />\r\n            <name>ServerEnvironmentType</name>\r\
+        \n            <relatedStateVariable>ServerEnvironmentType</relatedStateVariable>\r\
+        \n            <direction>out</direction>\r\n        </argument>\r\n      </argumentList>\r\
+        \n    </action>\r\n\r\n    <action>\r\n\t<name>GetIconVersion</name>\r\n\t\
+        <argumentList>\r\n\t    <argument>\r\n\t\t<retval />\r\n\t\t<name>IconVersion</name>\r\
+        \n\t\t<relatedStateVariable>IconVersion</relatedStateVariable>\r\n\t\t<direction>out</direction>\r\
+        \n\t    </argument>\r\n\t</argumentList>\r\n    </action>\r\n    <action>\r\
+        \n    <name>GetSimulatedRuleData</name>\r\n    <argumentList>\r\n    <retval\
+        \ />\r\n    <name>GetSimulatedRuleData</name>\r\n    <relatedStateVariable>RuleData</relatedStateVariable>\r\
+        \n    <direction>out</direction>\r\n    </argumentList>\r\n    </action>\r\
+        \n    <action>\r\n    <name>NotifyManualToggle</name>\r\n    <argumentList>\r\
+        \n    <retval />\r\n    <name>NotifyManualToggle</name>\r\n    <relatedStateVariable>ManualToggle</relatedStateVariable>\r\
+        \n    <direction>out</direction>\r\n    </argumentList>\r\n    </action>\r\
+        \n     <action>\r\n      <name>ControlCloudUpload</name>\r\n      <argumentList>\r\
+        \n        <argument>\r\n          <name>EnableUpload</name>\r\n          <direction>in</direction>\r\
+        \n          <relatedStateVariable>EnableUpload</relatedStateVariable>\r\n\
+        \        </argument>\r\n      </argumentList>\r\n    </action>\r\n</actionList>\r\
+        \n\r\n  <serviceStateTable>\r\n \r\n    <stateVariable sendEvents=\"yes\"\
+        >\r\n      <name>HomeSettingsVersion</name>\r\n      <dataType>String</dataType>\r\
+        \n      <defaultValue>0</defaultValue>\r\n    </stateVariable>\r\n    <stateVariable\
+        \ sendEvents=\"yes\">\r\n      <name>EnergyPerUnitCost</name>\r\n      <dataType>String</dataType>\r\
+        \n      <defaultValue>0</defaultValue>\r\n    </stateVariable>\r\n    <stateVariable\
+        \ sendEvents=\"yes\">\r\n      <name>Currency</name>\r\n      <dataType>String</dataType>\r\
+        \n      <defaultValue>0</defaultValue>\r\n    </stateVariable>\r\n \r\n  \
+        \  <stateVariable sendEvents=\"yes\">\r\n      <name>BinaryState</name>\r\n\
+        \      <dataType>string</dataType>\r\n      <defaultValue>0</defaultValue>\r\
+        \n    </stateVariable>\r\n\t\r\n     <stateVariable sendEvents=\"no\">\r\n\
+        \      <name>Duration</name>\r\n      <dataType>string</dataType>\r\n    \
+        \  <defaultValue>0</defaultValue>\r\n    </stateVariable>\r\n\r\n    <stateVariable\
+        \ sendEvents=\"no\">\r\n      <name>EndAction</name>\r\n      <dataType>string</dataType>\r\
+        \n      <defaultValue>0</defaultValue>\r\n    </stateVariable>\r\n\r\n   \
+        \ <stateVariable sendEvents=\"no\">\r\n      <name>UDN</name>\r\n      <dataType>string</dataType>\r\
+        \n      <defaultValue>0</defaultValue>\r\n    </stateVariable>\r\n\r\n\t<stateVariable\
+        \ sendEvents=\"yes\">\r\n      <name>mode</name>\r\n      <dataType>string</dataType>\r\
+        \n      <defaultValue>0</defaultValue>\r\n    </stateVariable>\r\n    \r\n\
+        \    <stateVariable sendEvents=\"yes\">\r\n      <name>time</name>\r\n   \
+        \   <dataType>string</dataType>\r\n      <defaultValue>0</defaultValue>\r\n\
+        \    </stateVariable>\r\n\t\r\n    <stateVariable sendEvents=\"yes\">\r\n\
+        \      <name>level</name>\r\n      <dataType>string</dataType>\r\n      <defaultValue>0</defaultValue>\r\
+        \n    </stateVariable>\r\n\r\n    <stateVariable sendEvents=\"yes\">\r\n \
+        \     <name>option</name>\r\n      <dataType>string</dataType>\r\n      <defaultValue>0</defaultValue>\r\
+        \n    </stateVariable>\r\n\r\n\t<stateVariable sendEvents=\"yes\">\r\n   \
+        \   <name>Reset</name>\r\n      <dataType>string</dataType>\r\n      <defaultValue>0</defaultValue>\r\
+        \n\r\n    </stateVariable>\r\n\t<stateVariable sendEvents=\"yes\">\r\n   \
+        \   <name>FriendlyName</name>\r\n      <dataType>string</dataType>\r\n   \
+        \   <defaultValue>0</defaultValue>\r\n    </stateVariable>\r\n\t\r\n\t<stateVariable\
+        \ sendEvents=\"yes\">\r\n      <name>HomeId</name>\r\n      <dataType>string</dataType>\r\
+        \n      <defaultValue>0</defaultValue>\r\n    </stateVariable>\r\n\t<stateVariable\
+        \ sendEvents=\"yes\">\r\n      <name>DeviceId</name>\r\n      <dataType>string</dataType>\r\
+        \n      <defaultValue>0</defaultValue>\r\n    </stateVariable>\r\n\t<stateVariable\
+        \ sendEvents=\"yes\">\r\n      <name>SmartDevInfo</name>\r\n      <dataType>string</dataType>\r\
+        \n      <defaultValue>0</defaultValue>\r\n    </stateVariable>\r\n\t<stateVariable\
+        \ sendEvents=\"yes\">\r\n      <name>MacAddr</name>\r\n      <dataType>string</dataType>\r\
+        \n      <defaultValue>0</defaultValue>\r\n    </stateVariable>\r\n\t<stateVariable\
+        \ sendEvents=\"yes\">\r\n      <name>SerialNo</name>\r\n      <dataType>string</dataType>\r\
+        \n      <defaultValue>0</defaultValue>\r\n    </stateVariable>\r\n\r\n\t<stateVariable\
+        \ sendEvents=\"yes\">\r\n      <name>PluginUDN</name>\r\n      <dataType>string</dataType>\r\
+        \n      <defaultValue>0</defaultValue>\r\n    </stateVariable>\r\n\t<stateVariable\
+        \ sendEvents=\"yes\">\r\n      <name>DeviceIcon</name>\r\n      <dataType>string</dataType>\r\
+        \n      <defaultValue>0</defaultValue>\r\n    </stateVariable>\r\n  \r\n \
+        \   <stateVariable sendEvents=\"No\">\r\n      <name>StateList</name>\r\n\
+        \      <dataType>list</dataType>\r\n      <defaultValue>0</defaultValue>\r\
+        \n    </stateVariable>\r\n  <stateVariable sendEvents=\"yes\">\r\n      <name>URL</name>\r\
+        \n\t  <dataType>string</dataType>\r\n\t  <defaultValue>0</defaultValue>\r\n\
+        \  </stateVariable>\r\n\t\t\t\t\t\t\r\n\t<stateVariable sendEvents=\"yes\"\
+        >\r\n      <name>RuleOverrideStatus</name>\r\n\t  <dataType>string</dataType>\r\
+        \n\t  <defaultValue>0</defaultValue>\r\n  </stateVariable>\r\n\t\t\t\t\t\t\
+        \r\n    <stateVariable sendEvents=\"yes\">\r\n      <name>WDFile</name>\r\n\
+        \      <dataType>string</dataType>\r\n      <defaultValue>0</defaultValue>\r\
+        \n    </stateVariable>\r\n\r\n    <stateVariable sendEvents=\"yes\">\r\n \
+        \     <name>SignalStrength</name>\r\n      <dataType>string</dataType>\r\n\
+        \      <defaultValue>0</defaultValue>\r\n    </stateVariable>\r\n\r\n    <stateVariable\
+        \ sendEvents=\"yes\">\r\n      <name>ServerEnvironment</name>\r\n      <dataType>string</dataType>\r\
+        \n      <defaultValue>0</defaultValue>\r\n    </stateVariable>\r\n\r\n   \
+        \ <stateVariable sendEvents=\"yes\">\r\n      <name>TurnServerEnvironment</name>\r\
+        \n      <dataType>string</dataType>\r\n      <defaultValue>0</defaultValue>\r\
+        \n    </stateVariable>\r\n\r\n  <stateVariable sendEvents=\"yes\">\r\n   \
+        \   <name>ServerEnvironmentType</name>\r\n      <dataType>string</dataType>\r\
+        \n      <defaultValue>0</defaultValue>\r\n    </stateVariable>\r\n\r\n   \
+        \ <stateVariable sendEvents=\"yes\">\r\n      <name>IconVersion</name>\r\n\
+        \      <dataType>string</dataType>\r\n      <defaultValue>0</defaultValue>\r\
+        \n    </stateVariable>\r\n\r\n    <stateVariable sendEvents=\"yes\">\r\n \
+        \     <name>RuleData</name>\r\n      <dataType>string</dataType>\r\n     \
+        \ <defaultValue>0</defaultValue>\r\n    </stateVariable>\r\n    <stateVariable\
+        \ sendEvents=\"yes\">\r\n      <name>ManualToggle</name>\r\n      <dataType>string</dataType>\r\
+        \n      <defaultValue>0</defaultValue>\r\n    </stateVariable>\r\n     <stateVariable\
+        \ sendEvents=\"yes\">\r\n      <name>EnableUpload</name>\r\n      <dataType>string</dataType>\r\
+        \n      <defaultValue>0</defaultValue>\r\n    </stateVariable>\r\n\r\n   \
+        \ <stateVariable sendEvents=\"yes\">\r\n      <name>CountdownEndTime</name>\r\
+        \n      <dataType>string</dataType>\r\n      <defaultValue>0</defaultValue>\r\
+        \n    </stateVariable>\r\n\r\n    <stateVariable sendEvents=\"yes\">\r\n \
+        \     <name>deviceCurrentTime</name>\r\n      <dataType>string</dataType>\r\
+        \n      <defaultValue>0</defaultValue>\r\n    </stateVariable>\r\n\r\n\r\n\
+        \  </serviceStateTable>\r\n  \r\n  </scpd>\r\n"
+    headers:
+      CONNECTION:
+      - close
+      CONTENT-LENGTH:
+      - '20836'
+      CONTENT-TYPE:
+      - text/xml
+      DATE:
+      - Mon, 25 Jan 2021 00:02:01 GMT
+      LAST-MODIFIED:
+      - Sat, 01 Jan 2000 00:00:32 GMT
+      SERVER:
+      - Unspecified, UPnP/1.0, Unspecified
+      X-User-Agent:
+      - redsonic
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.25.1
+    method: GET
+    uri: http://192.168.1.100:49153/firmwareupdate.xml
+  response:
+    body:
+      string: "<?xml version=\"1.0\" ?> \n<scpd xmlns=\"urn:Belkin:service-1-0\">\n\
+        <specVersion>\n<major>1</major> \n<minor>0</minor> \n</specVersion>\n<actionList>\n\
+        <action>\n<name>UpdateFirmware</name> \n<argumentList>\n<argument>\n<name>NewFirmwareVersion</name>\
+        \ \n<relatedStateVariable>NewFirmwareVersion</relatedStateVariable> \n<direction>in</direction>\
+        \ \n</argument>\n<argument>\n<name>ReleaseDate</name> \n<relatedStateVariable>ReleaseDate</relatedStateVariable>\
+        \ \n<direction>in</direction> \n</argument>\n<argument>\n<name>URL</name>\
+        \ \n<relatedStateVariable>URL</relatedStateVariable> \n<direction>in</direction>\
+        \ \n</argument>\n<argument>\n<name>Signature</name> \n<relatedStateVariable>Signature</relatedStateVariable>\
+        \ \n<direction>in</direction> \n</argument>\n<argument>\n<name>DownloadStartTime</name>\n\
+        <relatedStateVariable>DownloadStartTime</relatedStateVariable>\n<direction>in</direction>\n\
+        </argument>\n<argument>\n<name>WithUnsignedImage</name>\n<relatedStateVariable>WithUnsignedImage</relatedStateVariable>\n\
+        <direction>in</direction>\n</argument>\n</argumentList>\n</action>\n<action>\n\
+        <name>GetFirmwareVersion</name>\n<argumentList>\n<argument>\n<retval />\n\
+        <name>FirmwareVersion</name> \n<relatedStateVariable>FirmwareVersion</relatedStateVariable>\
+        \ \n<direction>out</direction> \n</argument>\n</argumentList>\n</action>\n\
+        </actionList>\n<serviceStateTable>\n<stateVariable sendEvents=\"yes\">\n<name>FirmwareVersion</name>\n\
+        <dataType>string</dataType>\n<defaultValue>0</defaultValue>\n</stateVariable>\n\
+        <stateVariable sendEvents=\"yes\">\n<name>FirmwareUpdateStatus</name>\n<dataType>string</dataType>\n\
+        <defaultValue>0</defaultValue>\n</stateVariable>\n<stateVariable sendEvents=\"\
+        no\">\n<name>WithUnsignedImage</name>\n<dataType>string</dataType>\n<defaultValue>0</defaultValue>\n\
+        </stateVariable>\n</serviceStateTable>\n</scpd>\n"
+    headers:
+      CONNECTION:
+      - close
+      CONTENT-LENGTH:
+      - '1754'
+      CONTENT-TYPE:
+      - text/xml
+      DATE:
+      - Mon, 25 Jan 2021 00:02:01 GMT
+      LAST-MODIFIED:
+      - Sat, 01 Jan 2000 00:00:32 GMT
+      SERVER:
+      - Unspecified, UPnP/1.0, Unspecified
+      X-User-Agent:
+      - redsonic
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.25.1
+    method: GET
+    uri: http://192.168.1.100:49153/rulesservice.xml
+  response:
+    body:
+      string: "\uFEFF<?xml version=\"1.0\"?>\n<scpd xmlns=\"urn:Belkin:service-1-0\"\
+        >\n\n  <specVersion>\n    <major>1</major>\n    <minor>0</minor>\n  </specVersion>\n\
+        \  \n<actionList>\n    <action>\n          <name>UpdateWeeklyCalendar</name>\
+        \   \n\t\t  <argumentList>\n\t        <argument>\n<!-- entire day's timers\
+        \ list: \nNumberOfTimers|time,action,[deviceUDN;deviceUDN;...]|time,action,[deviceUDN;deviceUDN...]|time,action\
+        \ \n -->\t\t\t\t\n<!--time, seconds from 00:00 am within 24 hours. action:\
+        \ 0x00 (OFF/NO detection), 0x01: (ON/Detection)--> \n<!--PLEASE note that,\
+        \ for simpler timer stored on socket, deviceUDN is NULL-->\n             \
+        \   <name>Mon</name>\n                <relatedStateVariable>Mon</relatedStateVariable>\n\
+        \                <direction>in</direction>\n            </argument>\n\t  \
+        \      <argument>\n                <name>Tues</name>\n                <relatedStateVariable>Tues</relatedStateVariable>\n\
+        \                <direction>in</direction>\n            </argument>\n\t  \
+        \      <argument>\n                <name>Wed</name>\n                <relatedStateVariable>Wed</relatedStateVariable>\n\
+        \                <direction>in</direction>\n            </argument>\n\t  \
+        \      <argument>\n                <name>Thurs</name>\n                <relatedStateVariable>Thurs</relatedStateVariable>\n\
+        \                <direction>in</direction>\n            </argument>\n\t  \
+        \      <argument>\n                <name>Fri</name>\n                <relatedStateVariable>Fri</relatedStateVariable>\n\
+        \                <direction>in</direction>\n            </argument>\n\t  \
+        \      <argument>\n                <name>Sat</name>\n                <relatedStateVariable>Sat</relatedStateVariable>\n\
+        \                <direction>in</direction>\n            </argument>\n\t  \
+        \      <argument>\n                <name>Sun</name>\n                <relatedStateVariable>Sun</relatedStateVariable>\n\
+        \                <direction>in</direction>\n            </argument>\n\n  \
+        \        </argumentList>\n    </action>\n\n    <action>\n          <name>EditWeeklycalendar</name>\
+        \    \n          <argumentList>\n           <argument>\n<!-- 0x00: disbale;\
+        \ 0x01: enable; 0x02: remove-->\n<!--- Disable will disable entire week schedule,\
+        \ now only remove will be applied \nsince app will manage all rules and store\
+        \ on device on other way \n-->\n                <name>action</name>\n    \
+        \            <relatedStateVariable>action</relatedStateVariable>\n       \
+        \         <direction>in</direction>\n          </argument>\n          </argumentList>\n\
+        \    </action>\n\n    \n    <!--Should create detailed low level protocol-->\n\
+        \    <action>\n          <name>GetRulesDBPath</name>    \n          <argumentList>\n\
+        \t  <argument>\n           <retval />\n           <name>RulesDBPath</name>\n\
+        \           <relatedStateVariable>RulesDBPath</relatedStateVariable>\n   \
+        \        <direction>out</direction>\n          </argument>\n          </argumentList>\n\
+        \    </action>\n\n<action>\n <name>SetRulesDBVersion</name>    \n        \
+        \  <argumentList>\n\t  <argument>\n           <name>RulesDBVersion</name>\n\
+        \           <relatedStateVariable>RulesDBVersion</relatedStateVariable>\n\
+        \           <direction>in</direction>\n          </argument>\n          </argumentList>\n\
+        \    </action>\n\n<action>\n\t  <name>GetRulesDBVersion</name>    \n\t  <argumentList>\n\
+        \t  <argument>\n           <retval />\n           <name>RulesDBVersion</name>\n\
+        \           <relatedStateVariable>RulesDBVersion</relatedStateVariable>\n\
+        \           <direction>out</direction>\n          </argument>\n          </argumentList>\n\
+        \    </action>\n<action>\n  <name>SetRuleID</name>\n  <argumentList>\n   \
+        \  <argument>\n       <name>RuleID</name>\n       <relatedStateVariable>RuleID</relatedStateVariable>\n\
+        \       <direction>in</direction>\n      </argument>\n     <argument>\n  \
+        \     <name>RuleMsg</name>\n       <relatedStateVariable>RuleMsg</relatedStateVariable>\n\
+        \       <direction>in</direction>\n      </argument>\n     <argument>\n  \
+        \     <name>RuleFreq</name>\n       <relatedStateVariable>RuleFreq</relatedStateVariable>\n\
+        \       <direction>in</direction>\n      </argument>\n  </argumentList>\n\
+        </action>\n\n<action>\n  <name>DeleteRuleID</name>\n  <argumentList>\n   \
+        \  <argument>\n       <name>RuleID</name>\n       <relatedStateVariable>RuleID</relatedStateVariable>\n\
+        \       <direction>in</direction>\n      </argument>\n  </argumentList>\n\
+        </action>\n\t\n<action>\n  <name>SimulatedRuleData</name>\n  <argumentList>\n\
+        \     <argument>\n       <name>DeviceList</name>\n       <relatedStateVariable>DeviceList</relatedStateVariable>\n\
+        \       <direction>in</direction>\n      </argument>\n     <argument>\n  \
+        \     <name>DeviceCount</name>\n       <relatedStateVariable>DeviceCount</relatedStateVariable>\n\
+        \       <direction>in</direction>\n      </argument>\n  </argumentList>\n\
+        </action>\n\n<!-- ** BEGIN ** Optimize Rules API: XML Schema -->\n<action>\n\
+        \  <name>FetchRules</name>\n  <argumentList>\n     <argument>\n       <retval></retval>\n\
+        \       <name>ruleDbPath</name>\n       <relatedStateVariable>ruleDbPath</relatedStateVariable>\n\
+        \       <direction>out</direction>\n     </argument>\n     <argument>\n  \
+        \     <retval></retval>\n       <name>ruleDbVersion</name>\n       <relatedStateVariable>ruleDbVersion</relatedStateVariable>\n\
+        \       <direction>out</direction>\n     </argument>\n     <argument>\n  \
+        \     <retval></retval>\n       <name>errorInfo</name>\n       <relatedStateVariable>errorInfo</relatedStateVariable>\n\
+        \       <direction>out</direction>\n     </argument>\n  </argumentList>\t\
+        \ \n</action>\n\n<action>\n  <name>StoreRules</name>\n  <argumentList>\n \
+        \    <argument>\n       <name>ruleDbVersion</name>\n       <relatedStateVariable>ruleDbVersion</relatedStateVariable>\n\
+        \       <direction>in</direction>\n     </argument>\n     <argument>\n   \
+        \    <name>processDb</name>\n       <relatedStateVariable>processDb</relatedStateVariable>\n\
+        \       <direction>in</direction>\n     </argument>\n     <argument>\n   \
+        \    <name>ruleDbBody</name>\n       <relatedStateVariable>ruleDbBody</relatedStateVariable>\n\
+        \       <direction>in</direction>\n     </argument>\n     <argument>\n\t \
+        \  <retval></retval>\n       <name>errorInfo</name>\n       <relatedStateVariable>errorInfo</relatedStateVariable>\n\
+        \       <direction>out</direction>\n     </argument>\n  </argumentList>\t\
+        \ \n</action>\n<!-- ** END ** Optimize Rules API: XML Schema -->\n</actionList>\n\
+        \n  <serviceStateTable>\n  \n  <!-- connected, connecting, disconnected, time\
+        \ out error -->\n  <stateVariable sendEvents=\"no\">\n      <name>RulesDBPath</name>\n\
+        \      <dataType>string</dataType>\n      <defaultValue>/rules.db</defaultValue>\n\
+        \    </stateVariable>\n\t\n\t  <stateVariable sendEvents=\"no\">\n      <name>RulesDBVersion</name>\n\
+        \      <dataType>string</dataType>\n      <defaultValue></defaultValue>\n\
+        \    </stateVariable>\n\t\n  <stateVariable sendEvents=\"no\">\t\n\t<name>Mon</name>\n\
+        \      <dataType>string</dataType>\n      <defaultValue></defaultValue>\n\
+        \    </stateVariable>\n    \n  <stateVariable sendEvents=\"no\">\t\n\t<name>Tues</name>\n\
+        \      <dataType>string</dataType>\n      <defaultValue></defaultValue>\n\
+        \    </stateVariable>\n    \n    <stateVariable sendEvents=\"no\">\n     \
+        \ <name>Wed</name>\n      <dataType>string</dataType>\n      <defaultValue></defaultValue>\n\
+        \    </stateVariable>\n\t\n\t<stateVariable sendEvents=\"no\">\n      <name>Thurs</name>\n\
+        \      <dataType>Thurs</dataType>\n      <defaultValue></defaultValue>\n \
+        \   </stateVariable>\n\t\n\t<stateVariable sendEvents=\"no\">\n      <name>Fri</name>\n\
+        \      <dataType>Fri</dataType>\n      <defaultValue></defaultValue>\n   \
+        \ </stateVariable>\t\n\n\t<stateVariable sendEvents=\"no\">\n      <name>Sat</name>\n\
+        \      <dataType>Sat</dataType>\n      <defaultValue></defaultValue>\n   \
+        \ </stateVariable>\n\t\n\t<stateVariable sendEvents=\"no\">\n      <name>Sun</name>\n\
+        \      <dataType>Sun</dataType>\n      <defaultValue></defaultValue>\n   \
+        \ </stateVariable>\n    <stateVariable sendEvents=\"yes\">\n      <name>RuleID</name>\n\
+        \      <dataType>string</dataType>\n      <defaultValue>0</defaultValue>\n\
+        \    </stateVariable>\n    <stateVariable sendEvents=\"yes\">\n      <name>RuleMsg</name>\n\
+        \      <dataType>string</dataType>\n      <defaultValue>0</defaultValue>\n\
+        \    </stateVariable>\n    <stateVariable sendEvents=\"yes\">\n      <name>RuleFreq</name>\n\
+        \      <dataType>string</dataType>\n      <defaultValue>0</defaultValue>\n\
+        \    </stateVariable>\n    <stateVariable sendEvents=\"yes\">\n      <name>DeviceList</name>\n\
+        \      <dataType>string</dataType>\n      <defaultValue>0</defaultValue>\n\
+        \    </stateVariable>\n    <stateVariable sendEvents=\"yes\">\n      <name>DeviceCount</name>\n\
+        \      <dataType>string</dataType>\n      <defaultValue>0</defaultValue>\n\
+        \    </stateVariable>\n\t\n\t<!-- ** BEGIN ** Optimize Rules API -->\n   \
+        \ <stateVariable sendEvents=\"no\">\n      <name>ruleDbPath</name>\n     \
+        \ <dataType>string</dataType>\n      <defaultValue>0</defaultValue>\n    </stateVariable>\n\
+        \n    <stateVariable sendEvents=\"no\">\n      <name>ruleDbVersion</name>\n\
+        \      <dataType>string</dataType>\n      <defaultValue>0</defaultValue>\n\
+        \    </stateVariable>\n    <stateVariable sendEvents=\"no\">\n      <name>processDb</name>\n\
+        \      <dataType>string</dataType>\n      <defaultValue>0</defaultValue>\n\
+        \    </stateVariable>\n    <stateVariable sendEvents=\"no\">\n      <name>ruleDbBody</name>\n\
+        \      <dataType>string</dataType>\n      <defaultValue>0</defaultValue>\n\
+        \    </stateVariable>\n    <stateVariable sendEvents=\"no\">\n      <name>errorInfo</name>\n\
+        \      <dataType>string</dataType>\n      <defaultValue>0</defaultValue>\n\
+        \    </stateVariable>\n\t<!-- ** END ** Optimize Rules API -->\n\t\n\t</serviceStateTable>\n\
+        \  \n  </scpd>\n"
+    headers:
+      CONNECTION:
+      - close
+      CONTENT-LENGTH:
+      - '9256'
+      CONTENT-TYPE:
+      - text/xml
+      DATE:
+      - Mon, 25 Jan 2021 00:02:01 GMT
+      LAST-MODIFIED:
+      - Sat, 01 Jan 2000 00:00:33 GMT
+      SERVER:
+      - Unspecified, UPnP/1.0, Unspecified
+      X-User-Agent:
+      - redsonic
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.25.1
+    method: GET
+    uri: http://192.168.1.100:49153/metainfoservice.xml
+  response:
+    body:
+      string: "\uFEFF<?xml version=\"1.0\"?>\n<scpd xmlns=\"urn:Belkin:service-1-0\"\
+        >\n\n  <specVersion>\n    <major>1</major>\n    <minor>0</minor>\n  </specVersion>\n\
+        \  \n  <actionList>\n  \n    <action>\n      <name>GetMetaInfo</name>\n  \
+        \    <argumentList>\n      <argument>\n \t<retval />\n           <name>MetaInfo</name>\n\
+        \           <relatedStateVariable>MetaInfo</relatedStateVariable>\n      \
+        \     <direction>out</direction>\n      </argument>\n      </argumentList>\n\
+        \    </action>\n    <action>\n      <name>GetExtMetaInfo</name>\n      <argumentList>\n\
+        \      <argument>\n \t<retval />\n           <name>ExtMetaInfo</name>\n  \
+        \         <relatedStateVariable>ExtMetaInfo</relatedStateVariable>\n     \
+        \      <direction>out</direction>\n      </argument>\n      </argumentList>\n\
+        \    </action>\n</actionList>\n\n  <serviceStateTable>\n  \n    <stateVariable\
+        \ sendEvents=\"no\">\n      <name>ExtMetaInfo</name>\n      <dataType>String</dataType>\n\
+        \      <defaultValue>0</defaultValue>\n    </stateVariable>\n    <stateVariable\
+        \ sendEvents=\"yes\">\n      <name>MetaInfo</name>\n      <dataType>string</dataType>\n\
+        \      <defaultValue>0</defaultValue>\n    </stateVariable>\n\n  </serviceStateTable>\n\
+        \  \n  </scpd>\n"
+    headers:
+      CONNECTION:
+      - close
+      CONTENT-LENGTH:
+      - '1132'
+      CONTENT-TYPE:
+      - text/xml
+      DATE:
+      - Mon, 25 Jan 2021 00:02:01 GMT
+      LAST-MODIFIED:
+      - Sat, 01 Jan 2000 00:00:32 GMT
+      SERVER:
+      - Unspecified, UPnP/1.0, Unspecified
+      X-User-Agent:
+      - redsonic
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.25.1
+    method: GET
+    uri: http://192.168.1.100:49153/remoteaccess.xml
+  response:
+    body:
+      string: "<?xml version=\"1.0\"?>\n<scpd xmlns=\"urn:Belkin:service-1-0\">\n\
+        \  <specVersion>\n    <major>1</major>\n    <minor>0</minor>\n  </specVersion>\n\
+        \  \n  <actionList>  \n    <action>\n      <name>RemoteAccess</name>\n   \
+        \   <argumentList>\n         <argument>\n           <name>DeviceId</name>\n\
+        \           <relatedStateVariable>DeviceId</relatedStateVariable>\n      \
+        \     <direction>in</direction>\n          </argument>\n\t\t  <argument>\n\
+        \           <name>dst</name>\n           <relatedStateVariable>dst</relatedStateVariable>\n\
+        \           <direction>in</direction>\n          </argument>\n\t  <argument>\n\
+        \           <name>HomeId</name>\n           <relatedStateVariable>HomeId</relatedStateVariable>\n\
+        \           <direction>in</direction>\n          </argument>\n\t  <argument>\n\
+        \           <name>DeviceName</name>\n           <relatedStateVariable>DeviceName</relatedStateVariable>\n\
+        \           <direction>in</direction>\n          </argument>\n\t  <argument>\n\
+        \           <name>MacAddr</name>\n           <relatedStateVariable>MacAddr</relatedStateVariable>\n\
+        \           <direction>in</direction>\n          </argument>\n\t<argument>\n\
+        \t\t<name>pluginprivateKey</name>\n\t\t<relatedStateVariable>pluginprivateKey</relatedStateVariable>\n\
+        \t\t<direction>in</direction>\n\t</argument>\n\t<argument>\n\t\t<name>smartprivateKey</name>\n\
+        \t\t<relatedStateVariable>smartprivateKey</relatedStateVariable>\n\t\t<direction>in</direction>\n\
+        \t</argument>\n\t<argument>\n\t<name>smartUniqueId</name>\n\t<relatedStateVariable>smartUniqueId</relatedStateVariable>\n\
+        \t<direction>in</direction>\n\t</argument>\t \t  \n\t<argument>\n\t<name>numSmartDev</name>\n\
+        \t<relatedStateVariable>numSmartDev</relatedStateVariable>\n\t<direction>in</direction>\n\
+        \t</argument>\t \t  \n\t<argument>\n\t<retval />\n\t<name>ArpMac</name>\n\t\
+        <relatedStateVariable>ArpMac</relatedStateVariable>\n\t<direction>out</direction>\n\
+        \t</argument>\t \t  \n </argumentList>\n </action>\n\t\n    \n</actionList>\n\
+        \n  <serviceStateTable>\n    \n        <stateVariable sendEvents=\"yes\">\n\
+        \        <!-- DEV ID -->\n      <name>homeId</name>\n      <dataType>string</dataType>\n\
+        \      <defaultValue>0</defaultValue>\n    </stateVariable>\n\t<stateVariable\
+        \ sendEvents=\"yes\">\n      <name>\"pluginprivateKey\"</name>\n      <dataType>string</dataType>\n\
+        \      <defaultValue>0</defaultValue>\n    </stateVariable>\n    <stateVariable\
+        \ sendEvents=\"yes\">\n      <name>\"smartprivateKey\"</name>\n      <dataType>string</dataType>\n\
+        \      <defaultValue>0</defaultValue>\n    </stateVariable>\n\t<stateVariable\
+        \ sendEvents=\"yes\">\n      <name>statusCode</name>\n      <dataType>string</dataType>\n\
+        \      <defaultValue>0</defaultValue>\n    </stateVariable>\n\t<stateVariable\
+        \ sendEvents=\"yes\">\n      <name>resultCode</name>\n      <dataType>string</dataType>\n\
+        \      <defaultValue>0</defaultValue>\n    </stateVariable>\n\t<stateVariable\
+        \ sendEvents=\"yes\">\n      <name>description</name>\n      <dataType>string</dataType>\n\
+        \      <defaultValue>0</defaultValue>\n    </stateVariable>\n\t<stateVariable\
+        \ sendEvents=\"yes\">\n      <name>smartUniqueId</name>\n      <dataType>string</dataType>\n\
+        \      <defaultValue>0</defaultValue>\n    </stateVariable>\n\t<stateVariable\
+        \ sendEvents=\"yes\">\n      <name>smartDeviceDescription</name>\n      <dataType>string</dataType>\n\
+        \      <defaultValue>0</defaultValue>\n    </stateVariable>\n    <stateVariable\
+        \ sendEvents=\"yes\">\n\t\t<name>pluginprivateKey</name>\n\t\t<dataType>string</dataType>\n\
+        \t\t<defaultValue>0</defaultValue>\n\t</stateVariable>\n\t<stateVariable sendEvents=\"\
+        yes\">\n\t\t<name>smartprivateKey</name>\n\t\t<dataType>string</dataType>\n\
+        \t\t<defaultValue>0</defaultValue>\n\t</stateVariable>\n\t<stateVariable sendEvents=\"\
+        yes\">\n\t\t<name>numSmartDev</name>\n\t\t<dataType>string</dataType>\n\t\t\
+        <defaultValue>0</defaultValue>\n\t</stateVariable>\n     <stateVariable sendEvents=\"\
+        yes\">\n      <name>ArpMac</name>\n      <dataType>string</dataType>\n   \
+        \   <defaultValue>0</defaultValue>\n     </stateVariable>\n  </serviceStateTable>\n\
+        \  \n  </scpd>\n"
+    headers:
+      CONNECTION:
+      - close
+      CONTENT-LENGTH:
+      - '3814'
+      CONTENT-TYPE:
+      - text/xml
+      DATE:
+      - Mon, 25 Jan 2021 00:02:01 GMT
+      LAST-MODIFIED:
+      - Sat, 01 Jan 2000 00:00:32 GMT
+      SERVER:
+      - Unspecified, UPnP/1.0, Unspecified
+      X-User-Agent:
+      - redsonic
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.25.1
+    method: GET
+    uri: http://192.168.1.100:49153/deviceinfoservice.xml
+  response:
+    body:
+      string: "\uFEFF<?xml version=\"1.0\"?>\n<scpd xmlns=\"urn:Belkin:service-1-0\"\
+        >\n\n  <specVersion>\n    <major>1</major>\n    <minor>0</minor>\n  </specVersion>\n\
+        \  \n  <actionList>\n    <action>\n\t<name>GetDeviceInformation</name>\n\t\
+        <argumentList>\n         <argument>\n           <retval />\n           <name>UTC</name>\n\
+        \           <relatedStateVariable>UTC</relatedStateVariable>\n           <direction>out</direction>\n\
+        \          </argument>\n         <argument>\n           <retval />\n     \
+        \      <name>TimeZone</name>\n           <relatedStateVariable>TimeZone</relatedStateVariable>\n\
+        \           <direction>out</direction>\n          </argument>\n         <argument>\n\
+        \           <retval />\n           <name>dst</name>\n           <relatedStateVariable>dst</relatedStateVariable>\n\
+        \           <direction>out</direction>\n          </argument>\n\t\t  <argument>\n\
+        \           <retval />\n           <name>DstSupported</name>\n           <relatedStateVariable>DstSupported</relatedStateVariable>\n\
+        \           <direction>out</direction>\n          </argument>\n \n\t    <argument>\n\
+        \t\t<retval />\n\t\t<name>DeviceInformation</name>\n\t\t<relatedStateVariable>DeviceInformation</relatedStateVariable>\n\
+        \t\t<direction>out</direction>\n\t    </argument>\n      <!--  Adding Countdown\
+        \ Time -->\n      <argument>\n        <retval />\n        <name>CountdownTime</name>\n\
+        \        <relatedStateVariable>CountdownTime</relatedStateVariable>\n    \
+        \    <direction>out</direction>\n      </argument>\n         <argument>\n\
+        \           <retval />\n           <name>TimeSync</name>\n           <relatedStateVariable>TimeSync</relatedStateVariable>\n\
+        \           <direction>out</direction>\n          </argument>\n\t</argumentList>\n\
+        \    </action>\n    <action>\n\t<name>GetInformation</name>\n\t<argumentList>\n\
+        \         <argument>\n           <retval />\n           <name>UTC</name>\n\
+        \           <relatedStateVariable>UTC</relatedStateVariable>\n           <direction>out</direction>\n\
+        \          </argument>\n         <argument>\n           <retval />\n     \
+        \      <name>TimeZone</name>\n           <relatedStateVariable>TimeZone</relatedStateVariable>\n\
+        \           <direction>out</direction>\n          </argument>\n         <argument>\n\
+        \           <retval />\n           <name>dst</name>\n           <relatedStateVariable>dst</relatedStateVariable>\n\
+        \           <direction>out</direction>\n          </argument>\n\t <argument>\n\
+        \           <retval />\n           <name>DstSupported</name>\n           <relatedStateVariable>DstSupported</relatedStateVariable>\n\
+        \           <direction>out</direction>\n          </argument>\n \n\t    <argument>\n\
+        \t\t<retval />\n\t\t<name>Information</name>\n\t\t<relatedStateVariable>Information</relatedStateVariable>\n\
+        \t\t<direction>out</direction>\n\t    </argument>\n         <argument>\n \
+        \          <retval />\n           <name>TimeSync</name>\n           <relatedStateVariable>TimeSync</relatedStateVariable>\n\
+        \           <direction>out</direction>\n          </argument>\n\t</argumentList>\n\
+        \    </action>\n    <action>\n\t<name>OpenInstaAP</name>\n    </action>\n\
+        \    <action>\n\t<name>CloseInstaAP</name>\n    </action>\n    <action>\n\t\
+        <name>GetConfigureState</name>\n\t<argumentList>\n\t    <argument>\n\t\t<retval\
+        \ />\n\t\t<name>ConfigureState</name>\n\t\t<relatedStateVariable>ConfigureState</relatedStateVariable>\n\
+        \t\t<direction>out</direction>\n\t    </argument>\n\t</argumentList>\n   \
+        \ </action>\n    <action>\n      <name>InstaConnectHomeNetwork</name>    \n\
+        \      <argumentList>\n         <argument>\n           <name>ssid</name>\n\
+        \           <relatedStateVariable>ssid</relatedStateVariable>\n          \
+        \ <direction>in</direction>\n         </argument>\n         <argument>\n\t\
+        \    <name>auth</name>\n\t    <relatedStateVariable>auth</relatedStateVariable>\n\
+        \t    <direction>in</direction>\n        </argument>\n        <argument>\n\
+        \            <name>password</name>\n            <relatedStateVariable>password</relatedStateVariable>\n\
+        \            <direction>in</direction>\n       </argument>\n       <argument>\n\
+        \            <name>encrypt</name>\n            <relatedStateVariable>encrypt</relatedStateVariable>\n\
+        \            <direction>in</direction>\n       </argument>\n       <argument>\n\
+        \            <name>channel</name>\n            <relatedStateVariable>channel</relatedStateVariable>\n\
+        \            <direction>in</direction>\n       </argument>\n\t<argument>\n\
+        \t    <name>brlist</name>\n\t    <relatedStateVariable>brlist</relatedStateVariable>\n\
+        \t    <direction>in</direction>\n\t</argument>\n      </argumentList>\n  \
+        \  </action>\n    <action>\n\t<name>UpdateBridgeList</name>\n\t<argumentList>\n\
+        \t    <argument>\n\t\t<name>BridgeList</name>\n\t\t<relatedStateVariable>BridgeList</relatedStateVariable>\n\
+        \t\t<direction>in</direction>\n\t    </argument>\n\t</argumentList>\n    </action>\n\
+        \    <action>\n\t<name>GetRouterInformation</name>\n\t<argumentList>\n\t \
+        \   <argument>\n\t\t<retval />\n\t\t<name>mac</name>\n\t\t<relatedStateVariable>mac</relatedStateVariable>\n\
+        \t\t<direction>out</direction>\n\t    </argument>\n         <argument>\n \
+        \          <retval />\n           <name>ssid</name>\n           <relatedStateVariable>ssid</relatedStateVariable>\n\
+        \           <direction>out</direction>\n         </argument>\n         <argument>\n\
+        \t    <retval />\n\t    <name>auth</name>\n\t    <relatedStateVariable>auth</relatedStateVariable>\n\
+        \t    <direction>out</direction>\n        </argument>\n        <argument>\n\
+        \t    <retval />\n            <name>password</name>\n            <relatedStateVariable>password</relatedStateVariable>\n\
+        \            <direction>out</direction>\n       </argument>\n       <argument>\n\
+        \            <retval />\n            <name>encrypt</name>\n            <relatedStateVariable>encrypt</relatedStateVariable>\n\
+        \            <direction>out</direction>\n       </argument>\n       <argument>\n\
+        \            <retval />\n            <name>channel</name>\n            <relatedStateVariable>channel</relatedStateVariable>\n\
+        \            <direction>out</direction>\n       </argument>\n\t</argumentList>\n\
+        \    </action>\n    <action>\n    <name>InstaRemoteAccess</name>\n    <argumentList>\n\
+        \    <argument>\n    <name>DeviceId</name>\n    <relatedStateVariable>DeviceId</relatedStateVariable>\n\
+        \    <direction>in</direction>\n    </argument>\n    <argument>\n    <name>dst</name>\n\
+        \    <relatedStateVariable>dst</relatedStateVariable>\n    <direction>in</direction>\n\
+        \    </argument>\n    <argument>\n    <name>HomeId</name>\n    <relatedStateVariable>HomeId</relatedStateVariable>\n\
+        \    <direction>in</direction>\n    </argument>\n    <argument>\n    <name>DeviceName</name>\n\
+        \    <relatedStateVariable>DeviceName</relatedStateVariable>\n    <direction>in</direction>\n\
+        \    </argument>\n    <argument>\n    <name>MacAddr</name>\n    <relatedStateVariable>MacAddr</relatedStateVariable>\n\
+        \    <direction>in</direction>\n    </argument>\n    <argument>\n    <name>pluginprivateKey</name>\n\
+        \    <relatedStateVariable>pluginprivateKey</relatedStateVariable>\n    <direction>in</direction>\n\
+        \    </argument>\n    <argument>\n    <name>smartprivateKey</name>\n    <relatedStateVariable>smartprivateKey</relatedStateVariable>\n\
+        \    <direction>in</direction>\n    </argument>\n    <argument>\n    <retval\
+        \ />\n    <name>smartUniqueId</name>\n    <relatedStateVariable>smartUniqueId</relatedStateVariable>\n\
+        \    <direction>in</direction>\n    </argument>\n    <argument>\n    <name>numSmartDev</name>\n\
+        \    <relatedStateVariable>numSmartDev</relatedStateVariable>\n    <direction>in</direction>\n\
+        \    </argument>\t \t  \n    </argumentList>\n    </action>\n</actionList>\n\
+        \n  <serviceStateTable>\n  \n    <stateVariable sendEvents=\"yes\">\n    \
+        \  <name>DeviceInformation</name>\n      <dataType>string</dataType>\n   \
+        \   <defaultValue>0</defaultValue>\n    </stateVariable>\n\n    <!--  Adding\
+        \ Countdown Time -->\n    <stateVariable sendEvents=\"yes\">\n      <name>CountdownTime</name>\n\
+        \      <dataType>string</dataType>\n      <defaultValue>0</defaultValue>\n\
+        \    </stateVariable>\n\n    <stateVariable sendEvents=\"yes\">\n      <name>Information</name>\n\
+        \      <dataType>string</dataType>\n      <defaultValue>0</defaultValue>\n\
+        \    </stateVariable>\n\n    <stateVariable sendEvents=\"yes\">\n      <name>ConfigureState</name>\n\
+        \      <dataType>string</dataType>\n      <defaultValue>0</defaultValue>\n\
+        \    </stateVariable>\n\n    <stateVariable sendEvents=\"yes\">\n      <name>BridgeList</name>\n\
+        \      <dataType>string</dataType>\n      <defaultValue>0</defaultValue>\n\
+        \    </stateVariable>\n\n    <stateVariable sendEvents=\"yes\">\n      <name>mac</name>\n\
+        \      <dataType>string</dataType>\n      <defaultValue>0</defaultValue>\n\
+        \    </stateVariable>\n\n    <stateVariable sendEvents=\"yes\">\n      <name>ssid</name>\n\
+        \      <dataType>string</dataType>\n      <defaultValue>0</defaultValue>\n\
+        \    </stateVariable>\n\n    <stateVariable sendEvents=\"yes\">\n      <name>auth</name>\n\
+        \      <dataType>string</dataType>\n      <defaultValue>0</defaultValue>\n\
+        \    </stateVariable>\n\n    <stateVariable sendEvents=\"yes\">\n      <name>password</name>\n\
+        \      <dataType>string</dataType>\n      <defaultValue>0</defaultValue>\n\
+        \    </stateVariable>\n\n    <stateVariable sendEvents=\"yes\">\n      <name>encrypt</name>\n\
+        \      <dataType>string</dataType>\n      <defaultValue>0</defaultValue>\n\
+        \    </stateVariable>\n\n    <stateVariable sendEvents=\"yes\">\n      <name>channel</name>\n\
+        \      <dataType>string</dataType>\n      <defaultValue>0</defaultValue>\n\
+        \    </stateVariable>\n\n  <stateVariable sendEvents=\"yes\">\t\n\t<name>PairingStatus</name>\n\
+        \      <dataType>string</dataType>\n      <defaultValue>Connecting</defaultValue>\n\
+        \    </stateVariable>\n\n    <stateVariable sendEvents=\"yes\">\n    <name>statusCode</name>\n\
+        \    <dataType>string</dataType>\n    <defaultValue>0</defaultValue>\n   \
+        \ </stateVariable>\n\n    <stateVariable sendEvents=\"yes\">\n    <name>TimeSync</name>\n\
+        \    <dataType>string</dataType>\n    <defaultValue>0</defaultValue>\n   \
+        \ </stateVariable>\n\n  </serviceStateTable>\n  \n  </scpd>\n"
+    headers:
+      CONNECTION:
+      - close
+      CONTENT-LENGTH:
+      - '9544'
+      CONTENT-TYPE:
+      - text/xml
+      DATE:
+      - Mon, 25 Jan 2021 00:02:01 GMT
+      LAST-MODIFIED:
+      - Sat, 01 Jan 2000 00:00:32 GMT
+      SERVER:
+      - Unspecified, UPnP/1.0, Unspecified
+      X-User-Agent:
+      - redsonic
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.25.1
+    method: GET
+    uri: http://192.168.1.100:49153/insightservice.xml
+  response:
+    body:
+      string: "\uFEFF<?xml version=\"1.0\"?>\n<scpd xmlns=\"urn:Belkin:service-1-0\"\
+        >\n\n  <specVersion>\n    <major>1</major>\n    <minor>0</minor>\n  </specVersion>\n\
+        \  \n  <actionList>\n\n<action>\n  <name>GetPower</name>\n  <argumentList>\n\
+        \     <argument>\n       <retval />\n       <name>InstantPower</name>\n  \
+        \     <relatedStateVariable>InstantPower</relatedStateVariable>\n       <direction>out</direction>\n\
+        \      </argument>\n  </argumentList>\n</action>\n\n<action>\n  <name>GetTodayKWH</name>\n\
+        \  <argumentList>\n     <argument>\n       <retval />\n       <name>TodayKWH</name>\n\
+        \       <relatedStateVariable>TodayKWH</relatedStateVariable>\n       <direction>out</direction>\n\
+        \      </argument>\n  </argumentList>\n</action>\n\n<action>\n  <name>SetAutoPowerThreshold</name>\n\
+        \  <argumentList>\n     <argument>\n       <name>PowerThreshold</name>\n \
+        \      <relatedStateVariable>PowerThreshold</relatedStateVariable>\n     \
+        \  <direction>in</direction>\n      </argument>\n  </argumentList>\n</action>\n\
+        \n<action>\n  <name>GetPowerThreshold</name>\n  <argumentList>\n     <argument>\n\
+        \       <retval />\n       <name>PowerThreshold</name>\n       <relatedStateVariable>PowerThreshold</relatedStateVariable>\n\
+        \       <direction>out</direction>\n      </argument>\n  </argumentList>\n\
+        </action>\n\n<action>\n  <name>SetPowerThreshold</name>\n  <argumentList>\n\
+        \     <argument>\n       <name>PowerThreshold</name>\n       <relatedStateVariable>PowerThreshold</relatedStateVariable>\n\
+        \       <direction>in</direction>\n      </argument>\n  </argumentList>\n\
+        </action>\n\n<action>\n  <name>ResetPowerThreshold</name>\n  <argumentList>\n\
+        \     <argument>\n       <name>PowerThreshold</name>\n       <relatedStateVariable>PowerThreshold</relatedStateVariable>\n\
+        \       <direction>in</direction>\n      </argument>\n  </argumentList>\n\
+        </action>\n\n<action>\n  <name>GetInsightInfo</name>\n  <argumentList>\n \
+        \ <argument>\n  <retval />\n  <name>InsightInfo</name>\n  <relatedStateVariable>InsightInfo</relatedStateVariable>\n\
+        \  <direction>out</direction>\n  </argument>\n  </argumentList>\n</action>\n\
+        \n<action>\n  <name>GetInsightParams</name>\n  <argumentList>\n  <argument>\n\
+        \  <retval />\n  <name>InsightParams</name>\n  <relatedStateVariable>InsightParams</relatedStateVariable>\n\
+        \  <direction>out</direction>\n  </argument>\n  </argumentList>\n</action>\n\
+        \n<action>\n  <name>GetONFor</name>\n  <argumentList>\n  <argument>\n  <retval\
+        \ />\n  <name>ONFor</name>\n  <relatedStateVariable>ONFor</relatedStateVariable>\n\
+        \  <direction>out</direction>\n  </argument>\n  </argumentList>\n</action>\n\
+        \n<action>\n  <name>GetInSBYSince</name>\n  <argumentList>\n  <argument>\n\
+        \  <retval />\n  <name>InSBYSince</name>\n  <relatedStateVariable>InSBYSince</relatedStateVariable>\n\
+        \  <direction>out</direction>\n   </argument>\n   </argumentList>\n</action>\n\
+        \n\n<action>\n  <name>GetTodayONTime</name>\n  <argumentList>\n  <argument>\n\
+        \  <retval />\n  <name>TodayONTime</name>\n  <relatedStateVariable>TodayONTime</relatedStateVariable>\n\
+        \  <direction>out</direction>\n   </argument>\n   </argumentList>\n</action>\n\
+        \n\n<action>\n  <name>GetTodaySBYTime</name>\n  <argumentList>\n  <argument>\n\
+        \  <retval />\n  <name>TodaySBYTime</name>\n  <relatedStateVariable>TodaySBYTime</relatedStateVariable>\n\
+        \  <direction>out</direction>\n   </argument>\n   </argumentList>\n</action>\n\
+        \  \n<action>\n  <name>ScheduleDataExport</name>\n  <argumentList>\n     <argument>\n\
+        \       <name>EmailAddress</name>\n       <relatedStateVariable>EmailAddress</relatedStateVariable>\n\
+        \       <direction>in</direction>\n     </argument>\n     <argument>\n   \
+        \    <name>DataExportType</name>\n       <relatedStateVariable>DataExportType</relatedStateVariable>\n\
+        \       <direction>in</direction>\n     </argument>\n  </argumentList>\n</action>\n\
+        \n<action>\n  <name>GetDataExportInfo</name>\n  <argumentList>\n     <argument>\n\
+        \       <retval />\n       <name>LastDataExportTS</name>\n       <relatedStateVariable>LastDataExportTS</relatedStateVariable>\n\
+        \       <direction>out</direction>\n     </argument>\n     <argument>\n  \
+        \     <retval />\n       <name>DataExportType</name>\n       <relatedStateVariable>DataExportType</relatedStateVariable>\n\
+        \       <direction>out</direction>\n     </argument>\n     <argument>\n  \
+        \     <retval />\n       <name>EmailAddress</name>\n       <relatedStateVariable>EmailAddress</relatedStateVariable>\n\
+        \       <direction>out</direction>\n     </argument>\n  </argumentList>\n\
+        </action>\n\n</actionList>\n  \n\n  <serviceStateTable>\n  \n    <stateVariable\
+        \ sendEvents=\"yes\">\n      <name>InstantPower</name>\n      <dataType>String</dataType>\n\
+        \      <defaultValue>0</defaultValue>\n    </stateVariable>\n    <stateVariable\
+        \ sendEvents=\"yes\">\n      <name>TodayKWH</name>\n      <dataType>String</dataType>\n\
+        \      <defaultValue>0</defaultValue>\n    </stateVariable>\n    <stateVariable\
+        \ sendEvents=\"yes\">\n      <name>InsightInfo</name>\n      <dataType>String</dataType>\n\
+        \      <defaultValue>0</defaultValue>\n    </stateVariable>\n    <stateVariable\
+        \ sendEvents=\"yes\">\n      <name>InsightParams</name>\n      <dataType>String</dataType>\n\
+        \      <defaultValue>0</defaultValue>\n    </stateVariable>\n    <stateVariable\
+        \ sendEvents=\"yes\">\n      <name>TodayONTime</name>\n      <dataType>String</dataType>\n\
+        \      <defaultValue>0</defaultValue>\n    </stateVariable>\n    <stateVariable\
+        \ sendEvents=\"yes\">\n      <name>InSBYSince</name>\n      <dataType>String</dataType>\n\
+        \      <defaultValue>0</defaultValue>\n    </stateVariable>\n    <stateVariable\
+        \ sendEvents=\"yes\">\n      <name>ONFor</name>\n      <dataType>String</dataType>\n\
+        \      <defaultValue>0</defaultValue>\n    </stateVariable>\n    <stateVariable\
+        \ sendEvents=\"yes\">\n      <name>TodaySBYTime</name>\n      <dataType>String</dataType>\n\
+        \      <defaultValue>0</defaultValue>\n    </stateVariable>\n    <stateVariable\
+        \ sendEvents=\"yes\">\n      <name>PowerThreshold</name>\n      <dataType>String</dataType>\n\
+        \      <defaultValue>0</defaultValue>\n    </stateVariable>\n    <stateVariable\
+        \ sendEvents=\"yes\">\n      <name>EmailAddress</name>\n      <dataType>string</dataType>\n\
+        \      <defaultValue>0</defaultValue>\n    </stateVariable>\n    <stateVariable\
+        \ sendEvents=\"yes\">\n      <name>DataExportType</name>\n      <dataType>string</dataType>\n\
+        \      <defaultValue>0</defaultValue>\n    </stateVariable>\n    <stateVariable\
+        \ sendEvents=\"yes\">\n      <name>LastDataExportTS</name>\n      <dataType>string</dataType>\n\
+        \      <defaultValue>0</defaultValue>\n    </stateVariable>\n\n  </serviceStateTable>\n\
+        \  \n  </scpd>\n"
+    headers:
+      CONNECTION:
+      - close
+      CONTENT-LENGTH:
+      - '6246'
+      CONTENT-TYPE:
+      - text/xml
+      DATE:
+      - Mon, 25 Jan 2021 00:02:01 GMT
+      LAST-MODIFIED:
+      - Sat, 01 Jan 2000 00:00:32 GMT
+      SERVER:
+      - Unspecified, UPnP/1.0, Unspecified
+      X-User-Agent:
+      - redsonic
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.25.1
+    method: GET
+    uri: http://192.168.1.100:49153/smartsetup.xml
+  response:
+    body:
+      string: "<?xml version=\"1.0\"?>\n<scpd xmlns=\"urn:Belkin:service-1-0\">\n\n\
+        \  <specVersion>\n    <major>1</major>\n    <minor>0</minor>\n  </specVersion>\n\
+        \  \n  <actionList>\n    <action>\n        <name>PairAndRegister</name>  \
+        \  \n\t<argumentList>\n\t<argument>\n\t    \t<name>PairingData</name>\n  \
+        \          \t<relatedStateVariable>PairingData</relatedStateVariable>\n\t\
+        \    \t<direction>in</direction>\n\t</argument>\n\t<argument>\n\t\t<name>RegistrationData</name>\n\
+        \t\t<relatedStateVariable>RegistrationData</relatedStateVariable>\n\t\t<direction>in</direction>\n\
+        \t</argument>\n\t<argument>\n\t\t<retval />\n\t\t<name>PairingStatus</name>\n\
+        \t\t<relatedStateVariable>PairingStatus</relatedStateVariable>\n\t\t<direction>out</direction>\n\
+        \t</argument>\n\t</argumentList>\n    </action>\n    \n    <action>\n\t<name>GetRegistrationData</name>\
+        \    \n\t<argumentList>\n\t<argument>\n           \t<retval />\n         \
+        \  \t<name>SmartDeviceData</name>\n           \t<relatedStateVariable>SmartDeviceData</relatedStateVariable>\n\
+        \           \t<direction>out</direction>\n\t</argument>         \n       \
+        \ <argument>\n\t\t<retval />\n        \t<name>RegistrationData</name>\n  \
+        \       \t<relatedStateVariable>RegistrationData</relatedStateVariable>\n\
+        \         \t<direction>out</direction>\n        </argument>\n       \t</argumentList>\
+        \       \n    </action>\n    \n    <action>\n\t<name>GetRegistrationStatus</name>\
+        \    \n\t<argumentList>\n\t<argument>\n           \t<retval />\n         \
+        \  \t<name>RegistrationStatus</name>\n           \t<relatedStateVariable>RegistrationStatus</relatedStateVariable>\n\
+        \           \t<direction>out</direction>\n\t</argument>         \n\t<argument>\n\
+        \           \t<retval />\n           \t<name>StatusCode</name>\n         \
+        \  \t<relatedStateVariable>StatusCode</relatedStateVariable>\n           \t\
+        <direction>out</direction>\n\t</argument>         \n\t</argumentList>    \
+        \   \n    </action>\n\n  </actionList>\n\n  <serviceStateTable>\n    <stateVariable\
+        \ sendEvents=\"yes\">\t\n\t<name>PairingStatus</name>\n      \t<dataType>string</dataType>\n\
+        \      \t<defaultValue>0</defaultValue>\n    </stateVariable>\n\n    <stateVariable\
+        \ sendEvents=\"yes\">\n      \t<name>RegistrationData</name>\n      \t<dataType>string</dataType>\n\
+        \      \t<defaultValue>0</defaultValue>\n    </stateVariable>\n\n    <stateVariable\
+        \ sendEvents=\"yes\">\n      \t<name>StatusCode</name>\n      \t<dataType>string</dataType>\n\
+        \      \t<defaultValue>0</defaultValue>\n    </stateVariable>\n\n    <stateVariable\
+        \ sendEvents=\"yes\">\n      \t<name>RegistrationStatus</name>\n      \t<dataType>string</dataType>\n\
+        \      \t<defaultValue>0</defaultValue>\n    </stateVariable>\n  </serviceStateTable>\n\
+        \n  </scpd>\n"
+    headers:
+      CONNECTION:
+      - close
+      CONTENT-LENGTH:
+      - '2511'
+      CONTENT-TYPE:
+      - text/xml
+      DATE:
+      - Mon, 25 Jan 2021 00:02:02 GMT
+      LAST-MODIFIED:
+      - Sat, 01 Jan 2000 00:00:33 GMT
+      SERVER:
+      - Unspecified, UPnP/1.0, Unspecified
+      X-User-Agent:
+      - redsonic
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.25.1
+    method: GET
+    uri: http://192.168.1.100:49153/manufacture.xml
+  response:
+    body:
+      string: "<?xml version=\"1.0\"?>\n<scpd xmlns=\"urn:Belkin:service-1-0\">\n\n\
+        \  <specVersion>\n    <major>1</major>\n    <minor>0</minor>\n  </specVersion>\n\
+        \n  <actionList>\n    <action>\n      <name>GetManufactureData</name>\n  \
+        \    <argumentList>\n        <argument>\n          <retval />\n          <name>ManufactureData</name>\n\
+        \          <direction>out</direction>\n          <relatedStateVariable>ManufactureData</relatedStateVariable>\n\
+        \        </argument>\n      </argumentList>\n    </action>\n  </actionList>\n\
+        \n  <serviceStateTable>\n    <stateVariable sendEvent=\"no\">\n      <name>ManufactureData</name>\n\
+        \      <dataType>string</dataType>\n    </stateVariable>\n  </serviceStateTable>\n\
+        \n</scpd>\n"
+    headers:
+      CONNECTION:
+      - close
+      CONTENT-LENGTH:
+      - '663'
+      CONTENT-TYPE:
+      - text/xml
+      DATE:
+      - Mon, 25 Jan 2021 00:02:02 GMT
+      LAST-MODIFIED:
+      - Sat, 01 Jan 2000 00:00:32 GMT
+      SERVER:
+      - Unspecified, UPnP/1.0, Unspecified
+      X-User-Agent:
+      - redsonic
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '<?xml version="1.0" encoding="utf-8"?>
+
+      <s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/" s:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/">
+
+      <s:Body>
+
+      <u:GetInsightParams xmlns:u="urn:Belkin:service:insight:1">
+
+
+      </u:GetInsightParams>
+
+      </s:Body>
+
+      </s:Envelope>'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '279'
+      Content-Type:
+      - text/xml
+      SOAPACTION:
+      - '"urn:Belkin:service:insight:1#GetInsightParams"'
+      User-Agent:
+      - python-requests/2.25.1
+    method: POST
+    uri: http://192.168.1.100:49153/upnp/control/insight1
+  response:
+    body:
+      string: "<s:Envelope xmlns:s=\"http://schemas.xmlsoap.org/soap/envelope/\" s:encodingStyle=\"\
+        http://schemas.xmlsoap.org/soap/encoding/\"><s:Body>\n<u:GetInsightParamsResponse\
+        \ xmlns:u=\"urn:Belkin:service:metainfo:1\">\r\n<InsightParams>8|1611530424|231|300|183183|1209600|8|1190|1164707|99830512.000000|8000</InsightParams>\r\
+        \n</u:GetInsightParamsResponse>\r\n</s:Body> </s:Envelope>"
+    headers:
+      CONTENT-LENGTH:
+      - '361'
+      CONTENT-TYPE:
+      - text/xml; charset="utf-8"
+      DATE:
+      - Mon, 25 Jan 2021 00:02:02 GMT
+      EXT:
+      - ''
+      SERVER:
+      - Unspecified, UPnP/1.0, Unspecified
+      X-User-Agent:
+      - redsonic
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/vcr/tests.test_subscribe/Test_SubscriptionRegistry.test_register_unregister.yaml
+++ b/tests/vcr/tests.test_subscribe/Test_SubscriptionRegistry.test_register_unregister.yaml
@@ -39,4 +39,44 @@ interactions:
     status:
       code: 200
       message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CALLBACK:
+      - <http://192.168.1.1:8989/insight1>
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      NT:
+      - upnp:event
+      TIMEOUT:
+      - Second-300
+      User-Agent:
+      - python-requests/2.25.1
+    method: SUBSCRIBE
+    uri: http://192.168.1.100:49153/upnp/event/insight1
+  response:
+    body:
+      string: ''
+    headers:
+      CONTENT-LENGTH:
+      - '0'
+      DATE:
+      - Tue, 26 Jan 2021 02:16:36 GMT
+      SERVER:
+      - Unspecified, UPnP/1.0, Unspecified
+      SID:
+      - uuid:849c1a56-1dd2-11b2-b5fd-dcf7b6ec9aaa
+      TIMEOUT:
+      - Second-300
+      X-User-Agent:
+      - redsonic
+    status:
+      code: 200
+      message: OK
 version: 1


### PR DESCRIPTION
## Description:

Support multiple subscriptions for the Insight device.

The original subscription logic stored the scheduler Event instances in the `self._events` dictionary, keyed by the device serial number. This only permitted one subscription (one scheduler Event) per device.

Original: `self._events[device.serialnumber] = self._sched.enter(...)`

This PR adds an additional level of dictionary. `self._events` is still keyed by serialnumber, but rather than a single Event instance, it now contains a dict with multiple Event instances. Each individual Event is keyed by the function used to fetch the URL for the subscription.

New: `self._events[device.serialnumber][url_fn] = self._sched.enter(...)`

Two new functions are added, each for a specific subscription URL.

```python
def _basic_event_subscription_url(device: Device) -> str:
    """Return the basic event subscription URL."""
    return device.basicevent.eventSubURL


def _insight_event_subscription_url(device: Device) -> str:
    """Return the insight event subscription URL."""
    return device.insight.eventSubURL
```

These functions are the keys for the second-level dictionary. They are also used to lookup the appropriate device URL to maintain the subscription.

It was important in this PR to not store the URL of the device directly, but rather read it from the device instance each time. This is necessary to support probing/rediscovery of a device when its IP/port changes. PR #209 made the mistake of using the URL as the second-level dictionary key and storing it in the Event arguments. #209 was flawed because the URL/host/port never changed when the device was rediscovered. Using the url_fn avoids that mistake.

**Related issue (if applicable):** fixes #115

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] There is no commented out code in this PR.