### PR TITLE
Clients can use HTTPException

### DIFF
--- a/pywemo/exceptions.py
+++ b/pywemo/exceptions.py
@@ -31,3 +31,7 @@ class APNotFound(SetupException):
 
 class ShortPassword(SetupException):
     """Exception raised when a password is too short (<8 characters)."""
+
+
+class HTTPException(PyWeMoException):
+    """HTTP request to the device failed."""

--- a/pywemo/ouimeaux_device/__init__.py
+++ b/pywemo/ouimeaux_device/__init__.py
@@ -10,6 +10,7 @@ import warnings
 import requests
 
 from ..exceptions import (
+    ActionException,
     APNotFound,
     ResetException,
     SetupException,
@@ -17,7 +18,7 @@ from ..exceptions import (
     UnknownService,
 )
 from .api.long_press import LongPressMixin
-from .api.service import REQUESTS_TIMEOUT, ActionException, Service, Session
+from .api.service import REQUESTS_TIMEOUT, Service, Session
 from .api.xsd import device as deviceParser
 
 LOG = logging.getLogger(__name__)

--- a/pywemo/ouimeaux_device/api/rules_db.py
+++ b/pywemo/ouimeaux_device/api/rules_db.py
@@ -10,10 +10,7 @@ import zipfile
 from types import MappingProxyType
 from typing import FrozenSet, List, Mapping, Optional, Tuple
 
-import requests
-
 from .db_orm import DatabaseRow, PrimaryKey, SQLType
-from .service import REQUESTS_TIMEOUT
 
 LOG = logging.getLogger(__name__)
 
@@ -370,13 +367,13 @@ def rules_db_from_device(device) -> RulesDb:
     fetch = device.rules.FetchRules()
     version = int(fetch["ruleDbVersion"])
     rule_db_url = fetch["ruleDbPath"]
-    response = requests.get(rule_db_url, timeout=REQUESTS_TIMEOUT)
+    response = device.session.get(rule_db_url)
 
     with tempfile.NamedTemporaryFile(
         prefix="wemorules", suffix=".db"
     ) as temp_db_file:
         # Create a new db, or extract the current db.
-        if response.status_code != 200:
+        if response.status != 200:
             db_file_name = _create_empty_db(temp_db_file.name)
         else:
             db_file_name = _unpack_db(response.content, temp_db_file)

--- a/tests/ouimeaux_device/api/unit/test_service.py
+++ b/tests/ouimeaux_device/api/unit/test_service.py
@@ -3,11 +3,11 @@
 import unittest.mock as mock
 
 import pytest
-import requests
 import urllib3
 from lxml import etree as et
 
 import pywemo.ouimeaux_device.api.service as svc
+from pywemo.exceptions import HTTPException
 
 BODY_KWARG_KEY = "body"
 HEADERS_KWARG_KEY = "headers"
@@ -55,15 +55,15 @@ class TestSession:
         mock_request.return_value = response
 
         session = svc.Session('http://1.2.3.4')
-        with pytest.raises(requests.RequestException):
+        with pytest.raises(HTTPException):
             session.get('/')
 
     @mock.patch(
         'urllib3.PoolManager.request', side_effect=urllib3.exceptions.HTTPError
     )
-    def test_urllib_raises_requests_exception(self, mock_request):
+    def test_urllib_raises_http_exception(self, mock_request):
         session = svc.Session('http://1.2.3.4')
-        with pytest.raises(requests.RequestException):
+        with pytest.raises(HTTPException):
             session.get('/')
 
     @mock.patch('urllib3.PoolManager')


### PR DESCRIPTION
## Description:

pyWeMo clients shouldn't need to know the library used to make http requests to be able to handle exceptions. This PR adds a `pywemo.exceptions.HTTPException` that is raised any time a client visible http request fails. This allows clients to interact with the library and expect all exceptions will map to the top-level `pywemo.PyWeMoException`.

```python
try:
    device = pywemo.discovery.device_from_description(url)
except pywemo.PyWeMoException:
    pass
```

I only added this exception in places where the exception is visible to the client. The exceptions in `subscribe.py`, for example, are only visible internally in pyWeMo.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] There is no commented out code in this PR.