### PR TITLE
Reconfirm the initial event is received when a renewal fails

### DIFF
--- a/pywemo/subscribe.py
+++ b/pywemo/subscribe.py
@@ -190,7 +190,10 @@ class Subscription:
         self.subscription_id = headers.get('SID', self.subscription_id)
         timeout_header = headers.get('TIMEOUT', None)
         if timeout_header:
-            timeout = int(timeout_header.replace('Second-', ''))
+            timeout = min(
+                int(timeout_header.replace('Second-', '')),
+                self.default_timeout_seconds,
+            )
         else:
             timeout = self.default_timeout_seconds
         self.expiration_time = timeout + time.time()

--- a/pywemo/subscribe.py
+++ b/pywemo/subscribe.py
@@ -124,6 +124,19 @@ class Subscription:
                 # invalid. Send an UNSUBSCRIBE for safety and then attempt to
                 # subscribe again.
                 self._unsubscribe()
+
+                # Also reset the `event_received` boolean at this point. A 412
+                # response code to a subscription renewal also happens when a
+                # device restarts. When a device loses power and power is
+                # restored it's possible that the device's state has changed.
+                # We need to reconfirm that the initial event is received again
+                # so that the device state is reported properly. And for
+                # devices that don't report their initial state, it's important
+                # that clients are aware that they should begin polling the
+                # device again.
+                self.event_received = False
+
+                # Try the subscription again.
                 response = self._subscribe()
             response.raise_for_status()
         except requests.RequestException:

--- a/tests/test_subscribe.py
+++ b/tests/test_subscribe.py
@@ -191,14 +191,14 @@ class Test_Subscription:
     @mock.patch('requests.request')
     def test_maintain(self, mock_request, subscription):
         mock_response = mock.create_autospec(requests.Response, instance=True)
-        mock_response.headers = {'SID': 'uuid:123', 'TIMEOUT': 'Second-567'}
+        mock_response.headers = {'SID': 'uuid:123', 'TIMEOUT': 'Second-222'}
         mock_response.status_code = requests.codes.ok
         mock_request.return_value = mock_response
 
-        assert subscription.maintain() == 567
+        assert subscription.maintain() == 222
         assert subscription.subscription_id == 'uuid:123'
         assert subscription.expiration_time == pytest.approx(
-            time.time() + 567, abs=2
+            time.time() + 222, abs=2
         )
         mock_request.assert_called_once_with(
             method='SUBSCRIBE',
@@ -217,10 +217,10 @@ class Test_Subscription:
         mock_response.status_code = requests.codes.ok
         mock_request.return_value = mock_response
 
-        assert subscription.maintain() == 765
+        assert subscription.maintain() == 300
         assert subscription.subscription_id == 'uuid:321'
         assert subscription.expiration_time == pytest.approx(
-            time.time() + 765, abs=2
+            time.time() + 300, abs=2
         )
         mock_request.assert_called_once_with(
             method='SUBSCRIBE',
@@ -238,10 +238,10 @@ class Test_Subscription:
         )
         mock_request.return_value = mock_response
 
-        assert subscription.maintain() == 333
+        assert subscription.maintain() == 300
         assert subscription.subscription_id == 'uuid:222'
         assert subscription.expiration_time == pytest.approx(
-            time.time() + 333, abs=2
+            time.time() + 300, abs=2
         )
         mock_request.assert_any_call(
             method='SUBSCRIBE',


### PR DESCRIPTION
## Description:

When a subscription renewal fails, it could indicate that the device has restarted. In that case it's important that the current device state be retrieved again. The initial state can be gotten by either by receiving the initial subscription event notification when the subscription is re-established, or by informing the pywemo client that the device is no longer subscribed and thus should begin polling.

This was caught as a potential edge case by @bdraco in https://github.com/home-assistant/core/pull/46806

Tested with this script:

```python
import logging
import time

import pywemo


def _cb(_device, _type, _params):
    logging.info('%s %s %s', _device.name, _type, _params)


logging.basicConfig(level=logging.DEBUG)
sub = pywemo.SubscriptionRegistry()
sub.start()

# Cheat to speed things up.
pywemo.subscribe.Subscription.default_timeout_seconds = 60

# Device named "Test Dimmer"
non_rtos = pywemo.discovery.device_from_description(
    pywemo.discovery.setup_url_for_address('IP_OF_TEST_DIMMER', 0)
)
sub.register(non_rtos)
sub.on(non_rtos, None, _cb)

# Device named "Holiday"
rtos = pywemo.discovery.device_from_description(
    pywemo.discovery.setup_url_for_address('IP_OF_HOLIDAY', 0)
)
sub.register(rtos)
sub.on(rtos, None, _cb)


try:
    time.sleep(5)
    logging.info('Ready')
    while True:
        if not sub.is_subscribed(non_rtos):
            logging.info('%r is not subscribed', non_rtos)
        if not sub.is_subscribed(rtos):
            logging.info('%r is not subscribed', rtos)
        time.sleep(1)
finally:
    sub.unregister(rtos)
    sub.unregister(non_rtos)
    logging.info('Shutting down')
    sub.stop()
```

The output was as expected:

```
INFO:root:Ready

## Holiday is an RTOS device that does not report it's state on SUBSCRIBE
INFO:root:<WeMo Switch "Holiday"> is not subscribed
INFO:root:<WeMo Switch "Holiday"> is not subscribed
... continues with the last log repeating

## I manually operate Holiday
INFO:pywemo.subscribe:Received /sub/basicevent event from <WeMo Switch "Holiday">(IP_OF_HOLIDAY) - BinaryState 1
INFO:root:Holiday BinaryState 1
INFO:pywemo.subscribe:Received /sub/basicevent event from <WeMo Switch "Holiday">(IP_OF_HOLIDAY) - BinaryState 0
INFO:root:Holiday BinaryState 0

## No more "<WeMo Switch "Holiday"> is not subscribed

## I unplug and reconnect both devices. "Holiday" reboots faster than "Test Dimmer" and the "Test Dimmer" subscription times-out.
INFO:pywemo.subscribe:Resubscribe for <Subscription basicevent "Test Dimmer">
DEBUG:urllib3.connectionpool:Starting new HTTP connection (1): IP_OF_TEST_DIMMER:49153
WARNING:pywemo.subscribe:Resubscribe error for <Subscription basicevent "Test Dimmer"> (HTTPConnectionPool(host='IP_OF_TEST_DIMMER', port=49153): Max retries exceeded with url: /upnp/event/basicevent1 (Caused by ConnectTimeoutError(<urllib3.connection.HTTPConnection object at 0x7f56b8306df0>, 'Connection to IP_OF_TEST_DIMMER timed out. (connect timeout=10)'))), will retry in 60s

## pywemo detects that the "Holiday" subscription has been lost and resets event_received
INFO:pywemo.subscribe:Resubscribe for <Subscription basicevent "Holiday">
DEBUG:urllib3.connectionpool:Starting new HTTP connection (1): IP_OF_HOLIDAY:49152
DEBUG:urllib3.connectionpool:http://IP_OF_HOLIDAY:49152 "SUBSCRIBE /upnp/event/basicevent1 HTTP/1.1" 412 None
DEBUG:urllib3.connectionpool:Starting new HTTP connection (1): IP_OF_HOLIDAY:49152
DEBUG:urllib3.connectionpool:http://IP_OF_HOLIDAY:49152 "UNSUBSCRIBE /upnp/event/basicevent1 HTTP/1.1" 200 None
DEBUG:urllib3.connectionpool:Starting new HTTP connection (1): IP_OF_HOLIDAY:49152
DEBUG:urllib3.connectionpool:http://IP_OF_HOLIDAY:49152 "SUBSCRIBE /upnp/event/basicevent1 HTTP/1.1" 200 0
INFO:root:<WeMo Dimmer "Test Dimmer"> is not subscribed
INFO:root:<WeMo Switch "Holiday"> is not subscribed
... continues with these two repeating

## "Test Dimmer" finished booting. New subscription is created and device state is received.
INFO:pywemo.subscribe:Resubscribe for <Subscription basicevent "Test Dimmer">
DEBUG:urllib3.connectionpool:Starting new HTTP connection (1): IP_OF_TEST_DIMMER:49153
DEBUG:urllib3.connectionpool:http://IP_OF_TEST_DIMMER:49153 "SUBSCRIBE /upnp/event/basicevent1 HTTP/1.1" 200 0
INFO:pywemo.subscribe:Received /sub/basicevent event from <WeMo Dimmer "Test Dimmer">(IP_OF_TEST_DIMMER) - BinaryState 0
INFO:root:Test Dimmer BinaryState 0
INFO:root:<WeMo Switch "Holiday"> is not subscribed
INFO:root:<WeMo Switch "Holiday"> is not subscribed
.... continues repeating last message

# Manually operate "Holiday" again
INFO:pywemo.subscribe:Received /sub/basicevent event from <WeMo Switch "Holiday">(IP_OF_HOLIDAY) - BinaryState 1
INFO:root:Holiday BinaryState 1
INFO:pywemo.subscribe:Received /sub/basicevent event from <WeMo Switch "Holiday">(IP_OF_HOLIDAY) - BinaryState 0
INFO:root:Holiday BinaryState 0
## No more "<WeMo Switch "Holiday"> is not subscribed


## Pressing Ctrl-c to exit
^CINFO:pywemo.subscribe:Unsubscribing to events from <WeMo Switch "Holiday">
INFO:pywemo.subscribe:Unsubscribing to events from <WeMo Dimmer "Test Dimmer">
INFO:root:Shutting down
INFO:pywemo.subscribe:Terminated threads
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] There is no commented out code in this PR.