### PR TITLE
Combine all requests timeouts into a single constant

### DIFF
--- a/pywemo/discovery.py
+++ b/pywemo/discovery.py
@@ -7,7 +7,7 @@ import requests
 
 from . import ssdp
 from .ouimeaux_device import UnsupportedDevice, probe_wemo
-from .ouimeaux_device.api.service import ActionException
+from .ouimeaux_device.api.service import REQUESTS_TIMEOUT, ActionException
 from .ouimeaux_device.api.xsd import device as deviceParser
 from .ouimeaux_device.bridge import Bridge
 from .ouimeaux_device.coffeemaker import CoffeeMaker
@@ -65,7 +65,7 @@ def discover_devices(
 
 def device_from_description(description_url, mac, rediscovery_enabled=True):
     """Return object representing WeMo device running at host, else None."""
-    xml = requests.get(description_url, timeout=10)
+    xml = requests.get(description_url, timeout=REQUESTS_TIMEOUT)
     parsed = deviceParser.parseString(
         xml.content, silence=True, print_warnings=False
     )

--- a/pywemo/ouimeaux_device/__init__.py
+++ b/pywemo/ouimeaux_device/__init__.py
@@ -9,7 +9,7 @@ from urllib.parse import urlparse
 import requests
 
 from .api.long_press import LongPressMixin
-from .api.service import ActionException, Service
+from .api.service import REQUESTS_TIMEOUT, ActionException, Service
 from .api.xsd import device as deviceParser
 
 LOG = logging.getLogger(__name__)
@@ -18,7 +18,7 @@ LOG = logging.getLogger(__name__)
 PROBE_PORTS = (49153, 49152, 49154, 49151, 49155, 49156, 49157, 49158, 49159)
 
 
-def probe_wemo(host, ports=PROBE_PORTS, probe_timeout=10):
+def probe_wemo(host, ports=PROBE_PORTS, probe_timeout=REQUESTS_TIMEOUT):
     """
     Probe a host for the current port.
 
@@ -110,7 +110,7 @@ class Device:
         self.retrying = False
         self.mac = mac
         self.rediscovery_enabled = rediscovery_enabled
-        xml = requests.get(url, timeout=10)
+        xml = requests.get(url, timeout=REQUESTS_TIMEOUT)
         self._config = deviceParser.parseString(
             xml.content, silence=True, print_warnings=False
         ).device

--- a/pywemo/ouimeaux_device/api/rules_db.py
+++ b/pywemo/ouimeaux_device/api/rules_db.py
@@ -13,6 +13,7 @@ from typing import FrozenSet, List, Mapping, Optional, Tuple
 import requests
 
 from .db_orm import DatabaseRow, PrimaryKey, SQLType
+from .service import REQUESTS_TIMEOUT
 
 LOG = logging.getLogger(__name__)
 
@@ -369,7 +370,7 @@ def rules_db_from_device(device) -> RulesDb:
     fetch = device.rules.FetchRules()
     version = int(fetch["ruleDbVersion"])
     rule_db_url = fetch["ruleDbPath"]
-    response = requests.get(rule_db_url)
+    response = requests.get(rule_db_url, timeout=REQUESTS_TIMEOUT)
 
     with tempfile.NamedTemporaryFile(
         prefix="wemorules", suffix=".db"

--- a/pywemo/ouimeaux_device/api/service.py
+++ b/pywemo/ouimeaux_device/api/service.py
@@ -113,7 +113,7 @@ class Service:
         self.actions = {}
 
         url = '%s/%s' % (base_url, service.get_SCPDURL().strip('/'))
-        xml = requests.get(url, timeout=10)
+        xml = requests.get(url, timeout=REQUESTS_TIMEOUT)
         if xml.status_code != 200:
             return
 

--- a/pywemo/ouimeaux_device/api/service.py
+++ b/pywemo/ouimeaux_device/api/service.py
@@ -9,6 +9,7 @@ from .xsd import service as serviceParser
 
 LOG = logging.getLogger(__name__)
 MAX_RETRIES = 3
+REQUESTS_TIMEOUT = 10
 
 REQUEST_TEMPLATE = """
 <?xml version="1.0" encoding="utf-8"?>
@@ -64,7 +65,7 @@ class Action:
                     self.controlURL,
                     body.strip(),
                     headers=self.headers,
-                    timeout=10,
+                    timeout=REQUESTS_TIMEOUT,
                 )
                 response_dict = {}
 

--- a/pywemo/ssdp.py
+++ b/pywemo/ssdp.py
@@ -10,6 +10,7 @@ import requests
 from lxml import etree as et
 
 from .ouimeaux_device.api.long_press import VIRTUAL_DEVICE_UDN
+from .ouimeaux_device.api.service import REQUESTS_TIMEOUT
 from .util import etree_to_dict, get_ip_address, interface_addresses
 
 DISCOVER_TIMEOUT = 5
@@ -175,7 +176,9 @@ class UPNPEntry:
             try:
                 for _ in range(3):
                     try:
-                        xml = requests.get(url, timeout=10).content
+                        xml = requests.get(
+                            url, timeout=REQUESTS_TIMEOUT
+                        ).content
 
                         tree = None
                         if xml is not None:

--- a/pywemo/subscribe.py
+++ b/pywemo/subscribe.py
@@ -12,6 +12,7 @@ from lxml import etree as et
 
 from .ouimeaux_device import Device
 from .ouimeaux_device.api.long_press import VIRTUAL_DEVICE_UDN
+from .ouimeaux_device.api.service import REQUESTS_TIMEOUT
 from .util import get_ip_address
 
 # Subscription event types.
@@ -353,13 +354,19 @@ class SubscriptionRegistry:
         request_headers = headers.copy()
         url = url_fn(device)
         response = requests.request(
-            method="SUBSCRIBE", url=url, headers=request_headers, timeout=10
+            method="SUBSCRIBE",
+            url=url,
+            headers=request_headers,
+            timeout=REQUESTS_TIMEOUT,
         )
         if response.status_code == 412 and sid:
             # Invalid subscription ID. Send an UNSUBSCRIBE for safety and
             # start over.
             requests.request(
-                method='UNSUBSCRIBE', url=url, headers={'SID': sid}, timeout=10
+                method='UNSUBSCRIBE',
+                url=url,
+                headers={'SID': sid},
+                timeout=REQUESTS_TIMEOUT,
             )
             return self._resubscribe(device, url_fn)
         timeout = int(

--- a/tests/ouimeaux_device/api/unit/test_rules.py
+++ b/tests/ouimeaux_device/api/unit/test_rules.py
@@ -9,6 +9,7 @@ import pytest
 import requests
 
 from pywemo.ouimeaux_device.api import rules_db
+from pywemo.ouimeaux_device.api.service import REQUESTS_TIMEOUT
 
 MOCK_NAME = "WemoDeviceName"
 MOCK_UDN = "WemoDeviceUDN"
@@ -239,7 +240,9 @@ def test_rules_db_from_device(temp_file, sqldb):
 
     with patch("requests.get", return_value=mock_response) as mock_get:
         with rules_db.rules_db_from_device(Device) as db:
-            mock_get.assert_called_once_with("http://localhost/rules.db")
+            mock_get.assert_called_once_with(
+                "http://localhost/rules.db", timeout=REQUESTS_TIMEOUT
+            )
             # Make a modification to trigger StoreRules.
             assert len(db._rules) == 1
             db._rules[501].State = 1


### PR DESCRIPTION
## Description: Combine all requests timeouts into a single constant

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] There is no commented out code in this PR.