### PR TITLE
Discovery optimizations

### DIFF
--- a/pywemo/discovery.py
+++ b/pywemo/discovery.py
@@ -26,7 +26,7 @@ LOG = logging.getLogger(__name__)
 
 def discover_devices(*, rediscovery_enabled=True, **kwargs):
     """Find WeMo devices on the local network."""
-    ssdp_st = kwargs.get('st', ssdp.ST)
+    ssdp_st = kwargs.pop('st', ssdp.ST)
     wemos = []
 
     for entry in ssdp.scan(st=ssdp_st, **kwargs):

--- a/pywemo/discovery.py
+++ b/pywemo/discovery.py
@@ -24,18 +24,12 @@ from .ouimeaux_device.switch import Switch
 LOG = logging.getLogger(__name__)
 
 
-def discover_devices(
-    ssdp_st=None, max_devices=None, rediscovery_enabled=True, match_udn=None
-):
+def discover_devices(*, rediscovery_enabled=True, **kwargs):
     """Find WeMo devices on the local network."""
-    ssdp_st = ssdp_st or ssdp.ST
-    ssdp_entries = ssdp.scan(
-        ssdp_st, max_entries=max_devices, match_udn=match_udn
-    )
-
+    ssdp_st = kwargs.get('st', ssdp.ST)
     wemos = []
 
-    for entry in ssdp_entries:
+    for entry in ssdp.scan(st=ssdp_st, **kwargs):
         if entry.match_device_description(
             {'manufacturer': 'Belkin International Inc.'}
         ):

--- a/pywemo/discovery.py
+++ b/pywemo/discovery.py
@@ -56,10 +56,10 @@ def discover_devices(
 
 
 def device_from_description(
-    description_url, mac=None, *, rediscovery_enabled=True
+    description_url, mac='deprecated', *, rediscovery_enabled=True
 ):
     """Return object representing WeMo device running at host, else None."""
-    if mac:
+    if mac != 'deprecated':
         warnings.warn(
             "The mac argument to device_from_description is deprecated and "
             "will be removed in a future release.",

--- a/pywemo/discovery.py
+++ b/pywemo/discovery.py
@@ -26,10 +26,9 @@ LOG = logging.getLogger(__name__)
 
 def discover_devices(*, rediscovery_enabled=True, **kwargs):
     """Find WeMo devices on the local network."""
-    ssdp_st = kwargs.pop('st', ssdp.ST)
     wemos = []
 
-    for entry in ssdp.scan(st=ssdp_st, **kwargs):
+    for entry in ssdp.scan(**kwargs):
         if entry.match_device_description(
             {'manufacturer': 'Belkin International Inc.'}
         ):

--- a/pywemo/ouimeaux_device/__init__.py
+++ b/pywemo/ouimeaux_device/__init__.py
@@ -100,9 +100,9 @@ class ShortPassword(SetupException):
 class Device:
     """Base object for WeMo devices."""
 
-    def __init__(self, url, mac=None, *, rediscovery_enabled=True):
+    def __init__(self, url, mac='deprecated', *, rediscovery_enabled=True):
         """Create a WeMo device."""
-        if mac:
+        if mac != 'deprecated':
             warnings.warn(
                 "The mac argument to Device is deprecated and will be removed "
                 "in a future release.",

--- a/pywemo/ouimeaux_device/__init__.py
+++ b/pywemo/ouimeaux_device/__init__.py
@@ -151,9 +151,7 @@ class Device:
         try_no = 0
 
         while True:
-            found = discover_devices(
-                ssdp_st=None, max_devices=1, match_udn=self.udn
-            )
+            found = discover_devices(max_entries=1, match_udn=self.udn)
 
             if found:
                 LOG.info("Found %s again, updating local values", self.name)

--- a/pywemo/ssdp.py
+++ b/pywemo/ssdp.py
@@ -182,9 +182,7 @@ class UPNPEntry:
                     tree = et.fromstring(xml or b'')
                     return etree_to_dict(tree).get('root', {})
                 except requests.RequestException:
-                    logging.getLogger(__name__).warning(
-                        "Error fetching description at %s", url
-                    )
+                    LOG.warning("Error fetching description at %s", url)
 
         except et.ParseError:
             # There used to be a log message here to record an error about

--- a/pywemo/ssdp.py
+++ b/pywemo/ssdp.py
@@ -174,7 +174,10 @@ class UPNPEntry:
     @property
     def description(self):
         """Return the description from the uPnP entry."""
-        url = self.values.get('location', '_NO_LOCATION')
+        url = self.location
+        if not url:
+            return {}
+
         try:
             for _ in range(3):
                 try:

--- a/pywemo/ssdp.py
+++ b/pywemo/ssdp.py
@@ -240,7 +240,6 @@ class UPNPEntry:
 
 def build_ssdp_request(ssdp_st, ssdp_mx):
     """Build the standard request to send during SSDP discovery."""
-    ssdp_st = ssdp_st or ST
     return "\r\n".join(
         [
             'M-SEARCH * HTTP/1.1',
@@ -254,7 +253,7 @@ def build_ssdp_request(ssdp_st, ssdp_mx):
     ).encode('ascii')
 
 
-def scan(st=None, timeout=DISCOVER_TIMEOUT, max_entries=None, match_udn=None):
+def scan(st=ST, timeout=DISCOVER_TIMEOUT, max_entries=None, match_udn=None):
     """
     Send a message over the network to discover upnp devices.
 

--- a/pywemo/ssdp.py
+++ b/pywemo/ssdp.py
@@ -179,13 +179,8 @@ class UPNPEntry:
             for _ in range(3):
                 try:
                     xml = requests.get(url, timeout=REQUESTS_TIMEOUT).content
-
-                    if xml is not None:
-                        tree = et.fromstring(xml)
-                        if tree is not None:
-                            return etree_to_dict(tree).get('root', {})
-                    break
-
+                    tree = et.fromstring(xml)
+                    return etree_to_dict(tree).get('root', {})
                 except requests.RequestException:
                     logging.getLogger(__name__).warning(
                         "Error fetching description at %s", url

--- a/pywemo/ssdp.py
+++ b/pywemo/ssdp.py
@@ -254,12 +254,7 @@ def build_ssdp_request(ssdp_st, ssdp_mx):
     ).encode('ascii')
 
 
-def scan(  # noqa: C901
-    st=None,
-    timeout=DISCOVER_TIMEOUT,
-    max_entries=None,
-    match_udn=None,
-):
+def scan(st=None, timeout=DISCOVER_TIMEOUT, max_entries=None, match_udn=None):
     """
     Send a message over the network to discover upnp devices.
 

--- a/pywemo/ssdp.py
+++ b/pywemo/ssdp.py
@@ -179,7 +179,7 @@ class UPNPEntry:
             for _ in range(3):
                 try:
                     xml = requests.get(url, timeout=REQUESTS_TIMEOUT).content
-                    tree = et.fromstring(xml)
+                    tree = et.fromstring(xml or b'')
                     return etree_to_dict(tree).get('root', {})
                 except requests.RequestException:
                     logging.getLogger(__name__).warning(

--- a/tests/ouimeaux_device/test_bridge.py
+++ b/tests/ouimeaux_device/test_bridge.py
@@ -11,7 +11,7 @@ LIGHT_ID = '0017880108DA898B'
 @pytest.fixture
 def bridge(vcr):
     with vcr.use_cassette('WeMo_WW_2.00.11057.PVT-OWRT-Link.yaml'):
-        return Bridge('http://192.168.1.100:49153/setup.xml', '')
+        return Bridge('http://192.168.1.100:49153/setup.xml')
 
 
 @pytest.mark.vcr()

--- a/tests/ouimeaux_device/test_device.py
+++ b/tests/ouimeaux_device/test_device.py
@@ -162,7 +162,7 @@ def device(mock_get):
     """Return a Device as created by some actual XML."""
     # Note that the actions on the services will not be created since the
     # URL(s) for them will return a 404.
-    device = Device('http://192.168.1.100:49158/setup.xml', '')
+    device = Device('http://192.168.1.100:49158/setup.xml')
     device.WiFiSetup.GetApList = mock.Mock(return_value={'ApList': APLIST})
     device.WiFiSetup.ConnectHomeNetwork = mock.Mock(
         return_value={'PairingStatus': 'Connecting'}

--- a/tests/ouimeaux_device/test_dimmer.py
+++ b/tests/ouimeaux_device/test_dimmer.py
@@ -37,6 +37,6 @@ class Test_PVT_OWRT_Dimmer_v1(Base, long_press_helpers.TestLongPress):
     @pytest.fixture
     def dimmer(self, vcr):
         with vcr.use_cassette('WeMo_WW_2.00.11453.PVT-OWRT-Dimmer'):
-            return Dimmer('http://192.168.1.100:49153/setup.xml', '')
+            return Dimmer('http://192.168.1.100:49153/setup.xml')
 
     device = dimmer  # for TestLongPress

--- a/tests/ouimeaux_device/test_insight.py
+++ b/tests/ouimeaux_device/test_insight.py
@@ -15,7 +15,7 @@ class Test_Insight:
     @pytest.fixture
     def insight(self, vcr):
         with vcr.use_cassette('WeMo_WW_2.00.11408.PVT-OWRT-Insight.yaml'):
-            return Insight('http://192.168.1.100:49153/setup.xml', '')
+            return Insight('http://192.168.1.100:49153/setup.xml')
 
     @pytest.mark.vcr()
     def test_turn_on(self, insight):

--- a/tests/ouimeaux_device/test_lightswitch.py
+++ b/tests/ouimeaux_device/test_lightswitch.py
@@ -27,6 +27,6 @@ class Test_PVT_OWRT_LS_v1(Base, long_press_helpers.TestLongPress):
     @pytest.fixture
     def lightswitch(self, vcr):
         with vcr.use_cassette('WeMo_WW_2.00.11408.PVT-OWRT-LS'):
-            return LightSwitch('http://192.168.1.100:49153/setup.xml', '')
+            return LightSwitch('http://192.168.1.100:49153/setup.xml')
 
     device = lightswitch  # for TestLongPress

--- a/tests/ouimeaux_device/test_maker.py
+++ b/tests/ouimeaux_device/test_maker.py
@@ -35,4 +35,4 @@ class Test_Maker:
     @pytest.fixture
     def maker(self, vcr):
         with vcr.use_cassette('WeMo_WW_2.00.11423.PVT-OWRT-Maker.yaml'):
-            return Maker('http://192.168.1.100:49153/setup.xml', '')
+            return Maker('http://192.168.1.100:49153/setup.xml')

--- a/tests/ouimeaux_device/test_switch.py
+++ b/tests/ouimeaux_device/test_switch.py
@@ -25,7 +25,7 @@ class Test_F7C027(Base):
     @pytest.fixture
     def switch(self, vcr):
         with vcr.use_cassette('WeMo_US_2.00.2769.PVT.yaml'):
-            return Switch('http://192.168.1.100:49153/setup.xml', '')
+            return Switch('http://192.168.1.100:49153/setup.xml')
 
 
 class Test_F7C063(Base):
@@ -34,7 +34,7 @@ class Test_F7C063(Base):
     @pytest.fixture
     def switch(self, vcr):
         with vcr.use_cassette('WeMo_WW_2.00.11420.PVT-OWRT-SNSV2.yaml'):
-            return Switch('http://192.168.1.100:49153/setup.xml', '')
+            return Switch('http://192.168.1.100:49153/setup.xml')
 
 
 class Test_WSP080(Base):
@@ -43,4 +43,4 @@ class Test_WSP080(Base):
     @pytest.fixture
     def switch(self, vcr):
         with vcr.use_cassette('WEMO_WW_4.00.20101902.PVT-RTOS-SNSV4.yaml'):
-            return Switch('http://192.168.1.100:49153/setup.xml', '')
+            return Switch('http://192.168.1.100:49153/setup.xml')

--- a/tests/test_ssdp.py
+++ b/tests/test_ssdp.py
@@ -227,15 +227,9 @@ class TestScan:
         "kwargs,expected_count",
         [
             ({'match_udn': 'no_match'}, 0),
-            ({'match_mac': 'no_match'}, 0),
-            ({'match_serial': 'no_match'}, 0),
-            ({'match_st': 'no_match'}, 0),
             ({}, 2),
             ({'match_udn': 'uuid:Socket-1_0-SERIAL'}, 1),
             ({'match_udn': 'uuid:Socket-1_0-SERIAL2'}, 1),
-            ({'match_mac': 'XXXXXXXXXXXX'}, 2),
-            ({'match_serial': 'XXXXXXXXXXXXXX'}, 2),
-            ({'match_st': 'urn:Belkin:service:basicevent:1'}, 2),
         ],
     )
     @mock.patch('requests.get', side_effect=mocked_requests_get)
@@ -270,8 +264,7 @@ class TestScan:
 
         entry = entries[0]
         assert entry.udn == 'uuid:Socket-1_0-SERIAL'
-        assert entry.mac_address is None
-        assert entry.serial_number is None
+        assert entry.description == {}
         assert entry.st == 'urn:Belkin:service:basicevent:1'
         assert repr(entry) == (
             '<UPNPEntry urn:Belkin:service:basicevent:1 - '

--- a/tests/test_subscribe.py
+++ b/tests/test_subscribe.py
@@ -15,7 +15,7 @@ from pywemo import Insight, LightSwitch, subscribe
 def device(vcr):
     """Mock WeMo Insight device."""
     with vcr.use_cassette('WeMo_WW_2.00.11408.PVT-OWRT-Insight.yaml'):
-        return Insight('http://192.168.1.100:49153/setup.xml', '')
+        return Insight('http://192.168.1.100:49153/setup.xml')
 
 
 class Test_RequestHandler:


### PR DESCRIPTION
## Description:

- Remove mac/serial/service_types comparisons from `ssdp.scan`. As a side-effect, /setup.xml no longer needs to be fetched in `ssdp.scan`.
- Fix `__eq__` for `UPNPEntry` and remove `entry_in_entries`
- Remove the `DESCRIPTION_CACHE` in `ssdp.scan`. It is no longer required as `ssdp.scan` is no longer fetching /setup.xml
- Avoid a 2nd fetch of /setup.xml in `discover_devices` by calling `device_from_uuid_and_location` directly.
- Deprecate the `mac` argument to the Device constructor .

**Related issue (if applicable): https://github.com/home-assistant/core/issues/45904

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] There is no commented out code in this PR.