### PR TITLE
Use debug log level for subscription callbacks

### DIFF
--- a/pywemo/subscribe.py
+++ b/pywemo/subscribe.py
@@ -508,7 +508,7 @@ class SubscriptionRegistry:
 
     def event(self, device, type_, value, path=None):
         """Execute the callback for a received event."""
-        LOG.info(
+        LOG.debug(
             "Received %s event from %s(%s) - %s %s",
             path or 'an',
             device,


### PR DESCRIPTION
## Description:

Use debug log level for subscription callbacks

**Related issue (if applicable):** fixes #281

## Checklist:
  - [ ] The code change is tested and works locally.
  - [x] There is no commented out code in this PR.
  - [x] I have read and agree to the [CONTRIBUTING document](
        https://github.com/pavoni/pywemo/blob/master/CONTRIBUTING.md).