### PR TITLE
Map sqlite3 exceptions into PyWeMoException/RulesDbQueryError

### DIFF
--- a/pywemo/exceptions.py
+++ b/pywemo/exceptions.py
@@ -39,3 +39,11 @@ class HTTPException(PyWeMoException):
 
 class HTTPNotOkException(HTTPException):
     """Raised when a non-200 status is returned."""
+
+
+class RulesDbError(Exception):
+    """Base class for errors related to the Rules database."""
+
+
+class RulesDbQueryError(RulesDbError):
+    """Exception when querying the rules database."""


### PR DESCRIPTION
## Description:

[Some databases](https://github.com/home-assistant/core/issues/52996#issuecomment-879617955) are not in a format that pyWeMo currently recognizes. This causes sqlite3 exceptions to be raised.

Clients shouldn't need to know the inner workings of pyWeMo to figure out all possible exceptions. It would be easier for clients if these errors were mapped into a subclass of PyWeMoException.

**Related issue (if applicable):**  #277

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] There is no commented out code in this PR.
  - [x] I have read and agree to the [CONTRIBUTING document](
        https://github.com/pavoni/pywemo/blob/master/CONTRIBUTING.md).