### PR TITLE
Support WiFi setup for RTOS devices

### DIFF
--- a/pywemo/ouimeaux_device/__init__.py
+++ b/pywemo/ouimeaux_device/__init__.py
@@ -8,6 +8,7 @@ import time
 import warnings
 
 import requests
+from lxml import etree as et
 
 from ..exceptions import (
     ActionException,
@@ -109,6 +110,13 @@ class Device:
         self._config = deviceParser.parseString(
             xml.content, silence=True, print_warnings=False
         ).device
+        # The 'xs:any' values for the xs:complexType DeviceType in device.xsd.
+        xs_any = (et.fromstring(extra) for extra in self._config.anytypeobjs_)
+        self._config_any = {
+            et.QName(tag).localname: tag.text.strip()
+            for tag in xs_any
+            if tag.text and tag.text.strip()
+        }
         self.services = {}
         for svc in self._config.serviceList.service:
             service = Service(self, svc)

--- a/tests/ouimeaux_device/test_device.py
+++ b/tests/ouimeaux_device/test_device.py
@@ -265,21 +265,32 @@ class TestDevice:
     def test_encryption_no_openssl(self, mock_run, device):
         """Test device encryption (openssl not found/not installed)."""
         with pytest.raises(SetupException):
-            assert device.encrypt_aes128('password', self.METAINFO)
+            assert device.encrypt_aes128('password', self.METAINFO, False)
         assert mock_run.call_count == 1
 
     @mock.patch('subprocess.run', side_effect=CalledProcessError(-1, 'error'))
     def test_encryption_openssl_error(self, mock_run, device):
         """Test device encryption (error in openssl)."""
         with pytest.raises(SetupException):
-            assert device.encrypt_aes128('password', self.METAINFO)
+            assert device.encrypt_aes128('password', self.METAINFO, False)
         assert mock_run.call_count == 1
 
     @mock.patch('subprocess.run', return_value=mock.Mock(stdout=ENC_PASSWORD))
-    def test_encryption_successful(self, mock_run, device):
+    def test_encryption_successful_non_rtos(self, mock_run, device):
         """Test device encryption (good result)."""
         correct = 'wNTUdjT+cA1pa0Vta/jgEg==1808'
-        assert device.encrypt_aes128('password', self.METAINFO) == correct
+        assert (
+            device.encrypt_aes128('password', self.METAINFO, False) == correct
+        )
+        assert mock_run.call_count == 1
+
+    @mock.patch('subprocess.run', return_value=mock.Mock(stdout=ENC_PASSWORD))
+    def test_encryption_successful_rtos(self, mock_run, device):
+        """Test device encryption (good result)."""
+        correct = 'wNTUdjT+cA1pa0Vta/jgEg=='
+        assert (
+            device.encrypt_aes128('password', self.METAINFO, True) == correct
+        )
         assert mock_run.call_count == 1
 
     def test_setup_unknown_service(self, device):

--- a/tests/ouimeaux_device/test_switch.py
+++ b/tests/ouimeaux_device/test_switch.py
@@ -27,6 +27,14 @@ class Test_F7C027(Base):
         with vcr.use_cassette('WeMo_US_2.00.2769.PVT.yaml'):
             return Switch('http://192.168.1.100:49153/setup.xml')
 
+    @pytest.mark.vcr()
+    def test_config_any(self, switch):
+        assert switch._config_any == {
+            'binaryState': '0',
+            'firmwareVersion': 'WeMo_US_2.00.2769.PVT',
+            'iconVersion': '0|49153',
+        }
+
 
 class Test_F7C063(Base):
     """Tests for the WeMo F7C063 model switch."""
@@ -36,6 +44,17 @@ class Test_F7C063(Base):
         with vcr.use_cassette('WeMo_WW_2.00.11420.PVT-OWRT-SNSV2.yaml'):
             return Switch('http://192.168.1.100:49153/setup.xml')
 
+    @pytest.mark.vcr()
+    def test_config_any(self, switch):
+        assert switch._config_any == {
+            'binaryState': '0',
+            'firmwareVersion': 'WeMo_WW_2.00.11420.PVT-OWRT-SNSV2',
+            'hkSetupCode': '012-34-567',
+            'hwVersion': 'v3',
+            'iconVersion': '2|49153',
+            'new_algo': '1',
+        }
+
 
 class Test_WSP080(Base):
     """Tests for the WeMo WSP080 model switch."""
@@ -44,3 +63,15 @@ class Test_WSP080(Base):
     def switch(self, vcr):
         with vcr.use_cassette('WEMO_WW_4.00.20101902.PVT-RTOS-SNSV4.yaml'):
             return Switch('http://192.168.1.100:49153/setup.xml')
+
+    @pytest.mark.vcr()
+    def test_config_any(self, switch):
+        assert switch._config_any == {
+            'binaryState': '0',
+            'firmwareVersion': 'WEMO_WW_4.00.20101902.PVT-RTOS-SNSV4',
+            'hkSetupCode': '012-34-567',
+            'hwVersion': 'v4',
+            'iconVersion': '1|49152',
+            'new_algo': '1',
+            'rtos': '1',
+        }


### PR DESCRIPTION
## Description:

The newer RTOS devices have a different algorithm for exchanging the WiFi parameters during setup. This PR adds the necessary logic to support WiFi setup for these devices.

**Related issue (if applicable):** fixes #237

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] There is no commented out code in this PR.
  - [x] I have read and agree to the [CONTRIBUTING document](
        https://github.com/pavoni/pywemo/blob/master/CONTRIBUTING.md).