### PR TITLE
coveralls adjustments

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,5 +38,5 @@ jobs:
           COVERALLS_SERVICE_NAME: github-actions
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          pip3 install --upgrade coveralls
+          pip3 install --upgrade coveralls setuptools
           coveralls --finish

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,7 +23,7 @@ jobs:
         env:
           CI: 1
           COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
-          COVERALLS_SERVICE_NAME: github
+          COVERALLS_SERVICE_NAME: github-actions
           COVERALLS_PARALLEL: true
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: ./scripts/build.sh
@@ -34,7 +34,8 @@ jobs:
     steps:
       - name: Finished
         env:
-          COVERALLS_SERVICE_NAME: github
+          COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
+          COVERALLS_SERVICE_NAME: github-actions
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           pip3 install --upgrade coveralls

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,6 +31,7 @@ jobs:
     name: Indicate completion to coveralls.io
     needs: build
     runs-on: ubuntu-latest
+    container: python:3-slim
     steps:
       - name: Finished
         env:
@@ -38,6 +39,5 @@ jobs:
           COVERALLS_SERVICE_NAME: github-actions
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          source scripts/common.sh
-          enterVenv
+          pip3 install --upgrade coveralls
           coveralls --finish

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,6 +6,7 @@ on:
     - master
 jobs:
   build:
+    name: Build and test
     runs-on: ubuntu-latest
     strategy:
       max-parallel: 4
@@ -23,5 +24,17 @@ jobs:
           CI: 1
           COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
           COVERALLS_SERVICE_NAME: github
+          COVERALLS_PARALLEL: true
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: ./scripts/build.sh
+  coveralls:
+    name: Indicate completion to coveralls.io
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Finished
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          pip3 install --upgrade coveralls
+          coveralls --finish

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,5 +22,6 @@ jobs:
         env:
           CI: 1
           COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
+          COVERALLS_SERVICE_NAME: github
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: ./scripts/build.sh

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,5 +38,6 @@ jobs:
           COVERALLS_SERVICE_NAME: github-actions
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          pip3 install --upgrade coveralls setuptools
+          pip3 install --upgrade setuptools
+          pip3 install --upgrade coveralls
           coveralls --finish

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,6 +38,6 @@ jobs:
           COVERALLS_SERVICE_NAME: github-actions
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          pip3 install --upgrade setuptools
-          pip3 install --upgrade coveralls
+          source scripts/common.sh
+          enterVenv
           coveralls --finish

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,6 +34,7 @@ jobs:
     steps:
       - name: Finished
         env:
+          COVERALLS_SERVICE_NAME: github
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           pip3 install --upgrade coveralls

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -25,6 +25,7 @@ jobs:
     name: Indicate completion to coveralls.io
     needs: deploy
     runs-on: ubuntu-latest
+    container: python:3-slim
     steps:
       - name: Finished
         env:
@@ -32,6 +33,5 @@ jobs:
           COVERALLS_SERVICE_NAME: github-actions
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          source scripts/common.sh
-          enterVenv
+          pip3 install --upgrade coveralls
           coveralls --finish

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -32,5 +32,6 @@ jobs:
           COVERALLS_SERVICE_NAME: github-actions
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          pip3 install --upgrade coveralls setuptools
+          pip3 install --upgrade setuptools
+          pip3 install --upgrade coveralls
           coveralls --finish

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,6 +4,7 @@ on:
     types: [created]
 jobs:
   deploy:
+    name: Build, test, and deploy to PyPI
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -17,5 +18,17 @@ jobs:
           CI: 1
           COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
           COVERALLS_SERVICE_NAME: github
+          COVERALLS_PARALLEL: true
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: ./scripts/build_and_publish.sh ${{ secrets.PYPI_PASSWORD }}
+  coveralls:
+    name: Indicate completion to coveralls.io
+    needs: deploy
+    runs-on: ubuntu-latest
+    steps:
+      - name: Finished
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          pip3 install --upgrade coveralls
+          coveralls --finish

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -32,5 +32,5 @@ jobs:
           COVERALLS_SERVICE_NAME: github-actions
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          pip3 install --upgrade coveralls
+          pip3 install --upgrade coveralls setuptools
           coveralls --finish

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -28,6 +28,7 @@ jobs:
     steps:
       - name: Finished
         env:
+          COVERALLS_SERVICE_NAME: github
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           pip3 install --upgrade coveralls

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,7 +17,7 @@ jobs:
         env:
           CI: 1
           COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
-          COVERALLS_SERVICE_NAME: github
+          COVERALLS_SERVICE_NAME: github-actions
           COVERALLS_PARALLEL: true
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: ./scripts/build_and_publish.sh ${{ secrets.PYPI_PASSWORD }}
@@ -28,7 +28,8 @@ jobs:
     steps:
       - name: Finished
         env:
-          COVERALLS_SERVICE_NAME: github
+          COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
+          COVERALLS_SERVICE_NAME: github-actions
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           pip3 install --upgrade coveralls

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -32,6 +32,6 @@ jobs:
           COVERALLS_SERVICE_NAME: github-actions
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          pip3 install --upgrade setuptools
-          pip3 install --upgrade coveralls
+          source scripts/common.sh
+          enterVenv
           coveralls --finish

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,5 +16,6 @@ jobs:
         env:
           CI: 1
           COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
+          COVERALLS_SERVICE_NAME: github
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: ./scripts/build_and_publish.sh ${{ secrets.PYPI_PASSWORD }}

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -53,7 +53,7 @@ echo "===Test with pytest and coverage==="
 coverage run -m pytest --vcr-record=none
 coverage report --skip-covered
 if [[ "${CI:-}" = "1" ]]; then
-  coveralls --service=github
+  coveralls
 fi
 
 echo


### PR DESCRIPTION
## Description:
When run with parallel jobs, you need a final "finish" step.  I've made a few adjustments based on this:
https://coveralls-python.readthedocs.io/en/latest/usage/configuration.html#github-actions-support

That adjustment probably isn't needed for the publish since I don't think it runs parallel like the pull requests/build script does, but I assume it won't hurt since it will still run the `--finish` part.

Also, right now it just installs the latest coveralls in this final/finish step.  If this works, we can make that a little bit smarter to re-activate the virtual environment and use the same version that is already installed.

## Checklist:
  - [ ] The code change is tested and works locally.
  - [X] There is no commented out code in this PR.