### PR TITLE
Combine all pyWeMo exceptions in a single file

### DIFF
--- a/pywemo/__init__.py
+++ b/pywemo/__init__.py
@@ -1,15 +1,16 @@
 """Lightweight Python module to discover and control WeMo devices."""
+# flake8: noqa F401
 
-from .discovery import discover_devices  # noqa F401
-from .discovery import setup_url_for_address  # noqa F401
-from .ouimeaux_device import Device as WeMoDevice  # noqa F401
-from .ouimeaux_device.bridge import Bridge  # noqa F401
-from .ouimeaux_device.coffeemaker import CoffeeMaker  # noqa F401
-from .ouimeaux_device.dimmer import Dimmer  # noqa F401
-from .ouimeaux_device.humidifier import Humidifier  # noqa F401
-from .ouimeaux_device.insight import Insight  # noqa F401
-from .ouimeaux_device.lightswitch import LightSwitch  # noqa F401
-from .ouimeaux_device.maker import Maker  # noqa F401
-from .ouimeaux_device.motion import Motion  # noqa F401
-from .ouimeaux_device.switch import Switch  # noqa F401
-from .subscribe import SubscriptionRegistry  # noqa F401
+from .discovery import discover_devices, setup_url_for_address
+from .exceptions import PyWeMoException
+from .ouimeaux_device import Device as WeMoDevice
+from .ouimeaux_device.bridge import Bridge
+from .ouimeaux_device.coffeemaker import CoffeeMaker
+from .ouimeaux_device.dimmer import Dimmer
+from .ouimeaux_device.humidifier import Humidifier
+from .ouimeaux_device.insight import Insight
+from .ouimeaux_device.lightswitch import LightSwitch
+from .ouimeaux_device.maker import Maker
+from .ouimeaux_device.motion import Motion
+from .ouimeaux_device.switch import Switch
+from .subscribe import SubscriptionRegistry

--- a/pywemo/exceptions.py
+++ b/pywemo/exceptions.py
@@ -1,0 +1,33 @@
+"""Exceptions raised by pywemo."""
+
+
+class PyWeMoException(Exception):
+    """Base exception class for pyWeMo exceptions."""
+
+
+class ActionException(PyWeMoException):
+    """Generic exceptions when dealing with SOAP request Actions."""
+
+
+class SubscriptionRegistryFailed(PyWeMoException):
+    """General exceptions related to the subscription registry."""
+
+
+class UnknownService(PyWeMoException):
+    """Exception raised when a non-existent service is called."""
+
+
+class ResetException(PyWeMoException):
+    """Exception raised when reset fails."""
+
+
+class SetupException(PyWeMoException):
+    """Exception raised when setup fails."""
+
+
+class APNotFound(SetupException):
+    """Exception raised when the AP requested is not found."""
+
+
+class ShortPassword(SetupException):
+    """Exception raised when a password is too short (<8 characters)."""

--- a/pywemo/ouimeaux_device/__init__.py
+++ b/pywemo/ouimeaux_device/__init__.py
@@ -8,6 +8,13 @@ import warnings
 
 import requests
 
+from ..exceptions import (
+    APNotFound,
+    ResetException,
+    SetupException,
+    ShortPassword,
+    UnknownService,
+)
 from .api.long_press import LongPressMixin
 from .api.service import REQUESTS_TIMEOUT, ActionException, Service, Session
 from .api.xsd import device as deviceParser
@@ -64,36 +71,6 @@ def probe_device(device):
     ports.insert(0, device.port)
 
     return probe_wemo(device.host, ports)
-
-
-class UnknownService(Exception):
-    """Exception raised when a non-existent service is called."""
-
-    pass
-
-
-class ResetException(Exception):
-    """Exception raised when reset fails."""
-
-    pass
-
-
-class SetupException(Exception):
-    """Exception raised when setup fails."""
-
-    pass
-
-
-class APNotFound(SetupException):
-    """Exception raised when the AP requested is not found."""
-
-    pass
-
-
-class ShortPassword(SetupException):
-    """Exception raised when a password is too short (<8 characters)."""
-
-    pass
 
 
 class Device:

--- a/pywemo/ouimeaux_device/api/service.py
+++ b/pywemo/ouimeaux_device/api/service.py
@@ -7,6 +7,8 @@ import requests
 import urllib3
 from lxml import etree as et
 
+from pywemo.exceptions import ActionException
+
 from .xsd import service as serviceParser
 
 LOG = logging.getLogger(__name__)
@@ -22,12 +24,6 @@ REQUEST_TEMPLATE = """
 </s:Body>
 </s:Envelope>
 """
-
-
-class ActionException(Exception):
-    """Generic exceptions when dealing with Actions."""
-
-    pass
 
 
 class Session:

--- a/pywemo/subscribe.py
+++ b/pywemo/subscribe.py
@@ -10,6 +10,7 @@ from typing import Dict, Iterable, List, Optional
 import requests
 from lxml import etree as et
 
+from .exceptions import SubscriptionRegistryFailed
 from .ouimeaux_device import Device
 from .ouimeaux_device.api.long_press import VIRTUAL_DEVICE_UDN
 from .ouimeaux_device.api.service import REQUESTS_TIMEOUT
@@ -56,10 +57,6 @@ VIRTUAL_SETUP_XML = f"""<?xml version="1.0"?>
     </serviceList>
 </device>
 </root>"""
-
-
-class SubscriptionRegistryFailed(Exception):
-    """General exceptions related to the subscription registry."""
 
 
 class Subscription:


### PR DESCRIPTION
## Description:

Make it easier for clients handle exceptions by allowing them to be imported from one location.

```python
try:
    device.on()
except pywemo.PyWeMoException:
    pass
```

or

```python
try:
    device.on()
except pywemo.exceptions.ActionException:
    pass
```


## Checklist:
  - [x] The code change is tested and works locally.
  - [x] There is no commented out code in this PR.