### PR TITLE
Add retries for individual SOAP actions

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -4,7 +4,7 @@ Python 3 module to setup, discover and control WeMo devices.
 
 Dependencies
 ------------
-pyWeMo depends on Python packages: requests, ifaddr, lxml
+pyWeMo depends on Python packages: requests, ifaddr, lxml, urllib3
 
 How to use
 ----------

--- a/poetry.lock
+++ b/poetry.lock
@@ -581,7 +581,7 @@ testing = ["pytest (>=3.5,!=3.7.3)", "pytest-checkdocs (>=1.2.3)", "pytest-flake
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7"
-content-hash = "4a32d160f88491ba9de960521669d933c81090f308ae50541ff0d6ff29364d5a"
+content-hash = "f7295bdee51c4366d2b462781c60acd706edc7000c3465b25604b81bfa04e717"
 
 [metadata.files]
 appdirs = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ keywords = ['wemo', 'api']
 python = "^3.7"
 ifaddr = ">=0.1.0"
 requests = ">=2.0"
+urllib3 = ">=1.21.1"
 lxml = "^4.6"
 
 [tool.poetry.dev-dependencies]

--- a/pywemo/ouimeaux_device/__init__.py
+++ b/pywemo/ouimeaux_device/__init__.py
@@ -705,6 +705,7 @@ class Device:
     def mac(self):
         """Return the mac address from the device description."""
         return self._config.get_macAddress()
+
     @property
     def model(self):
         """Return the model description of the device."""

--- a/pywemo/ouimeaux_device/__init__.py
+++ b/pywemo/ouimeaux_device/__init__.py
@@ -114,7 +114,7 @@ class Device:
         self.session = Session(url)
         xml = self.session.get(url)
         self._config = deviceParser.parseString(
-            xml.data, silence=True, print_warnings=False
+            xml.content, silence=True, print_warnings=False
         ).device
         self.services = {}
         for svc in self._config.serviceList.service:

--- a/pywemo/ouimeaux_device/__init__.py
+++ b/pywemo/ouimeaux_device/__init__.py
@@ -5,12 +5,11 @@ import logging
 import subprocess
 import time
 import warnings
-from urllib.parse import urlparse
 
 import requests
 
 from .api.long_press import LongPressMixin
-from .api.service import REQUESTS_TIMEOUT, ActionException, Service
+from .api.service import REQUESTS_TIMEOUT, ActionException, Service, Session
 from .api.xsd import device as deviceParser
 
 LOG = logging.getLogger(__name__)
@@ -110,24 +109,18 @@ class Device:
             )
         self._state = None
         self.basic_state_params = {}
-        base_url = url.rsplit('/', 1)[0]
-        parsed_url = urlparse(url)
-        self.host = parsed_url.hostname
-        self.port = parsed_url.port
         self.retrying = False
         self.rediscovery_enabled = rediscovery_enabled
-        xml = requests.get(url, timeout=REQUESTS_TIMEOUT)
+        self.session = Session(url)
+        xml = self.session.get(url)
         self._config = deviceParser.parseString(
-            xml.content, silence=True, print_warnings=False
+            xml.data, silence=True, print_warnings=False
         ).device
-        service_list = self._config.serviceList
         self.services = {}
-        for svc in service_list.service:
-            svcname = svc.get_serviceType().split(':')[-2]
-            service = Service(self, svc, base_url)
-            service.eventSubURL = base_url + svc.get_eventSubURL()
-            self.services[svcname] = service
-            setattr(self, svcname, service)
+        for svc in self._config.serviceList.service:
+            service = Service(self, svc)
+            self.services[service.name] = service
+            setattr(self, service.name, service)
 
     def _reconnect_with_device_by_discovery(self):
         """
@@ -699,10 +692,19 @@ class Device:
         return issubclass(cls, LongPressMixin)
 
     @property
+    def host(self) -> str:
+        """Host name of the device's UPnP web server."""
+        return self.session.host
+
+    @property
+    def port(self) -> int:
+        """TCP port for the device's UPnP web server."""
+        return self.session.port
+
+    @property
     def mac(self):
         """Return the mac address from the device description."""
         return self._config.get_macAddress()
-
     @property
     def model(self):
         """Return the model description of the device."""

--- a/pywemo/ouimeaux_device/api/service.py
+++ b/pywemo/ouimeaux_device/api/service.py
@@ -1,14 +1,15 @@
 """Representation of Services and Actions for WeMo devices."""
 # flake8: noqa E501
 import logging
+from urllib.parse import urljoin, urlparse
 
 import requests
+import urllib3
 from lxml import etree as et
 
 from .xsd import service as serviceParser
 
 LOG = logging.getLogger(__name__)
-MAX_RETRIES = 3
 REQUESTS_TIMEOUT = 10
 
 REQUEST_TEMPLATE = """
@@ -29,73 +30,210 @@ class ActionException(Exception):
     pass
 
 
+class Session:
+    """HTTP session with device.
+
+    The Session provides timeouts and retries by default. The default
+    parameters were chosen to provide for 3 attempts within 10 seconds, and
+    further attempts beyond that to reestablish a link with the device without
+    needing to attempt rediscovery. Retries continue for the duration that it
+    would take the device to reboot, at which point reconnect_with_device
+    should be able to find the device again by probing.
+
+    It is important to not be too agressive with retries. The WeMo devices only
+    have a small number of threads for servicing requests. If the timeout is
+    too short or the retries are too frequent, it is easy to overwhelm the
+    device with too many requests. This can result in a device that crashes
+    and is unavailable until it reboots.
+
+    The `urllib3` library is used as it provides better timeout/retry support
+    than the `requests` library. Specifically, the `urllib3` library will
+    retry in the case where the response body is not returned within timeout
+    seconds. The `requests` library does not support retries of fetching the
+    response body and will raise an exception if fetching the response body
+    takes longer than the timeout.
+
+    Since much of pywemo is built atop the requests library, any urllib3
+    exceptions will be raised as requests.RequestException.
+    """
+
+    # Retry strategy for requests that fail.
+    retries = urllib3.Retry(
+        total=6, backoff_factor=1.5, allowed_methods=['GET', 'POST']
+    )
+
+    # Seconds that a request can be idle before retrying.
+    timeout = 3
+
+    def __init__(self, url, retries=None, timeout=None):
+        """Create a session with the specified default parameters."""
+        self.url = url
+        if retries is not None:
+            self.retries = retries
+        if timeout is not None:
+            self.timeout = timeout
+
+    def request(
+        self,
+        method: str,
+        url: str,
+        retries=None,
+        timeout=None,
+        **kwargs,
+    ) -> urllib3.HTTPResponse:
+        """Send request and gather response.
+
+        A non-200 response code will result in a requests.RequestException
+        exception.
+
+        Args:
+            method: HTTP method/verb to use for request (ex: 'GET' or 'POST').
+            url: URL to to connect to.
+            retries: Number of retries, or urllib3.Retry instance.
+            timeout: Timeout in seconds for each request attempt.
+            kwargs: Additional arguments for urllib3 pool.request(**kwargs).
+
+        Raises:
+            requests.RequestException for any urllib3 exception or if the
+            response code is not 200.
+        """
+        if retries is None:
+            retries = self.retries
+        if timeout is None:
+            timeout = self.timeout
+
+        # Create and destroy the pool each time. WeMo devices do not support
+        # http keep-alive. Forcing the pool to be destroyed ensures that the
+        # http connection is also closed. This avoids tying up TCP sessions
+        # on the device.
+        with urllib3.PoolManager(retries=retries, timeout=timeout) as pool:
+            try:
+                response = pool.request(method=method, url=url, **kwargs)
+                if response.status != 200:
+                    raise urllib3.exceptions.HTTPError(
+                        f"Received status {response.status} for {url}"
+                    )
+            except urllib3.exceptions.HTTPError as err:
+                raise requests.RequestException(err)
+            return response
+
+    def get(self, url: str, **kwargs) -> urllib3.HTTPResponse:
+        """HTTP GET request."""
+        return self.request('GET', url, **kwargs)
+
+    def post(self, url: str, **kwargs) -> urllib3.HTTPResponse:
+        """HTTP POST request."""
+        return self.request('POST', url, **kwargs)
+
+    def urljoin(self, path: str) -> str:
+        """Build an absolute URL from a path."""
+        return urljoin(self._url, path)
+
+    @property
+    def url(self) -> str:
+        """Return the current URL for the session."""
+        return self._url
+
+    @url.setter
+    def url(self, url: str) -> str:
+        """Update the URL for the session."""
+        parsed_url = urlparse(url)
+        self._url = parsed_url.geturl()
+        self._port = parsed_url.port or 80
+        self._host = parsed_url.hostname
+        return url
+
+    @property
+    def port(self) -> int:
+        """TCP port associated with this session."""
+        return self._port
+
+    @property
+    def host(self) -> str:
+        """Hostname associated with this session."""
+        return self._host
+
+
 class Action:
     """Representation of an Action for a WeMo device."""
 
-    def __init__(self, device, service, action_config):
+    # A few actions take longer than the default timeout. Override the default
+    # timeout value for those actions.
+    soap_action_timeout_override = {
+        "urn:Belkin:service:bridge:1#AddDevice": 30,
+        "urn:Belkin:service:bridge:1#OpenNetwork": 30,
+        "urn:Belkin:service:WiFiSetup:1#GetApList": 10,
+    }
+
+    max_rediscovery_retries = 3
+
+    def __init__(self, service, action_config):
         """Create an instance of an Action."""
-        self._device = device
+        self.service = service
         self._action_config = action_config
         self.name = action_config.get_name()
-        self.serviceType = service.serviceType
-        self.controlURL = service.controlURL
-        self.args = {}
+        self.soap_action = f'{service.serviceType}#{self.name}'
         self.headers = {
             'Content-Type': 'text/xml',
-            'SOAPACTION': '"%s#%s"' % (self.serviceType, self.name),
+            'SOAPACTION': f'"{self.soap_action}"',
         }
 
+        self.args = []
         arglist = action_config.get_argumentList()
         if arglist is not None:
-            for arg in arglist.get_argument():
-                self.args[arg.get_name()] = 0
+            self.args.extend(a.get_name() for a in arglist.get_argument())
 
-    def __call__(self, **kwargs):
+    def __call__(self, *, pywemo_timeout=None, **kwargs):
         """Representations a method or function call."""
         arglist = '\n'.join(
             '<{0}>{1}</{0}>'.format(arg, value)
             for arg, value in kwargs.items()
         )
         body = REQUEST_TEMPLATE.format(
-            action=self.name, service=self.serviceType, args=arglist
+            action=self.name, service=self.service.serviceType, args=arglist
+        ).strip()
+        timeout = pywemo_timeout or self.soap_action_timeout_override.get(
+            self.soap_action
         )
-        for attempt in range(3):
+        last_exception = None
+
+        for attempt in range(self.max_rediscovery_retries):
+            session = self.service.device.session
             try:
-                response = requests.post(
-                    self.controlURL,
-                    body.strip(),
+                response = session.post(
+                    self.service.controlURL,
                     headers=self.headers,
-                    timeout=REQUESTS_TIMEOUT,
+                    body=body,
+                    timeout=timeout,
                 )
+            except requests.exceptions.RequestException as err:
+                LOG.warning(
+                    "Error communicating with %s at %s:%i, %r retry %i",
+                    self.service.device.name,
+                    session.host,
+                    session.port,
+                    err,
+                    attempt,
+                )
+                last_exception = err
+            else:
                 response_dict = {}
 
                 for response_item in list(
-                    list(et.fromstring(response.content))[0]
+                    list(et.fromstring(response.data))[0]
                 )[0]:
                     response_dict[response_item.tag] = response_item.text
                 return response_dict
-            except requests.exceptions.RequestException:
-                LOG.warning(
-                    "Error communicating with %s at %s:%i, retry %i",
-                    self._device.name,
-                    self._device.host,
-                    self._device.port,
-                    attempt,
-                )
 
-                if self._device.rediscovery_enabled:
-                    self._device.reconnect_with_device()
+            if self.service.device.rediscovery_enabled:
+                self.service.device.reconnect_with_device()
 
-        LOG.error(
-            "Error communicating with %s after %i attempts. Giving up.",
-            self._device.name,
-            MAX_RETRIES,
+        msg = (
+            f"Error communicating with {self.service.device.name} after "
+            f"{self.max_rediscovery_retries} attempts. Giving up."
         )
-
-        raise ActionException(
-            "Error communicating with {0} after {1} attempts. "
-            "Giving up.".format(self._device.name, MAX_RETRIES)
-        )
+        LOG.error(msg)
+        raise ActionException(msg) from last_exception
 
     def __repr__(self):
         """Return a string representation of the Action."""
@@ -105,39 +243,32 @@ class Action:
 class Service:
     """Representation of a service for a WeMo device."""
 
-    def __init__(self, device, service, base_url):
+    def __init__(self, device, service):
         """Create an instance of a Service."""
-        self._base_url = base_url.rstrip('/')
+        self.device = device
         self._config = service
-        self.name = self._config.get_serviceType().split(':')[-2]
+        self.name = self.serviceType.split(':')[-2]
         self.actions = {}
 
-        url = '%s/%s' % (base_url, service.get_SCPDURL().strip('/'))
-        xml = requests.get(url, timeout=REQUESTS_TIMEOUT)
-        if xml.status_code != 200:
-            return
+        xml = device.session.get(device.session.urljoin(service.get_SCPDURL()))
 
         self._svc_config = serviceParser.parseString(
-            xml.content, silence=True, print_warnings=False
+            xml.data, silence=True, print_warnings=False
         ).actionList
         for action in self._svc_config.get_action():
-            act = Action(device, self, action)
-            name = action.get_name()
-            self.actions[name] = act
-            setattr(self, name, act)
-
-    @property
-    def hostname(self):
-        """Get the hostname from the base URL."""
-        return self._base_url.split('/')[-1]
+            act = Action(self, action)
+            self.actions[act.name] = act
+            setattr(self, act.name, act)
 
     @property
     def controlURL(self):
         """Get the controlURL for interacting with this Service."""
-        return '%s/%s' % (
-            self._base_url,
-            self._config.get_controlURL().strip('/'),
-        )
+        return self.device.session.urljoin(self._config.get_controlURL())
+
+    @property
+    def eventSubURL(self):
+        """Get the eventSubURL for interacting with this Service."""
+        return self.device.session.urljoin(self._config.get_eventSubURL())
 
     @property
     def serviceType(self):

--- a/pywemo/ouimeaux_device/api/service.py
+++ b/pywemo/ouimeaux_device/api/service.py
@@ -165,7 +165,7 @@ class Action:
         "urn:Belkin:service:WiFiSetup:1#GetApList": 10,
     }
 
-    max_rediscovery_retries = 3
+    max_rediscovery_attempts = 3
 
     def __init__(self, service, action_config):
         """Create an instance of an Action."""
@@ -197,7 +197,7 @@ class Action:
         )
         last_exception = None
 
-        for attempt in range(self.max_rediscovery_retries):
+        for attempt in range(self.max_rediscovery_attempts):
             session = self.service.device.session
             try:
                 response = session.post(
@@ -230,7 +230,7 @@ class Action:
 
         msg = (
             f"Error communicating with {self.service.device.name} after "
-            f"{self.max_rediscovery_retries} attempts. Giving up."
+            f"{self.max_rediscovery_attempts} attempts. Giving up."
         )
         LOG.error(msg)
         raise ActionException(msg) from last_exception

--- a/tests/ouimeaux_device/api/unit/test_service.py
+++ b/tests/ouimeaux_device/api/unit/test_service.py
@@ -181,7 +181,7 @@ class TestAction:
         except svc.ActionException:
             pass
 
-        assert mock_request.call_count == svc.Action.max_rediscovery_retries
+        assert mock_request.call_count == svc.Action.max_rediscovery_attempts
 
     @mock.patch(
         'urllib3.PoolManager.request', side_effect=urllib3.exceptions.HTTPError

--- a/tests/ouimeaux_device/api/unit/test_service.py
+++ b/tests/ouimeaux_device/api/unit/test_service.py
@@ -4,11 +4,14 @@ import unittest.mock as mock
 
 import pytest
 import requests
+import urllib3
 from lxml import etree as et
 
 import pywemo.ouimeaux_device.api.service as svc
 
+BODY_KWARG_KEY = "body"
 HEADERS_KWARG_KEY = "headers"
+TIMEOUT_KWARG_KEY = "timeout"
 CONTENT_TYPE_KEY = "Content-Type"
 SOAPACTION_KEY = "SOAPACTION"
 
@@ -26,31 +29,87 @@ MOCK_RESPONSE = (
 )
 
 
+class TestSession:
+    """Test the Session class."""
+
+    def test_init_and_properties(self):
+        url = 'HTTP://1.2.3.4/setup/#'
+        session = svc.Session(url, retries=3, timeout=4)
+        assert session.url == 'http://1.2.3.4/setup/'
+        assert session.host == '1.2.3.4'
+        assert session.port == 80
+        assert session.retries == 3
+        assert session.timeout == 4
+
+        url = 'HTTP://5.6.7.8:9090/setup.xml'
+        orig = session.url = url
+        assert orig == url
+        assert session.url == 'http://5.6.7.8:9090/setup.xml'
+        assert session.host == '5.6.7.8'
+        assert session.port == 9090
+
+    @mock.patch('urllib3.PoolManager.request')
+    def test_404_raises(self, mock_request):
+        response = mock.Mock()
+        response.status = 404
+        mock_request.return_value = response
+
+        session = svc.Session('http://1.2.3.4')
+        with pytest.raises(requests.RequestException):
+            session.get('/')
+
+    @mock.patch(
+        'urllib3.PoolManager.request', side_effect=urllib3.exceptions.HTTPError
+    )
+    def test_urllib_raises_requests_exception(self, mock_request):
+        session = svc.Session('http://1.2.3.4')
+        with pytest.raises(requests.RequestException):
+            session.get('/')
+
+    @mock.patch('urllib3.PoolManager')
+    def test_arg_override(self, mock_poolmgr):
+        pool = mock.Mock()
+        mock_poolmgr.return_value.__enter__.return_value = pool
+        response = mock.Mock()
+        response.status = 200
+        pool.request.return_value = response
+
+        session = svc.Session('http://1.2.3.4')
+        session.get('/', retries=3, timeout=4)
+        mock_poolmgr.assert_called_once_with(retries=3, timeout=4)
+
+        mock_poolmgr.reset_mock()
+        session.post('/', retries=3, timeout=4)
+        mock_poolmgr.assert_called_once_with(retries=3, timeout=4)
+
+
 class TestAction:
     """Test class for actions."""
 
     @staticmethod
     def get_mock_action(name="", service_type="", url=""):
         device = mock.Mock()
+        device.session = svc.Session('http://192.168.1.100:53892/')
 
         service = mock.Mock()
+        service.device = device
         service.serviceType = service_type
         service.controlURL = url
 
         action_config = mock.MagicMock()
         action_config.get_name = lambda: name
 
-        return svc.Action(device, service, action_config)
+        return svc.Action(service, action_config)
 
-    @staticmethod
-    def get_et_mock():
+    @pytest.fixture(autouse=True)
+    def mock_et_fromstring(self):
         resp = et.fromstring(MOCK_RESPONSE)
-        return mock.MagicMock(return_value=resp)
+        with mock.patch('lxml.etree.fromstring', return_value=resp) as mocked:
+            yield mocked
 
     def test_call_post_request_is_made_exactly_once_when_successful(self):
         action = self.get_mock_action()
-        requests.post = post_mock = mock.Mock()
-        et.fromstring = self.get_et_mock()
+        action.service.device.session.post = post_mock = mock.Mock()
 
         action()
 
@@ -58,17 +117,16 @@ class TestAction:
 
     def test_call_request_has_well_formed_xml_body(self):
         action = self.get_mock_action(name="cool_name", service_type="service")
-        requests.post = post_mock = mock.Mock()
-        et.fromstring = self.get_et_mock()
+        action.service.device.session.post = post_mock = mock.Mock()
 
         action()
 
-        body = post_mock.call_args[MOCK_ARGS_ORDERED][1]
+        body = post_mock.call_args[MOCK_ARGS_KWARGS][BODY_KWARG_KEY]
         et.fromstring(body)  # will raise error if xml is malformed
 
     def test_call_request_has_correct_header_keys(self):
         action = self.get_mock_action()
-        requests.post = post_mock = mock.Mock()
+        action.service.device.session.post = post_mock = mock.Mock()
 
         action()
 
@@ -78,7 +136,7 @@ class TestAction:
 
     def test_call_headers_has_correct_content_type(self):
         action = self.get_mock_action()
-        requests.post = post_mock = mock.Mock()
+        action.service.device.session.post = post_mock = mock.Mock()
 
         action()
 
@@ -91,7 +149,7 @@ class TestAction:
         service_type = "some_service"
         name = "cool_name"
         action = self.get_mock_action(name, service_type)
-        requests.post = post_mock = mock.Mock()
+        action.service.device.session.post = post_mock = mock.Mock()
 
         action()
 
@@ -103,38 +161,42 @@ class TestAction:
     def test_call_headers_has_correct_url(self):
         url = "http://www.github.com/"
         action = self.get_mock_action(url=url)
-        requests.post = post_mock = mock.Mock()
+        action.service.device.session.post = post_mock = mock.Mock()
 
         action()
 
         actual_url = post_mock.call_args[MOCK_ARGS_ORDERED][0]
         assert actual_url == url
 
-    def test_call_request_is_tried_up_to_max_on_communication_error(self):
+    @mock.patch(
+        'urllib3.PoolManager.request', side_effect=urllib3.exceptions.HTTPError
+    )
+    def test_call_request_is_tried_up_to_max_on_communication_error(
+        self, mock_request
+    ):
         action = self.get_mock_action()
-        requests.post = post_mock = mock.Mock(
-            side_effect=requests.exceptions.RequestException
-        )
 
         try:
             action()
         except svc.ActionException:
             pass
 
-        assert post_mock.call_count == svc.MAX_RETRIES
+        assert mock_request.call_count == svc.Action.max_rediscovery_retries
 
-    def test_call_throws_when_final_retry_fails(self):
+    @mock.patch(
+        'urllib3.PoolManager.request', side_effect=urllib3.exceptions.HTTPError
+    )
+    def test_call_throws_when_final_retry_fails(self, mock_request):
         action = self.get_mock_action()
-        requests.post = mock.Mock(
-            side_effect=requests.exceptions.RequestException
-        )
 
         with pytest.raises(svc.ActionException):
             action()
 
-    def test_call_returns_correct_dictionary_with_response_contents(self):
+    def test_call_returns_correct_dictionary_with_response_contents(
+        self, mock_et_fromstring
+    ):
         action = self.get_mock_action()
-        requests.post = mock.Mock()
+        action.service.device.session.post = mock.Mock()
 
         envelope = et.Element("soapEnvelope")
         body = et.SubElement(envelope, "soapBody")
@@ -150,8 +212,23 @@ class TestAction:
             element = et.SubElement(response, key)
             element.text = value
 
-        et.fromstring = mock.MagicMock(return_value=envelope)
+        mock_et_fromstring.return_value = envelope
 
         actual_responses = action()
 
         assert actual_responses == response_content
+
+    def test_call_with_overridden_timeout(self):
+        action = self.get_mock_action(
+            name="OpenNetwork", service_type="urn:Belkin:service:bridge:1"
+        )
+        action.service.device.session.post = post_mock = mock.Mock()
+
+        action()
+        timeout = post_mock.call_args[MOCK_ARGS_KWARGS][TIMEOUT_KWARG_KEY]
+        assert timeout == 30
+
+        post_mock.reset_mock()
+        action(pywemo_timeout=40)
+        timeout = post_mock.call_args[MOCK_ARGS_KWARGS][TIMEOUT_KWARG_KEY]
+        assert timeout == 40

--- a/tests/test_subscribe.py
+++ b/tests/test_subscribe.py
@@ -370,7 +370,7 @@ class Test_SubscriptionRegistry:
         with mock.patch.object(device, 'reconnect_with_device') as reconnect:
 
             def change_url():
-                device.basicevent.eventSubURL = 'http://192.168.1.100:1234/'
+                device.session.url = 'http://192.168.1.100:1234/'
 
             reconnect.side_effect = change_url
 
@@ -383,7 +383,7 @@ class Test_SubscriptionRegistry:
 
         mock_request.assert_called_with(
             method='SUBSCRIBE',
-            url='http://192.168.1.100:1234/',
+            url='http://192.168.1.100:1234/upnp/event/basicevent1',
             headers=mock.ANY,
             timeout=10,
         )


### PR DESCRIPTION
## Description: 

Add retries for individual SOAP actions.

WeMo devices with weak wifi connections often get stuck in the unavailable state in Home Assistant for a few minutes at a time. The main cause for this is because the Device enters probing/rediscovery as soon as a SOAP action request fails.

**Before**
The graph shows the number of times the pywemo library timed-out waiting for the WeMo device to respond over a 10 minute period. Each color represents a different device.
![Screenshot 2021-02-08 1 38 33 PM](https://user-images.githubusercontent.com/289218/107284641-f5c1b380-6a12-11eb-904f-b147b1fe627b.png)

And this graph shows the amount of time spent attempting to reconnect to the device when the SOAP action has a timeout. (Gaps in the graph are periods of time where no reconnects happened)
![Screenshot 2021-02-11 1 47 59 PM](https://user-images.githubusercontent.com/289218/107702951-d5426500-6c6f-11eb-8c39-308db9d517af.png)

**After**
This PR adds 6 retries to the SOAP actions. These retries happen before attempting to reconnect, allowing the action to complete in the majority of cases without triggering a reconnection.

With this PR, the SOAP action completes most of the time. As with the previous graph the colors in this one represent individual devices. Only [one device](https://github.com/home-assistant/core/issues/45904#issuecomment-778912833) on my wifi still has issues now.
![Screenshot 2021-02-15 at 8 32 41 AM](https://user-images.githubusercontent.com/289218/107972239-682d1900-6f68-11eb-9c63-cf623de18dce.png)

And in 99 percentile of the cases, including the one flaky device, the request completes in less than 5 seconds, occasionally requiring 1 retry. (The median over this same period is about 0.11 seconds.)
![Screenshot 2021-02-15 at 8 34 57 AM](https://user-images.githubusercontent.com/289218/107972520-d1149100-6f68-11eb-8ef7-4f423afa042d.png)

There are a few SOAP actions that are intended to take longer than the default timeout. I've added a separate timeout for those to allow them to still work correctly (see: `Action.soap_action_timeout_override`). I've also added a `pywemo_timeout` kwarg to allow clients to override the timeouts on individual requests. [I would have found this helpful when initially setting up my Bridge device]

In addition to retrying the SOAP actions, this PR also causes the Device description request for /setup.xml to be retried as well as retrying the fetch of all the service description xml files too.

Note that the urllib3 dependency is not new. The requests library was already depending on it. I simply copied the version requirements from the requests library and added urllib3 to pyproject.toml. 

I described in the comments for the `Session` class why urllib3 is being used. The requests library sets [`preload_content=False`](https://github.com/psf/requests/search?q=preload_content), making the fetch of the body/content happen outside of the urllib3 retries logic. Because of this, there doesn't appear to be any way to have the requests library automatically retry when the fetch of the body times-out. An alternative could be to re-implement the urllib3 retry logic in pywemo, but I'm choosing to re-use rather than re-implement.

Finally, after this PR the URL/host/port are all contained in a single location inside the `Session` instance. All other uses of the URL/host/port reference it from that single location. This makes it possible for the reconnection logic to update the device location by just setting `device.session.url`. After this PR, and #238, are merged I'll send another PR to just update `self.session.url`, rather than creating a new device and replacing the inner `self.__dict__` of properties. There is a test case for this in test_subscribe.py.

**Related issue (if applicable):** https://github.com/home-assistant/core/issues/45904

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] There is no commented out code in this PR.