### PR TITLE
make port optional for setup_url_for_address

### DIFF
--- a/pywemo/discovery.py
+++ b/pywemo/discovery.py
@@ -125,7 +125,7 @@ def hostname_lookup(hostname):
         return hostname
 
 
-def setup_url_for_address(host, port):
+def setup_url_for_address(host, port=None):
     """Determine setup.xml url for a given host and port pair."""
     # Force hostnames into IP addresses
     try:


### PR DESCRIPTION
## Description:
This implements the code half of #252 - we will leave that PR open for only the documentation change once this PR is in a released version of pywemo.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] There is no commented out code in this PR.