### PR TITLE
clarifications to the README, mainly setup/reset

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -23,7 +23,7 @@ For advanced usage, the ``device.explain()`` method will print all known actions
 If discovery doesn't work on your network
 -----------------------------------------
 Automatic discovery may not work reliably on some networks.
-In that case, you can find the device based on an IP or hostname:
+In that case, you can use the device with an IP or hostname:
 
 .. code-block:: python
 
@@ -65,7 +65,7 @@ Setup
 
 Device setup is through the ``setup`` method, which has two required arguments: ``ssid`` and ``password``.
 The user must first connect to the devices locally broadcast access point, which typically starts with "WeMo.", and then discover the device there.
-Once done, pass the desired SSID and password (AES encryption only) to the ``setup`` method to connect it to your wifi network.
+Once done, pass the desired SSID and password (WPA2/AES encryption only) to the ``setup`` method to connect it to your wifi network.
 
 ``device.setup(ssid='wifi_name', password='special_secret')``
 
@@ -75,7 +75,7 @@ A few important notes:
 - WeMo requires a password of at least 8 characters long.
 - For a WeMo without internet access, see `this guide <https://github.com/pavoni/pywemo/wiki/WeMo-Cloud#disconnecting-from-the-cloud>`_ to stop any blinking lights.
 - If connecting to an open network, the password argument is ignored and you can provide anything, e.g. ``password=None``.
-- If connecting to an AES-encrypted network, OpenSSL is used to encrypt the password by the ``pywemo`` library.
+- If connecting to a WPA2/AES-encrypted network, OpenSSL is used to encrypt the password by the ``pywemo`` library.
   It must be installed and available on your ``PATH`` via calling ``openssl`` from a terminal or command prompt.
 
 Firmware Warning
@@ -111,8 +111,10 @@ This started as a stripped down version of `ouimeaux <https://github.com/iancmcc
 
 License
 -------
-Some of the code in `pywemo/ouimeaux_device` was originally written, copyright, and released under the BSD license by Ian McCracken.
-The overall library is released under the MIT license.
+The code in `pywemo/ouimeaux_device` is released under the BSD LICENSE file in that directory.
+Some of this code was originally written and copyright by Ian McCracken.
+The rest of pyWeMo is released under the MIT license.
+
 
 .. |Build Badge| image:: https://github.com/pavoni/pywemo/workflows/Build/badge.svg
     :target: https://github.com/pavoni/pywemo/actions?query=workflow%3ABuild

--- a/README.rst
+++ b/README.rst
@@ -79,8 +79,7 @@ Once done, pass the desired SSID and password (WPA2/AES encryption only) to the 
 
 A few important notes:
 
-- Not all devices are supported for setup.
-- WeMo requires a password of at least 8 characters long.
+- Not all devices are currently supported for setup.
 - For a WeMo without internet access, see `this guide <https://github.com/pavoni/pywemo/wiki/WeMo-Cloud#disconnecting-from-the-cloud>`_ to stop any blinking lights.
 - If connecting to an open network, the password argument is ignored and you can provide anything, e.g. ``password=None``.
 - If connecting to a WPA2/AES-encrypted network, OpenSSL is used to encrypt the password by the ``pywemo`` library.

--- a/README.rst
+++ b/README.rst
@@ -18,9 +18,12 @@ How to use
 
     >>> devices[0].toggle()
 
+For advanced usage, the ``device.explain()`` method will print all known actions that the device reports to PyWeMo.
+
 If discovery doesn't work on your network
 -----------------------------------------
-On some networks discovery doesn't work reliably, in that case if you can find the ip address of your Wemo device you can use the following code.
+Automatic discovery may not work reliably on some networks.
+In that case, you can find the device based on an IP or hostname:
 
 .. code-block:: python
 
@@ -32,49 +35,66 @@ On some networks discovery doesn't work reliably, in that case if you can find t
     >>> print(device)
     <WeMo Maker "Hi Fi Systemline Sensor">
 
-Please note that `discovery.device_from_description` call requires a `url` with an IP address, rather than a hostnames. This is needed for the subscription update logic to work properly. In addition recent versions of the WeMo firmware may not accept connections from hostnames, and will return a 500 error.
+Please note that ``discovery.device_from_description`` requires a ``url`` with an IP address, rather than a hostname.
+This is needed for the subscription update logic to work properly.
+In addition, recent versions of the WeMo firmware may not accept connections from hostnames and will return a 500 error.
 
-The `setup_url_for_address` function will lookup a hostname and provide a suitable `url` with an IP address.
+The ``setup_url_for_address`` function will lookup a hostname and provide a suitable ``url`` with an IP address.
 
 Device Reset and Setup
 ----------------------
-pywemo includes the ability to reset and setup devices, without using the Belkin app or needing to create a Belkin account.
+PyWeMo includes the ability to reset and setup devices, without using the Belkin app or needing to create a Belkin account.
 This can be particularly useful if the intended use is fully local control, such as using Home Assistant.
 
-Reset can be performed with the `reset` method, which has 2 boolean input arguments, `data` and `wifi`.
-Setting `data=True` will reset data ("Clear Personalized Info" in the Wemo app), which resets the device name and clears the icon and rules.
-Setting `wifi=True` will clear wifi information ("Change Wi-Fi" in the Wemo app), which does not clear the rules, name, etc.
-Setting both to true is equivalent to a "Factory Restore" from the app.
-It should also be noted that devices contain a hardware reset procedure as well, so using the software is for convenience or if physical access is not available.
+Reset
+~~~~~
+Reset can be performed with the ``reset`` method, which has 2 boolean input arguments, ``data`` and ``wifi``.
+WeMo devices contain a hardware reset procedure as well, so use of ``pywemo`` is for convenience or if physical access is not available.
+This ``reset`` method may not work on all devices.
 
-Device setup is through the `setup` method.
-The user must first connect to the devices locally broadcast access point, then discover the device there.
-Once done, pass the desired SSID and password (AES encryption only) to the `setup` method to connect it to your wifi network.
+=======================================  =================  =======================
+Method in ``pywemo``                     Clears             Name in WeMo App
+=======================================  =================  =======================
+``device.reset(data=True, wifi=False)``  name, icon, rules  Clear Personalized Info
+``device.reset(data=False, wifi=True)``  wifi information   Change Wi-Fi
+``device.reset(data=True, wifi=True)``   everything         Factory Restore
+=======================================  =================  =======================
 
-Important Note for Device Setup - OpenSSL is Required!
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Setup
+~~~~~
 
-OpenSSL is used to encrypt the password by the pywemo library.
-It must be installed and available on the path via calling `openssl` with a terminal (or command prompt, if on Windows).
-This is not required if connecting the device to an open network, since that requires no password, although an open network certainly isn't recommended.
+Device setup is through the ``setup`` method, which has two required arguments: ``ssid`` and ``password``.
+The user must first connect to the devices locally broadcast access point, which typically starts with "WeMo.", and then discover the device there.
+Once done, pass the desired SSID and password (AES encryption only) to the ``setup`` method to connect it to your wifi network.
+
+``device.setup(ssid='wifi_name', password='special_secret')``
+
+A few important notes:
+
+- Not all devices are supported for setup.
+- WeMo requires a password of at least 8 characters long.
+- For a WeMo without internet access, see `this guide <https://github.com/pavoni/pywemo/wiki/WeMo-Cloud#disconnecting-from-the-cloud>`_ to stop any blinking lights.
+- If connecting to an open network, the password argument is ignored and you can provide anything, e.g. ``password=None``.
+- If connecting to an AES-encrypted network, OpenSSL is used to encrypt the password by the ``pywemo`` library.
+  It must be installed and available on your ``PATH`` via calling ``openssl`` from a terminal or command prompt.
 
 Firmware Warning
 ----------------
 Starting in May of 2020, Belkin started requiring users to create an account and login to the app (Android app version 1.25).
 In addition to the account, most of the app functionality now requires a connection to the cloud (internet access), even for simple actions such as toggling a switch.
 All of the commands that go through the cloud are encrypted and cannot be easily inspected.
-This raises the possibility that Belkin could, in the future, update Wemo device firmware and make breaking API changes that can not longer be deciphered.
-If this happens, pywemo may no longer function on that device.
-It would be prudent to upgrade firmware cautiously and preferably only after confirming that breaking API changes have not been introduced.
+This raises the possibility that Belkin could, in the future, update WeMo device firmware and make breaking API changes that can no longer be deciphered.
+If this happens, ``pywemo`` may no longer function on that device.
+Thus it would be prudent to upgrade firmware cautiously and preferably only after confirming that breaking API changes have not been introduced.
 
 Developing
 ----------
-Setup and builds are fully automated. You can run build pipeline locally by running.
+Setup and builds are fully automated.
+You can run the build pipeline locally via:
 
 .. code-block::
 
-    # Setup, build, lint and test the code:
-
+    # setup, install, format, lint, test and build:
     ./scripts/build.sh
 
 History
@@ -83,7 +103,7 @@ This started as a stripped down version of `ouimeaux <https://github.com/iancmcc
 
 License
 -------
-Some of the code in `pywemo/ouimeaux_device` was originally written by by Ian McCracken (and is copyright). It is released under the BSD license.
+Some of the code in `pywemo/ouimeaux_device` was originally written, copyright, and released under the BSD license by Ian McCracken.
 The overall library is released under the MIT license.
 
 .. |Build Badge| image:: https://github.com/pavoni/pywemo/workflows/Build/badge.svg

--- a/README.rst
+++ b/README.rst
@@ -98,7 +98,7 @@ You can run the build pipeline locally via:
     ./scripts/build.sh
 
 Note that this will install a git ``pre-commit`` hook.
-For this hook to work correctly, ``poetry`` needs to be globally accessible on your ``PATH`` and/or the local virtual environment must be activated.
+For this hook to work correctly, ``poetry`` needs to be globally accessible on your ``PATH`` or the local virtual environment must be activated.
 This virtual environment can be activated with:
 
 .. code-block::

--- a/README.rst
+++ b/README.rst
@@ -97,6 +97,14 @@ You can run the build pipeline locally via:
     # setup, install, format, lint, test and build:
     ./scripts/build.sh
 
+Note that this will install a git ``pre-commit`` hook.
+For this hook to work correctly, ``poetry`` needs to be globally accessible on your ``PATH`` and/or the local virtual environment must be activated.
+This virtual environment can be activated with:
+
+.. code-block::
+
+    . .venv/bin/activate
+
 History
 -------
 This started as a stripped down version of `ouimeaux <https://github.com/iancmcc/ouimeaux>`_, but has since taken its own path.


### PR DESCRIPTION
## Description:
I've re-written parts of the README, mainly the text in the setup and reset methods to hopefully make it more clear and also link to @esev's guide for blinking light issues if the device has no connection to the internet.  I've put all of the code stuff to have two back-ticks so that it gets formatted correctly.  I've seen other reStructuredText files do this for README files, so I believe that PyPI will not have an issue with that (I once tried using a :code: block to do it but PyPI complained --- I think this way works though).

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] There is no commented out code in this PR.