### PR TITLE
Add top-level CONTRIBUTING and LICENSE files

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -6,3 +6,5 @@
 ## Checklist:
   - [ ] The code change is tested and works locally.
   - [ ] There is no commented out code in this PR.
+  - [ ] I have read and agree to the [CONTRIBUTING document](
+        https://github.com/pavoni/pywemo/blob/master/CONTRIBUTING.md).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,44 @@
+# How to Contribute
+
+We'd love to accept your patches and contributions to this project. There are
+just a few small guidelines you need to follow.
+
+## Open Source Licenses
+
+Portions of the pywemo code are MIT licensed and BSD licensed.
+
+### Code within pywemo/ouimeaux_device
+
+All contents of the pywemo/ouimeaux_device directory are licensed under a
+BSD license. The full text of the license is maintained within the
+pywemo/ouimeaux_device/LICENSE file.
+
+### All other code
+
+All contents not within the pywemo/ouimeaux_device directory are licensed under
+the MIT license. A copy of this license is maintained within the top-level
+LICENSE file.
+
+## Contributor License Agreement
+
+By making a contribution to this project, I certify that:
+
+(a) The contribution was created in whole or in part by me and I
+    have the right to submit it under the appropriate license (see section
+    above); or
+
+(b) The contribution is based upon previous work that, to the best
+    of my knowledge, is covered under an appropriate open source
+    license and I have the right under that license to submit that
+    work with modifications, whether created in whole or in part
+    by me, under the appropriate license (see section above); or
+
+(c) The contribution was provided directly to me by some other
+    person who certified (a), (b) or (c) and I have not modified
+    it.
+
+(d) I understand and agree that this project and the contribution
+    are public and that a record of the contribution (including all
+    personal information I submit with it) is maintained indefinitely
+    and may be redistributed consistent with this project or the open
+    source license(s) involved.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,54 @@
+Copyright 2014 Paulus Schoutsen
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+------------------------------------------------------------------------------
+
+The pyWeMo project also contains files that were originally from the
+ouimeaux project. https://github.com/iancmcc/ouimeaux/
+The following license applies to all content within the pywemo/ouimeaux_device
+directory:
+
+Copyright (c) 2014, Ian McCracken
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+* Neither the name of ouimeaux nor the names of its contributors may be used to
+  endorse or promote products derived from this software without specific prior
+  written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/README.rst
+++ b/README.rst
@@ -114,13 +114,12 @@ This virtual environment can be activated with:
 
 History
 -------
-This started as a stripped down version of `ouimeaux <https://github.com/iancmcc/ouimeaux>`_, but has since taken its own path.
+This started as a stripped down version of `ouimeaux <https://github.com/iancmcc/ouimeaux>`_, copyright Ian McCracken, but has since taken its own path.
 
 License
 -------
-The code in `pywemo/ouimeaux_device` is released under the BSD LICENSE file in that directory.
-Some of this code was originally written and copyright by Ian McCracken.
-The rest of pyWeMo is released under the MIT license.
+All contents of the pywemo/ouimeaux_device directory are licensed under a BSD 3-Clause license. The full text of that license is maintained within the pywemo/ouimeaux_device/LICENSE file.
+The rest of pyWeMo is released under the MIT license. See the top-level LICENSE file for more details.
 
 
 .. |Build Badge| image:: https://github.com/pavoni/pywemo/workflows/Build/badge.svg


### PR DESCRIPTION
## Description:

Add top-level CONTRIBUTING and LICENSE files.

I've borrowed and adapted the Home Assistant [CLA](https://github.com/home-assistant/core/blob/a066f8482866d69a38f69dd99cc20682565d9f4b/CLA.md) for that section in the CONTRIBUTING file, and added a new checkbox to the PR template about reading/agreeing to the CONTRIBUTING file. This is being done just to ensure everyone understands how the code that they are contributing is intended to be used.

I've also clarified the licenses in the README.rst file.