### PR TITLE
Dimmer BinaryState value is only fetched/set once

### DIFF
--- a/pywemo/ouimeaux_device/__init__.py
+++ b/pywemo/ouimeaux_device/__init__.py
@@ -179,7 +179,7 @@ class Device:
 
     def update_binary_state(self):
         """Update the cached copy of the basic state response."""
-        self.basic_state_params = self.basicevent.GetBinaryState()
+        self.basic_state_params = self.basicevent.GetBinaryState() or {}
 
     def subscription_update(self, _type, _params):
         """Update device state based on subscription event."""
@@ -199,10 +199,12 @@ class Device:
     def get_state(self, force_update=False):
         """Return 0 if off and 1 if on."""
         if force_update or self._state is None:
-            state = self.basicevent.GetBinaryState() or {}
+            self.update_binary_state()
 
             try:
-                self._state = int(state.get('BinaryState', 0))
+                self._state = int(
+                    self.basic_state_params.get('BinaryState', 0)
+                )
             except ValueError:
                 self._state = 0
 

--- a/pywemo/ouimeaux_device/dimmer.py
+++ b/pywemo/ouimeaux_device/dimmer.py
@@ -17,21 +17,16 @@ class Dimmer(Switch, LongPressMixin):
         return self._brightness
 
     def set_brightness(self, brightness):
-        """
-        Set the brightness of this device to an integer between 1-100.
-
-        Setting the brightness does not turn the light on, so we need
-        to check the state of the switch.
-        """
-        if brightness == 0:
-            if self.get_state() != 0:
-                self.off()
+        """Set the brightness of this device to an integer between 1-100."""
+        value = int(brightness)
+        # WeMo only supports values between 1-100. WeMo will ignore a 0
+        # brightness value. If 0 is requested, then turn the light off instead.
+        if brightness:
+            self.basicevent.SetBinaryState(BinaryState=1, brightness=value)
+            self._state = 1
+            self._brightness = value
         else:
-            if self.get_state() == 0:
-                self.on()
-
-        self.basicevent.SetBinaryState(brightness=int(brightness))
-        self._brightness = int(brightness)
+            self.off()
 
     def get_state(self, force_update=False):
         """Update the state & brightness for the Dimmer."""

--- a/pywemo/ouimeaux_device/dimmer.py
+++ b/pywemo/ouimeaux_device/dimmer.py
@@ -36,7 +36,7 @@ class Dimmer(Switch, LongPressMixin):
     def get_state(self, force_update=False):
         """Update the state & brightness for the Dimmer."""
         state = super().get_state(force_update)
-        if force_update:
+        if force_update or self._brightness is None:
             try:
                 brightness = int(self.basic_state_params.get("brightness", 0))
             except ValueError:

--- a/tests/ouimeaux_device/test_dimmer.py
+++ b/tests/ouimeaux_device/test_dimmer.py
@@ -20,6 +20,18 @@ class Base:
         dimmer.off()
         assert dimmer.get_state(force_update=True) == 0
 
+    @pytest.mark.vcr()
+    @pytest.mark.parametrize(
+        "brightness,expected_state,expected_brightness",
+        [(100, 1, 100), (0, 0, 100), (45, 1, 45)],
+    )
+    def test_set_brightness(
+        self, dimmer, brightness, expected_state, expected_brightness
+    ):
+        dimmer.set_brightness(brightness)
+        assert dimmer.get_state(force_update=True) == expected_state
+        assert dimmer.get_brightness() == expected_brightness
+
     def test_subscription_update_brightness(self, dimmer):
         # Invalid value fails gracefully.
         assert dimmer.subscription_update('Brightness', 'invalid') is False

--- a/tests/ouimeaux_device/test_dimmer.py
+++ b/tests/ouimeaux_device/test_dimmer.py
@@ -21,8 +21,8 @@ class Base:
         assert dimmer.get_state(force_update=True) == 0
 
     def test_subscription_update_brightness(self, dimmer):
-        # Does not update when the light is off.
-        assert dimmer.subscription_update('Brightness', '23') is False
+        # Invalid value fails gracefully.
+        assert dimmer.subscription_update('Brightness', 'invalid') is False
 
         assert dimmer.subscription_update('BinaryState', '1') is True
         assert dimmer.get_state() == 1

--- a/tests/vcr/tests.ouimeaux_device.test_dimmer/Test_PVT_OWRT_Dimmer_v1.test_set_brightness[0-0-100].yaml
+++ b/tests/vcr/tests.ouimeaux_device.test_dimmer/Test_PVT_OWRT_Dimmer_v1.test_set_brightness[0-0-100].yaml
@@ -1,0 +1,89 @@
+interactions:
+- request:
+    body: '<?xml version="1.0" encoding="utf-8"?>
+
+      <s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/" s:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/">
+
+      <s:Body>
+
+      <u:SetBinaryState xmlns:u="urn:Belkin:service:basicevent:1">
+
+      <BinaryState>0</BinaryState>
+
+      </u:SetBinaryState>
+
+      </s:Body>
+
+      </s:Envelope>'
+    headers:
+      Content-Type:
+      - text/xml
+      SOAPACTION:
+      - '"urn:Belkin:service:basicevent:1#SetBinaryState"'
+    method: POST
+    uri: http://192.168.1.100:49153/upnp/control/basicevent1
+  response:
+    body:
+      string: "<s:Envelope xmlns:s=\"http://schemas.xmlsoap.org/soap/envelope/\" s:encodingStyle=\"http://schemas.xmlsoap.org/soap/encoding/\"><s:Body>\n<u:SetBinaryStateResponse
+        xmlns:u=\"urn:Belkin:service:basicevent:1\">\r\n<BinaryState>0</BinaryState>\r\n<CountdownEndTime>0</CountdownEndTime>\r\n<deviceCurrentTime>1627611121</deviceCurrentTime>\r\n</u:SetBinaryStateResponse>\r\n</s:Body>
+        </s:Envelope>"
+    headers:
+      CONTENT-LENGTH:
+      - '376'
+      CONTENT-TYPE:
+      - text/xml; charset="utf-8"
+      DATE:
+      - Fri, 30 Jul 2021 02:12:01 GMT
+      EXT:
+      - ''
+      SERVER:
+      - Unspecified, UPnP/1.0, Unspecified
+      X-User-Agent:
+      - redsonic
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '<?xml version="1.0" encoding="utf-8"?>
+
+      <s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/" s:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/">
+
+      <s:Body>
+
+      <u:GetBinaryState xmlns:u="urn:Belkin:service:basicevent:1">
+
+
+      </u:GetBinaryState>
+
+      </s:Body>
+
+      </s:Envelope>'
+    headers:
+      Content-Type:
+      - text/xml
+      SOAPACTION:
+      - '"urn:Belkin:service:basicevent:1#GetBinaryState"'
+    method: POST
+    uri: http://192.168.1.100:49153/upnp/control/basicevent1
+  response:
+    body:
+      string: "<s:Envelope xmlns:s=\"http://schemas.xmlsoap.org/soap/envelope/\" s:encodingStyle=\"http://schemas.xmlsoap.org/soap/encoding/\"><s:Body>\n<u:GetBinaryStateResponse
+        xmlns:u=\"urn:Belkin:service:basicevent:1\">\r\n<BinaryState>0</BinaryState>\r\n<brightness>100</brightness>\r\n<fader>300:-1:1:0:100</fader>\r\n</u:GetBinaryStateResponse>\r\n</s:Body>
+        </s:Envelope>"
+    headers:
+      CONTENT-LENGTH:
+      - '346'
+      CONTENT-TYPE:
+      - text/xml; charset="utf-8"
+      DATE:
+      - Fri, 30 Jul 2021 02:12:01 GMT
+      EXT:
+      - ''
+      SERVER:
+      - Unspecified, UPnP/1.0, Unspecified
+      X-User-Agent:
+      - redsonic
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/vcr/tests.ouimeaux_device.test_dimmer/Test_PVT_OWRT_Dimmer_v1.test_set_brightness[100-1-100].yaml
+++ b/tests/vcr/tests.ouimeaux_device.test_dimmer/Test_PVT_OWRT_Dimmer_v1.test_set_brightness[100-1-100].yaml
@@ -1,0 +1,91 @@
+interactions:
+- request:
+    body: '<?xml version="1.0" encoding="utf-8"?>
+
+      <s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/" s:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/">
+
+      <s:Body>
+
+      <u:SetBinaryState xmlns:u="urn:Belkin:service:basicevent:1">
+
+      <BinaryState>1</BinaryState>
+
+      <brightness>100</brightness>
+
+      </u:SetBinaryState>
+
+      </s:Body>
+
+      </s:Envelope>'
+    headers:
+      Content-Type:
+      - text/xml
+      SOAPACTION:
+      - '"urn:Belkin:service:basicevent:1#SetBinaryState"'
+    method: POST
+    uri: http://192.168.1.100:49153/upnp/control/basicevent1
+  response:
+    body:
+      string: "<s:Envelope xmlns:s=\"http://schemas.xmlsoap.org/soap/envelope/\" s:encodingStyle=\"http://schemas.xmlsoap.org/soap/encoding/\"><s:Body>\n<u:SetBinaryStateResponse
+        xmlns:u=\"urn:Belkin:service:basicevent:1\">\r\n<BinaryState>1</BinaryState>\r\n<CountdownEndTime>0</CountdownEndTime>\r\n<deviceCurrentTime>1627611121</deviceCurrentTime>\r\n<brightness>100</brightness>\r\n</u:SetBinaryStateResponse>\r\n</s:Body>
+        </s:Envelope>"
+    headers:
+      CONTENT-LENGTH:
+      - '406'
+      CONTENT-TYPE:
+      - text/xml; charset="utf-8"
+      DATE:
+      - Fri, 30 Jul 2021 02:12:01 GMT
+      EXT:
+      - ''
+      SERVER:
+      - Unspecified, UPnP/1.0, Unspecified
+      X-User-Agent:
+      - redsonic
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '<?xml version="1.0" encoding="utf-8"?>
+
+      <s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/" s:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/">
+
+      <s:Body>
+
+      <u:GetBinaryState xmlns:u="urn:Belkin:service:basicevent:1">
+
+
+      </u:GetBinaryState>
+
+      </s:Body>
+
+      </s:Envelope>'
+    headers:
+      Content-Type:
+      - text/xml
+      SOAPACTION:
+      - '"urn:Belkin:service:basicevent:1#GetBinaryState"'
+    method: POST
+    uri: http://192.168.1.100:49153/upnp/control/basicevent1
+  response:
+    body:
+      string: "<s:Envelope xmlns:s=\"http://schemas.xmlsoap.org/soap/envelope/\" s:encodingStyle=\"http://schemas.xmlsoap.org/soap/encoding/\"><s:Body>\n<u:GetBinaryStateResponse
+        xmlns:u=\"urn:Belkin:service:basicevent:1\">\r\n<BinaryState>1</BinaryState>\r\n<brightness>100</brightness>\r\n<fader>300:-1:1:0:100</fader>\r\n</u:GetBinaryStateResponse>\r\n</s:Body>
+        </s:Envelope>"
+    headers:
+      CONTENT-LENGTH:
+      - '346'
+      CONTENT-TYPE:
+      - text/xml; charset="utf-8"
+      DATE:
+      - Fri, 30 Jul 2021 02:12:01 GMT
+      EXT:
+      - ''
+      SERVER:
+      - Unspecified, UPnP/1.0, Unspecified
+      X-User-Agent:
+      - redsonic
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/vcr/tests.ouimeaux_device.test_dimmer/Test_PVT_OWRT_Dimmer_v1.test_set_brightness[45-1-45].yaml
+++ b/tests/vcr/tests.ouimeaux_device.test_dimmer/Test_PVT_OWRT_Dimmer_v1.test_set_brightness[45-1-45].yaml
@@ -1,0 +1,91 @@
+interactions:
+- request:
+    body: '<?xml version="1.0" encoding="utf-8"?>
+
+      <s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/" s:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/">
+
+      <s:Body>
+
+      <u:SetBinaryState xmlns:u="urn:Belkin:service:basicevent:1">
+
+      <BinaryState>1</BinaryState>
+
+      <brightness>45</brightness>
+
+      </u:SetBinaryState>
+
+      </s:Body>
+
+      </s:Envelope>'
+    headers:
+      Content-Type:
+      - text/xml
+      SOAPACTION:
+      - '"urn:Belkin:service:basicevent:1#SetBinaryState"'
+    method: POST
+    uri: http://192.168.1.100:49153/upnp/control/basicevent1
+  response:
+    body:
+      string: "<s:Envelope xmlns:s=\"http://schemas.xmlsoap.org/soap/envelope/\" s:encodingStyle=\"http://schemas.xmlsoap.org/soap/encoding/\"><s:Body>\n<u:SetBinaryStateResponse
+        xmlns:u=\"urn:Belkin:service:basicevent:1\">\r\n<BinaryState>1</BinaryState>\r\n<CountdownEndTime>0</CountdownEndTime>\r\n<deviceCurrentTime>1627611121</deviceCurrentTime>\r\n<brightness>45</brightness>\r\n</u:SetBinaryStateResponse>\r\n</s:Body>
+        </s:Envelope>"
+    headers:
+      CONTENT-LENGTH:
+      - '405'
+      CONTENT-TYPE:
+      - text/xml; charset="utf-8"
+      DATE:
+      - Fri, 30 Jul 2021 02:12:01 GMT
+      EXT:
+      - ''
+      SERVER:
+      - Unspecified, UPnP/1.0, Unspecified
+      X-User-Agent:
+      - redsonic
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '<?xml version="1.0" encoding="utf-8"?>
+
+      <s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/" s:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/">
+
+      <s:Body>
+
+      <u:GetBinaryState xmlns:u="urn:Belkin:service:basicevent:1">
+
+
+      </u:GetBinaryState>
+
+      </s:Body>
+
+      </s:Envelope>'
+    headers:
+      Content-Type:
+      - text/xml
+      SOAPACTION:
+      - '"urn:Belkin:service:basicevent:1#GetBinaryState"'
+    method: POST
+    uri: http://192.168.1.100:49153/upnp/control/basicevent1
+  response:
+    body:
+      string: "<s:Envelope xmlns:s=\"http://schemas.xmlsoap.org/soap/envelope/\" s:encodingStyle=\"http://schemas.xmlsoap.org/soap/encoding/\"><s:Body>\n<u:GetBinaryStateResponse
+        xmlns:u=\"urn:Belkin:service:basicevent:1\">\r\n<BinaryState>1</BinaryState>\r\n<brightness>45</brightness>\r\n<fader>300:-1:1:0:100</fader>\r\n</u:GetBinaryStateResponse>\r\n</s:Body>
+        </s:Envelope>"
+    headers:
+      CONTENT-LENGTH:
+      - '345'
+      CONTENT-TYPE:
+      - text/xml; charset="utf-8"
+      DATE:
+      - Fri, 30 Jul 2021 02:12:01 GMT
+      EXT:
+      - ''
+      SERVER:
+      - Unspecified, UPnP/1.0, Unspecified
+      X-User-Agent:
+      - redsonic
+    status:
+      code: 200
+      message: OK
+version: 1


### PR DESCRIPTION
## Description:

Optimizing the `Dimmer` class a bit so that both `_state` & `_brightness` are updated at the same time. It's the same underlying `GetBinaryState`/`SetBinaryState` calls that are made to the WeMo device for both, so might as well save a call and update both together.

**Related issue (if applicable):** fixes #<pywemo issue number goes here>

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] There is no commented out code in this PR.
  - [x] I have read and agree to the [CONTRIBUTING document](
        https://github.com/pavoni/pywemo/blob/master/CONTRIBUTING.md).