### PR TITLE
Don't log as exception if it's a caught exception.

### DIFF
--- a/pywemo/ssdp.py
+++ b/pywemo/ssdp.py
@@ -427,7 +427,7 @@ class DiscoveryResponder:
                         (SSDP_REPLY % callback_addr).encode("UTF-8"), sock_addr
                     )
                 except OSError:
-                    LOG.exception("Failed to send SSDP reply to %r", sock_addr)
+                    LOG.error("Failed to send SSDP reply to %r", sock_addr)
         except Exception as exp:
             self._thread_exception = exp  # Used in the stop() method.
             raise


### PR DESCRIPTION
## Description:
This OS error is caught and reported accordingly. There is no need to print a stack trace.

**Related issue (if applicable):** fixes #<pywemo issue number goes here>

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] There is no commented out code in this PR.
  - [ ] I have read and agree to the [CONTRIBUTING document](
        https://github.com/pavoni/pywemo/blob/master/CONTRIBUTING.md).