### PR TITLE
remove mac argument for device_from_description

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -28,7 +28,7 @@ On some networks discovery doesn't work reliably, in that case if you can find t
     >>> url = pywemo.setup_url_for_address("192.168.1.192", None)
     >>> print(url)
     http://192.168.1.192:49153/setup.xml
-    >>> device = pywemo.discovery.device_from_description(url, None)
+    >>> device = pywemo.discovery.device_from_description(url)
     >>> print(device)
     <WeMo Maker "Hi Fi Systemline Sensor">
 


### PR DESCRIPTION
## Description:
Remove the depreciated `mac` argument from the example in the README file.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] There is no commented out code in this PR.