### PR TITLE
Fix computation for RuleOrder when adding a long press rule

### DIFF
--- a/pywemo/ouimeaux_device/api/long_press.py
+++ b/pywemo/ouimeaux_device/api/long_press.py
@@ -36,7 +36,7 @@ def ensure_long_press_rule_exists(
 
     Returns the long press rule.
     """
-    current_rules = rules_db.rules_for_device()
+    current_rules = rules_db.rules_for_device(rule_type=RULE_TYPE_LONG_PRESS)
     for (rule, _) in current_rules:
         if rule.State != "1":
             LOG.info("Enabling long press rule for device %s", device_name)
@@ -47,7 +47,8 @@ def ensure_long_press_rule_exists(
     LOG.info("Adding long press rule for device %s", device_name)
     current_rules = rules_db.rules_for_device()
     max_order = max(
-        rules_db.rules.values(), key=lambda r: r.RuleOrder, default=-1
+        map(lambda r: getattr(r, 'RuleOrder', -1), rules_db.rules.values()),
+        default=-1,
     )
     new_rule = RulesRow(
         Name=f"{device_name} Long Press Rule",

--- a/pywemo/ouimeaux_device/api/rules_db.py
+++ b/pywemo/ouimeaux_device/api/rules_db.py
@@ -199,7 +199,7 @@ class RulesDb:
     def add_rule(self, rule: RulesRow) -> RulesRow:
         """Add a new entry to the RULES table."""
         if not hasattr(rule, "RuleID"):
-            rule.RuleID = max(self._rules.keys(), default=1)
+            rule.RuleID = max(self._rules.keys(), default=0) + 1
         rule.update_db(self.cursor())
         self._rules[rule.RuleID] = rule
         self.modified = True

--- a/tests/ouimeaux_device/api/unit/test_long_press.py
+++ b/tests/ouimeaux_device/api/unit/test_long_press.py
@@ -111,6 +111,56 @@ MOCK_UDN = "WemoDeviceUDN"
                 )
             ],
         ),
+        # Test case 3: A rule exists, but it is not a long press rule. Expect
+        # that a new entry is generated.
+        (
+            [
+                rules_db.RulesRow(
+                    RuleID=501,
+                    Name=f"{MOCK_NAME} Timer Rule",
+                    Type="UNKNOWN_TYPE",
+                    State=0,
+                ),
+                rules_db.RuleDevicesRow(
+                    RuleDevicePK=1, RuleID=501, DeviceID=MOCK_UDN
+                ),
+            ],
+            [
+                (
+                    rules_db.RulesRow(
+                        RuleID=502,
+                        Name=f"{MOCK_NAME} Long Press Rule",
+                        Type=long_press.RULE_TYPE_LONG_PRESS,
+                        RuleOrder=0,
+                        StartDate="12201982",
+                        EndDate="07301982",
+                        State=1,
+                        Sync="NOSYNC",
+                    ),
+                    rules_db.RuleDevicesRow(
+                        RuleDevicePK=2,
+                        RuleID=502,
+                        DeviceID=MOCK_UDN,
+                        GroupID=0,
+                        DayID=-1,
+                        StartTime=60,
+                        RuleDuration=86340,
+                        StartAction=long_press.ActionType.TOGGLE.value,
+                        EndAction=-1.0,
+                        SensorDuration=-1,
+                        Type=-1,
+                        Value=-1,
+                        Level=-1,
+                        ZBCapabilityStart='',
+                        ZBCapabilityEnd='',
+                        OnModeOffset=-1,
+                        OffModeOffset=-1,
+                        CountdownTime=-1,
+                        EndTime=86400,
+                    ),
+                ),
+            ],
+        ),
     ],
 )
 def test_ensure_long_press_rule_exists(test_input, expected):


### PR DESCRIPTION
## Description:

The original computation of `max_order` returns a RulesRow instance when an integer value was expected. This PR corrects the computation to always return an integer.

While testing this, I also discovered the logic to insert a new LongPress rule is incorrect in the case where an existing non-LongPress rule is present.

**Related issue (if applicable):** https://github.com/home-assistant/core/issues/52641

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] There is no commented out code in this PR.
  - [x] I have read and agree to the [CONTRIBUTING document](
        https://github.com/pavoni/pywemo/blob/master/CONTRIBUTING.md).