### PR TITLE
only return UnsupportedDevice w/ new debug flag

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -36,6 +36,14 @@ Please note that `discovery.device_from_description` call requires a `url` with 
 
 The `setup_url_for_address` function will lookup a hostname and provide a suitable `url` with an IP address.
 
+Testing new products
+--------------------
+If both methods above are not successful, then pyWeMo may not support your WeMo product yet.
+This may be particularly true if it is a new device.
+To test this, you can use a debug flag, ``pywemo.discover_devices(debug=True)`` or ``pywemo.discovery.device_from_description(url, debug=True)``.
+If an ``UnsupportedDevice`` is found, then it is highly likely that the product can be added to ``pywemo``.
+This ``UnsupportedDevice`` will allow manual interation, but please open an issue to get first class support for the device.
+
 Device Reset and Setup
 ----------------------
 pywemo includes the ability to reset and setup devices, without using the Belkin app or needing to create a Belkin account.

--- a/README.rst
+++ b/README.rst
@@ -38,11 +38,11 @@ The `setup_url_for_address` function will lookup a hostname and provide a suitab
 
 Testing new products
 --------------------
-If both methods above are not successful, then pyWeMo may not support your WeMo product yet.
-This may be particularly true if it is a new device.
+If both methods above are not successful, then ``pywemo`` may not support your WeMo product yet.
+This may be particularly true if it is a new WeMo product.
 To test this, you can use a debug flag, ``pywemo.discover_devices(debug=True)`` or ``pywemo.discovery.device_from_description(url, debug=True)``.
 If an ``UnsupportedDevice`` is found, then it is highly likely that the product can be added to ``pywemo``.
-This ``UnsupportedDevice`` will allow manual interation, but please open an issue to get first class support for the device.
+This ``UnsupportedDevice`` will allow manual interaction, but please open an issue to get first class support for the device.
 
 Device Reset and Setup
 ----------------------

--- a/pywemo/discovery.py
+++ b/pywemo/discovery.py
@@ -25,7 +25,7 @@ from .ouimeaux_device.switch import Switch
 LOG = logging.getLogger(__name__)
 
 
-def discover_devices(**kwargs):
+def discover_devices(debug=False, **kwargs):
     """Find WeMo devices on the local network."""
     wemos = []
 
@@ -35,7 +35,7 @@ def discover_devices(**kwargs):
         ):
             try:
                 device = device_from_uuid_and_location(
-                    entry.udn, entry.location
+                    entry.udn, entry.location, debug
                 )
             except (HTTPException, ActionException) as exc:
                 LOG.warning(
@@ -47,7 +47,7 @@ def discover_devices(**kwargs):
     return wemos
 
 
-def device_from_description(description_url, mac='deprecated'):
+def device_from_description(description_url, mac='deprecated', debug=False):
     """Return object representing WeMo device running at host, else None."""
     if mac != 'deprecated':
         warnings.warn(
@@ -64,10 +64,10 @@ def device_from_description(description_url, mac='deprecated'):
     )
     uuid = parsed.device.UDN
 
-    return device_from_uuid_and_location(uuid, description_url)
+    return device_from_uuid_and_location(uuid, description_url, debug)
 
 
-def device_from_uuid_and_location(uuid, location):
+def device_from_uuid_and_location(uuid, location, debug=False):
     """Determine device class based on the device uuid."""
     if not (uuid and location):
         return None
@@ -91,7 +91,7 @@ def device_from_uuid_and_location(uuid, location):
         return Humidifier(location)
     if uuid.startswith('uuid:OutdoorPlug'):
         return OutdoorPlug(location)
-    if uuid.startswith('uuid:'):
+    if uuid.startswith('uuid:') and debug:
         # unsupported device, but if this function was called from
         # discover_devices then this should be a Belkin product and is probably
         # a WeMo product without a custom class yet.  So attempt to return a


### PR DESCRIPTION
## Description:
This adds a `debug` flag so that `UnsupportedDevice` is only returned when the debug flag is set to `True`.  This should prevent it from ever being returned within Home Assistant.  I've also added a short section to the README to make users aware of the existence of the flag.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] There is no commented out code in this PR.