### PR TITLE
Use separate send/receive sockets in DiscoveryResponder

### DIFF
--- a/tests/test_ssdp.py
+++ b/tests/test_ssdp.py
@@ -34,9 +34,8 @@ def mock_get_ip_address():
 def mock_socket():
     """Mock socket instance returned from socket.socket."""
     sock = mock.create_autospec(socket.socket, instance=True)
-    with mock.patch("socket.socket", return_value=sock) as mock_sock:
+    with mock.patch("socket.socket", return_value=sock):
         yield sock
-        assert mock_sock.call_count == 1
 
 
 @pytest.fixture()


### PR DESCRIPTION
## Description:

On macOS systems it's not possible to send packets from the multicast socket pyWeMo uses to receive SSDP messages. This PR creates a second socket used for sending responses from the `DiscoveryResponder`

Thank you for testing this, @Garulf.

**Related issue (if applicable):** https://github.com/home-assistant/core/issues/52853

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] There is no commented out code in this PR.
  - [x] I have read and agree to the [CONTRIBUTING document](
        https://github.com/pavoni/pywemo/blob/master/CONTRIBUTING.md).