### PR TITLE
Create an empty RulesDb when the database does not exist

### DIFF
--- a/pywemo/exceptions.py
+++ b/pywemo/exceptions.py
@@ -35,3 +35,7 @@ class ShortPassword(SetupException):
 
 class HTTPException(PyWeMoException):
     """HTTP request to the device failed."""
+
+
+class HTTPNotOkException(HTTPException):
+    """Raised when a non-200 status is returned."""

--- a/pywemo/ouimeaux_device/api/rules_db.py
+++ b/pywemo/ouimeaux_device/api/rules_db.py
@@ -10,6 +10,8 @@ import zipfile
 from types import MappingProxyType
 from typing import FrozenSet, List, Mapping, Optional, Tuple
 
+from pywemo.exceptions import HTTPNotOkException
+
 from .db_orm import DatabaseRow, PrimaryKey, SQLType
 
 LOG = logging.getLogger(__name__)
@@ -367,13 +369,16 @@ def rules_db_from_device(device) -> RulesDb:
     fetch = device.rules.FetchRules()
     version = int(fetch["ruleDbVersion"])
     rule_db_url = fetch["ruleDbPath"]
-    response = device.session.get(rule_db_url)
+    try:
+        response = device.session.get(rule_db_url)
+    except HTTPNotOkException:
+        response = None
 
     with tempfile.NamedTemporaryFile(
         prefix="wemorules", suffix=".db"
     ) as temp_db_file:
         # Create a new db, or extract the current db.
-        if response.status != 200:
+        if response is None:
             db_file_name = _create_empty_db(temp_db_file.name)
         else:
             db_file_name = _unpack_db(response.content, temp_db_file)

--- a/pywemo/ouimeaux_device/api/service.py
+++ b/pywemo/ouimeaux_device/api/service.py
@@ -6,7 +6,11 @@ from urllib.parse import urljoin, urlparse
 import urllib3
 from lxml import etree as et
 
-from pywemo.exceptions import ActionException, HTTPException
+from pywemo.exceptions import (
+    ActionException,
+    HTTPException,
+    HTTPNotOkException,
+)
 
 from .xsd import service as serviceParser
 
@@ -89,8 +93,8 @@ class Session:
             kwargs: Additional arguments for urllib3 pool.request(**kwargs).
 
         Raises:
-            HTTPException for any urllib3 exception or if the response code is
-            not 200.
+            HTTPNotOkException: when the response code is not 200.
+            HTTPException: for any urllib3 exception.
         """
         if retries is None:
             retries = self.retries
@@ -105,7 +109,7 @@ class Session:
             try:
                 response = pool.request(method=method, url=url, **kwargs)
                 if response.status != 200:
-                    raise urllib3.exceptions.HTTPError(
+                    raise HTTPNotOkException(
                         f"Received status {response.status} for {url}"
                     )
             except urllib3.exceptions.HTTPError as err:

--- a/tests/ouimeaux_device/api/unit/test_rules.py
+++ b/tests/ouimeaux_device/api/unit/test_rules.py
@@ -273,6 +273,7 @@ def test_rules_db_from_device_404():
                     "ruleDbPath": "http://localhost/rules.db",
                 }
 
+    completed_with_no_exceptions = False
     with patch(
         "urllib3.PoolManager.request", return_value=mock_response
     ) as mock_request:
@@ -281,6 +282,9 @@ def test_rules_db_from_device_404():
                 method="GET", url="http://localhost/rules.db"
             )
         assert len(db.rules) == 0
+        completed_with_no_exceptions = True
+
+    assert completed_with_no_exceptions
 
 
 def test_rules_db_from_device_raises_http_exception():

--- a/tests/ouimeaux_device/api/unit/test_rules.py
+++ b/tests/ouimeaux_device/api/unit/test_rules.py
@@ -256,6 +256,33 @@ def test_rules_db_from_device(temp_file, sqldb):
     assert len(store_rules[0]["ruleDbBody"]) > 1000
 
 
+def test_rules_db_from_device_404():
+    mock_response = create_autospec(urllib3.HTTPResponse, instance=True)
+    mock_response.status = 404
+
+    class Device:
+        name = MOCK_NAME
+        udn = MOCK_UDN
+        session = Session("http://localhost/")
+
+        class rules:
+            @staticmethod
+            def FetchRules():
+                return {
+                    "ruleDbVersion": "1",
+                    "ruleDbPath": "http://localhost/rules.db",
+                }
+
+    with patch(
+        "urllib3.PoolManager.request", return_value=mock_response
+    ) as mock_request:
+        with rules_db.rules_db_from_device(Device) as db:
+            mock_request.assert_called_once_with(
+                method="GET", url="http://localhost/rules.db"
+            )
+        assert len(db.rules) == 0
+
+
 def test_rules_db_from_device_raises_http_exception():
     device = Mock()
     device.session = Session("http://localhost/")


### PR DESCRIPTION
## Description:

#242 introduced a regression that prevents an empty RulesDb from being created when a non-`200` http response code is returned from the device. This PR fixes that regression.

**Related issue (if applicable):**
* Broken by: #242
* Related to: https://github.com/home-assistant/core/issues/52654

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] There is no commented out code in this PR.
  - [x] I have read and agree to the [CONTRIBUTING document](
        https://github.com/pavoni/pywemo/blob/master/CONTRIBUTING.md).