### PR TITLE
remove unused files/options

### DIFF
--- a/.hound.yml
+++ b/.hound.yml
@@ -1,2 +1,0 @@
-python:
-  enabled: false

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,3 @@
-[bdist_wheel]
-universal = 1
-
 [flake8]
 exclude =
     # common directories or files to exclude


### PR DESCRIPTION
## Description:
Remove the hound CI file which is not longer used and also remove the unused option from the `setup.cfg` file for a universal wheel.  The universal wheel is for a pure python library supporting python 2 and 3.  When removing this, I didn't notice anything different and I don't think poetry even reads this option anyway.

```
[bdist_wheel]
universal = 1
```

**Related issue (if applicable):** fixes #232

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] There is no commented out code in this PR.