### PR TITLE
make port optional to setup_url_for_address

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -25,7 +25,7 @@ On some networks discovery doesn't work reliably, in that case if you can find t
 .. code-block:: python
 
     >>> import pywemo
-    >>> url = pywemo.setup_url_for_address("192.168.1.192", None)
+    >>> url = pywemo.setup_url_for_address("192.168.1.192")
     >>> print(url)
     http://192.168.1.192:49153/setup.xml
     >>> device = pywemo.discovery.device_from_description(url)
@@ -83,7 +83,7 @@ This started as a stripped down version of `ouimeaux <https://github.com/iancmcc
 
 License
 -------
-Some of the code in `pywemo/ouimeaux_device` was originally written by by Ian McCracken (and is copyright). It is released under the BSD license.
+Some of the code in `pywemo/ouimeaux_device` was originally written by Ian McCracken (and is copyright). It is released under the BSD license.
 The overall library is released under the MIT license.
 
 .. |Build Badge| image:: https://github.com/pavoni/pywemo/workflows/Build/badge.svg

--- a/pywemo/discovery.py
+++ b/pywemo/discovery.py
@@ -125,7 +125,7 @@ def hostname_lookup(hostname):
         return hostname
 
 
-def setup_url_for_address(host, port):
+def setup_url_for_address(host, port=None):
     """Determine setup.xml url for a given host and port pair."""
     # Force hostnames into IP addresses
     try:


### PR DESCRIPTION
## Description:
Make the `port` argument to `setup_url_for_address` optional by assigning a default value of `None`.  I'd think the vast majority of use cases would provide `None` for the argument anyway so that `pywemo` can probe for the port.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] There is no commented out code in this PR.