### PR TITLE
Close SSDP discovery sockets on error

### DIFF
--- a/pywemo/ssdp.py
+++ b/pywemo/ssdp.py
@@ -279,13 +279,16 @@ def scan(st=ST, timeout=DISCOVER_TIMEOUT, max_entries=None, match_udn=None):
     sockets = []
     try:
         for addr in interface_addresses():
+            s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
             try:
-                s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
                 s.bind((addr, 0))
                 s.sendto(ssdp_request, ssdp_target)
                 sockets.append(s)
             except OSError:
                 pass
+            finally:
+                if s not in sockets:
+                    s.close()
 
         start = calc_now()
         while sockets:


### PR DESCRIPTION
## Description:

Fix a potential socket descriptor leak. Home Assistant runs the pyWeMo SSDP discovery every 5 minutes. If the multicast send fails then the socket descriptor is leaked. This can eventually result in the OS not having enough socket/file handles. I suspect this might be the case for https://github.com/home-assistant/core/issues/52853#issuecomment-888667983.

Thanks @Garulf for mentioning this issue.

**Related issue (if applicable):** https://github.com/home-assistant/core/issues/52853

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] There is no commented out code in this PR.
  - [x] I have read and agree to the [CONTRIBUTING document](
        https://github.com/pavoni/pywemo/blob/master/CONTRIBUTING.md).