### PR TITLE
add pre-commit and some hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,49 @@
+fail_fast: true
+repos:
+  - repo: local
+    hooks:
+      - id: poetry-check
+        name: poetry-check
+        language: system
+        entry: poetry check
+        pass_filenames: false
+        types: [file]
+        files: ^(pyproject.toml|poetry.lock)$
+
+      - id: isort
+        name: isort
+        language: system
+        entry: poetry run isort
+        args: ['--check-only', '--filter-files']
+        require_serial: true
+        types_or: [cython, pyi, python]
+
+      - id: black
+        name: black
+        language: system
+        entry: poetry run black
+        args: ['--check']
+        require_serial: true
+        types_or: [python, pyi]
+
+      - id: flake8
+        name: flake8
+        language: system
+        entry: poetry run flake8
+        require_serial: true
+        types: [python]
+
+      - id: pylint
+        name: pylint
+        language: system
+        entry: poetry run pylint
+        args: ['--disable=fixme']
+        require_serial: true
+        types: [python]
+        exclude: tests/
+
+      - id: rstcheck
+        name: rstcheck
+        language: system
+        entry: poetry run rstcheck
+        types: [rst]

--- a/poetry.lock
+++ b/poetry.lock
@@ -72,6 +72,14 @@ optional = false
 python-versions = "*"
 
 [[package]]
+name = "cfgv"
+version = "3.2.0"
+description = "Validate configuration and produce human readable error messages."
+category = "dev"
+optional = false
+python-versions = ">=3.6.1"
+
+[[package]]
 name = "chardet"
 version = "4.0.0"
 description = "Universal encoding detector for Python 2 and 3"
@@ -123,6 +131,14 @@ requests = ">=1.0.0"
 yaml = ["PyYAML (>=3.10)"]
 
 [[package]]
+name = "distlib"
+version = "0.3.1"
+description = "Distribution utilities"
+category = "dev"
+optional = false
+python-versions = "*"
+
+[[package]]
 name = "docopt"
 version = "0.6.2"
 description = "Pythonic argument parser, that will make you smile"
@@ -137,6 +153,14 @@ description = "Docutils -- Python Documentation Utilities"
 category = "dev"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+
+[[package]]
+name = "filelock"
+version = "3.0.12"
+description = "A platform independent file lock."
+category = "dev"
+optional = false
+python-versions = "*"
 
 [[package]]
 name = "flake8"
@@ -191,6 +215,17 @@ python-versions = "*"
 lxml = "*"
 requests = ">=2.21.0"
 six = "*"
+
+[[package]]
+name = "identify"
+version = "1.5.13"
+description = "File identification library for Python"
+category = "dev"
+optional = false
+python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,>=2.7"
+
+[package.extras]
+license = ["editdistance"]
 
 [[package]]
 name = "idna"
@@ -308,6 +343,14 @@ optional = false
 python-versions = "*"
 
 [[package]]
+name = "nodeenv"
+version = "1.5.0"
+description = "Node.js virtual environment builder"
+category = "dev"
+optional = false
+python-versions = "*"
+
+[[package]]
 name = "packaging"
 version = "20.9"
 description = "Core utilities for Python packages"
@@ -339,6 +382,23 @@ importlib-metadata = {version = ">=0.12", markers = "python_version < \"3.8\""}
 
 [package.extras]
 dev = ["pre-commit", "tox"]
+
+[[package]]
+name = "pre-commit"
+version = "2.10.1"
+description = "A framework for managing and maintaining multi-language pre-commit hooks."
+category = "dev"
+optional = false
+python-versions = ">=3.6.1"
+
+[package.dependencies]
+cfgv = ">=2.0.0"
+identify = ">=1.0.0"
+importlib-metadata = {version = "*", markers = "python_version < \"3.8\""}
+nodeenv = ">=0.11.1"
+pyyaml = ">=5.1"
+toml = "*"
+virtualenv = ">=20.0.8"
 
 [[package]]
 name = "py"
@@ -545,6 +605,25 @@ wrapt = "*"
 yarl = {version = "*", markers = "python_version >= \"3.6\""}
 
 [[package]]
+name = "virtualenv"
+version = "20.4.2"
+description = "Virtual Python Environment builder"
+category = "dev"
+optional = false
+python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,>=2.7"
+
+[package.dependencies]
+appdirs = ">=1.4.3,<2"
+distlib = ">=0.3.1,<1"
+filelock = ">=3.0.0,<4"
+importlib-metadata = {version = ">=0.12", markers = "python_version < \"3.8\""}
+six = ">=1.9.0,<2"
+
+[package.extras]
+docs = ["proselint (>=0.10.2)", "sphinx (>=3)", "sphinx-argparse (>=0.2.5)", "sphinx-rtd-theme (>=0.4.3)", "towncrier (>=19.9.0rc1)"]
+testing = ["coverage (>=4)", "coverage-enable-subprocess (>=1)", "flaky (>=3)", "pytest (>=4)", "pytest-env (>=0.6.2)", "pytest-freezegun (>=0.4.1)", "pytest-mock (>=2)", "pytest-randomly (>=1)", "pytest-timeout (>=1)", "packaging (>=20.0)", "xonsh (>=0.9.16)"]
+
+[[package]]
 name = "wrapt"
 version = "1.12.1"
 description = "Module for decorators, wrappers and monkey patching."
@@ -580,7 +659,7 @@ testing = ["pytest (>=3.5,!=3.7.3)", "pytest-checkdocs (>=1.2.3)", "pytest-flake
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7"
-content-hash = "56332fcd66bcd4f765c769fc79b0c46a427a6b9a727b0c6701f1bb7f29589a87"
+content-hash = "51ffe5aafc1c48bc104d3b4c43fba7808a8df4831a02e3ebfa18927761621105"
 
 [metadata.files]
 appdirs = [
@@ -605,6 +684,10 @@ black = [
 certifi = [
     {file = "certifi-2020.12.5-py2.py3-none-any.whl", hash = "sha256:719a74fb9e33b9bd44cc7f3a8d94bc35e4049deebe19ba7d8e108280cfd59830"},
     {file = "certifi-2020.12.5.tar.gz", hash = "sha256:1a4995114262bffbc2413b159f2a1a480c969de6e6eb13ee966d470af86af59c"},
+]
+cfgv = [
+    {file = "cfgv-3.2.0-py2.py3-none-any.whl", hash = "sha256:32e43d604bbe7896fe7c248a9c2276447dbef840feb28fe20494f62af110211d"},
+    {file = "cfgv-3.2.0.tar.gz", hash = "sha256:cf22deb93d4bcf92f345a5c3cd39d3d41d6340adc60c78bbbd6588c384fda6a1"},
 ]
 chardet = [
     {file = "chardet-4.0.0-py2.py3-none-any.whl", hash = "sha256:f864054d66fd9118f2e67044ac8981a54775ec5b67aed0441892edb553d21da5"},
@@ -673,12 +756,20 @@ coveralls = [
     {file = "coveralls-3.0.0-py2.py3-none-any.whl", hash = "sha256:f8384968c57dee4b7133ae701ecdad88e85e30597d496dcba0d7fbb470dca41f"},
     {file = "coveralls-3.0.0.tar.gz", hash = "sha256:5399c0565ab822a70a477f7031f6c88a9dd196b3de2877b3facb43b51bd13434"},
 ]
+distlib = [
+    {file = "distlib-0.3.1-py2.py3-none-any.whl", hash = "sha256:8c09de2c67b3e7deef7184574fc060ab8a793e7adbb183d942c389c8b13c52fb"},
+    {file = "distlib-0.3.1.zip", hash = "sha256:edf6116872c863e1aa9d5bb7cb5e05a022c519a4594dc703843343a9ddd9bff1"},
+]
 docopt = [
     {file = "docopt-0.6.2.tar.gz", hash = "sha256:49b3a825280bd66b3aa83585ef59c4a8c82f2c8a522dbe754a8bc8d08c85c491"},
 ]
 docutils = [
     {file = "docutils-0.16-py2.py3-none-any.whl", hash = "sha256:0c5b78adfbf7762415433f5515cd5c9e762339e23369dbe8000d84a4bf4ab3af"},
     {file = "docutils-0.16.tar.gz", hash = "sha256:c2de3a60e9e7d07be26b7f2b00ca0309c207e06c100f9cc2a94931fc75a478fc"},
+]
+filelock = [
+    {file = "filelock-3.0.12-py3-none-any.whl", hash = "sha256:929b7d63ec5b7d6b71b0fa5ac14e030b3f70b75747cef1b10da9b879fef15836"},
+    {file = "filelock-3.0.12.tar.gz", hash = "sha256:18d82244ee114f543149c66a6e0c14e9c4f8a1044b5cdaadd0f82159d6a6ff59"},
 ]
 flake8 = [
     {file = "flake8-3.8.4-py2.py3-none-any.whl", hash = "sha256:749dbbd6bfd0cf1318af27bf97a14e28e5ff548ef8e5b1566ccfb25a11e7c839"},
@@ -695,6 +786,10 @@ flake8-docstrings = [
 generateds = [
     {file = "generateDS-2.37.11-py3.8.egg", hash = "sha256:4a596a6e9ef7dca862d64422b09a001f329ed95c47fe5632be58173207c33089"},
     {file = "generateDS-2.37.11.tar.gz", hash = "sha256:bfd10f0e53b105ec7f7869edb97e4602e6063e735f36b63f094887725f88eebc"},
+]
+identify = [
+    {file = "identify-1.5.13-py2.py3-none-any.whl", hash = "sha256:9dfb63a2e871b807e3ba62f029813552a24b5289504f5b071dea9b041aee9fe4"},
+    {file = "identify-1.5.13.tar.gz", hash = "sha256:70b638cf4743f33042bebb3b51e25261a0a10e80f978739f17e7fd4837664a66"},
 ]
 idna = [
     {file = "idna-2.10-py2.py3-none-any.whl", hash = "sha256:b97d804b1e9b523befed77c48dacec60e6dcb0b5391d57af6a65a312a90648c0"},
@@ -852,6 +947,10 @@ mypy-extensions = [
     {file = "mypy_extensions-0.4.3-py2.py3-none-any.whl", hash = "sha256:090fedd75945a69ae91ce1303b5824f428daf5a028d2f6ab8a299250a846f15d"},
     {file = "mypy_extensions-0.4.3.tar.gz", hash = "sha256:2d82818f5bb3e369420cb3c4060a7970edba416647068eb4c5343488a6c604a8"},
 ]
+nodeenv = [
+    {file = "nodeenv-1.5.0-py2.py3-none-any.whl", hash = "sha256:5304d424c529c997bc888453aeaa6362d242b6b4631e90f3d4bf1b290f1c84a9"},
+    {file = "nodeenv-1.5.0.tar.gz", hash = "sha256:ab45090ae383b716c4ef89e690c41ff8c2b257b85b309f01f3654df3d084bd7c"},
+]
 packaging = [
     {file = "packaging-20.9-py2.py3-none-any.whl", hash = "sha256:67714da7f7bc052e064859c05c595155bd1ee9f69f76557e21f051443c20947a"},
     {file = "packaging-20.9.tar.gz", hash = "sha256:5b327ac1320dc863dca72f4514ecc086f31186744b84a230374cc1fd776feae5"},
@@ -863,6 +962,10 @@ pathspec = [
 pluggy = [
     {file = "pluggy-0.13.1-py2.py3-none-any.whl", hash = "sha256:966c145cd83c96502c3c3868f50408687b38434af77734af1e9ca461a4081d2d"},
     {file = "pluggy-0.13.1.tar.gz", hash = "sha256:15b2acde666561e1298d71b523007ed7364de07029219b604cf808bfa1c765b0"},
+]
+pre-commit = [
+    {file = "pre_commit-2.10.1-py2.py3-none-any.whl", hash = "sha256:16212d1fde2bed88159287da88ff03796863854b04dc9f838a55979325a3d20e"},
+    {file = "pre_commit-2.10.1.tar.gz", hash = "sha256:399baf78f13f4de82a29b649afd74bef2c4e28eb4f021661fc7f29246e8c7a3a"},
 ]
 py = [
     {file = "py-1.10.0-py2.py3-none-any.whl", hash = "sha256:3b80836aa6d1feeaa108e046da6423ab8f6ceda6468545ae8d02d9d58d18818a"},
@@ -1025,6 +1128,10 @@ urllib3 = [
 vcrpy = [
     {file = "vcrpy-4.1.1-py2.py3-none-any.whl", hash = "sha256:12c3fcdae7b88ecf11fc0d3e6d77586549d4575a2ceee18e82eee75c1f626162"},
     {file = "vcrpy-4.1.1.tar.gz", hash = "sha256:57095bf22fc0a2d99ee9674cdafebed0f3ba763018582450706f7d3a74fff599"},
+]
+virtualenv = [
+    {file = "virtualenv-20.4.2-py2.py3-none-any.whl", hash = "sha256:2be72df684b74df0ea47679a7df93fd0e04e72520022c57b479d8f881485dbe3"},
+    {file = "virtualenv-20.4.2.tar.gz", hash = "sha256:147b43894e51dd6bba882cf9c282447f780e2251cd35172403745fc381a0a80d"},
 ]
 wrapt = [
     {file = "wrapt-1.12.1.tar.gz", hash = "sha256:b62ffa81fb85f4332a4f609cab4ac40709470da05643a082ec1eb88e6d9b97d7"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,8 @@ coverage = "^5.4"
 coveralls = "^3.0.0"
 # version of generateDS used to create device.py and service.py in .../api/xsd
 generateDS = "2.37.11"
+# other
+pre-commit = "^2.10"
 
 [tool.coverage]
   [tool.coverage.run]

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -21,6 +21,10 @@ echo "===Installing dependencies==="
 poetry install
 
 echo
+echo "===Installing pre-commit hooks==="
+pre-commit install
+
+echo
 echo "===Validate with rstcheck==="
 rstcheck README.rst
 


### PR DESCRIPTION
## Description:
This adds several pre-commit hooks using the pre-commit python package.  We may want a ~short~ (became long!) discussion on this first.  First, 2 quick notes:

- Poetry normally recommends that you install it outside of your local project, see their instructions [here](https://github.com/python-poetry/poetry#installation).  I don't really love the idea of installing it with some special script, but I do understand the purpose of installing it outside of your local virtual environment, mainly that it can then be used to create the virtual environment itself.  For other projects, I've installed it with `pipx` so that it is globally accessible and in an isolated environment.  PyWeMo gets around that by using a few bash functions, `assertPython` and `enterVenv`, then installing Poetry into the created environment and using it.

- Pre-commit generally recommends that you point it at a git repository, that hosts a `.pre-commit-hooks.yaml` file at the top level of the directory.  For example, see [here](https://pre-commit.com/#2-add-a-pre-commit-configuration).  Pre-commit then manages an independent virtual environment for each "hook" that you install.  Personally, I don't like this method for a python project as it seems pointless to create extra virtual environment for tools that you already install into your project development virtual environment!  Further, now you need to manage the version of the tools you use in two places, the `pyproject.toml` file and your `.pre-commit-config.yaml` file, because occasionally different versions of these tools are not fully compatible.  For example, `black` version `19.10b0` and the next version of `20.8b1` would reformat some parts of code slightly differently.  This is one reason that I've pinned `black` and `isort` in our `pyproject.toml` file, so that we ensure we all format with the same version.

My solution to the second bullet is to use the [`system`](https://pre-commit.com/#system) "escape" language and then run the tools directly with `poetry`, which will automatically use the projects virtual environment to run whatever tool you request.  The catch here, is that you must have `poetry` installed somewhere outside of the virtual environment for this to work (see bullet 1), as pre-commit does not activate your project environment, so if you don't have `poetry` installed somewhere globally accessible on your `$PATH`, then pre-commit isn't going to find it (unless you commit with your virtual environment already activated, I suppose).

So, we just need to all agree on which path to take.  I can see good arguments for each way.

- Use pre-commit as it "recommends" and then just manage the versions of each tool in two locations (and probably pin each versions to be sure they are the same)
- Use what I've commited here, but make it clear that there is a requirement that `poetry` be installed outside of the virtual environment.  If we go this route, we could potentially just use `poetry` to also create the virtual environment for the project.

As for the settings themselves, I pretty much copied and edited the settings from each of the tools github repositories `.pre-commit-hooks.yaml` file, so that is where I got the various `types`, `types_or`, and `require_serial` options from.

I do not include pytest in this pre-commit hooks, as I assume we don't want to wait for all tests to run on every commit.  I tested committing a few "bad" files, like a bad `README.rst` and the hook did catch and reject it.

Sorry this is getting a bit longer than I'd planned, but 2 more points to bring up:

- We could potentially just run the `build.sh` script as a pre-commit hook instead (which is what @esev did?),  but then we would run the installations and tests as well.  Or we could break up the `build.sh` file into two, where only one would be installed as a pre-commit hook.  `pre-commit` seems to be the standard though, so I went that path.
- We could replace a bit of the `build.sh` file with just `pre-commit run --all-files`, but I personally prefer them all called separately in the `build.sh` files myself.  Plus then it would only check with `black` and `isort`, not actually format.

**Related issue (if applicable):** fixes #199

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] There is no commented out code in this PR.