### PR TITLE
Add per-instance UPNPEntry cache for description property

### DIFF
--- a/pywemo/ssdp.py
+++ b/pywemo/ssdp.py
@@ -212,11 +212,7 @@ class UPNPEntry:
 
         Values should only contain lowercase keys.
         """
-        device = self.description.get('device')
-
-        if device is None:
-            return False
-
+        device = self.description.get('device', {})
         return all(val == device.get(key) for key, val in values.items())
 
     @classmethod

--- a/pywemo/ssdp.py
+++ b/pywemo/ssdp.py
@@ -212,9 +212,6 @@ class UPNPEntry:
 
         Values should only contain lowercase keys.
         """
-        if self.description is None:
-            return False
-
         device = self.description.get('device')
 
         if device is None:


### PR DESCRIPTION
## Description:

The `UPNPEntry.description` property gets accessed multiple times as part of discovery. It ends up fetching /setup.xml each time it is accessed. There was a module-wide `DESCRIPTION_CACHE` that was removed in #238 that prevented this. I don't think a module wide cache is needed, but this PR adds a per-instance cache to avoid loading /setup.xml multiple times for the same device.

Example where `UPNPEntry.description` is accessed twice:
https://github.com/pavoni/pywemo/blob/dbc5855fcea6ca82168517966dcdc3f040381f76/pywemo/ssdp.py#L204-L207

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] There is no commented out code in this PR.