### PR TITLE
Use base Device class for device_type/__repr__

### DIFF
--- a/pywemo/ouimeaux_device/__init__.py
+++ b/pywemo/ouimeaux_device/__init__.py
@@ -685,6 +685,15 @@ class Device:
         """Return the uPnP unique device name of the device."""
         return self._config.get_UDN()
 
+    @property
+    def device_type(self) -> str:
+        """Return what kind of WeMo this device is."""
+        return type(self).__name__
+
+    def __repr__(self) -> str:
+        """Return a string representation of the device."""
+        return f'<WeMo {self.device_type} "{self.name}">'
+
 
 class UnsupportedDevice(Device):
     """Representation of a WeMo device without a definition in pywemo.
@@ -694,12 +703,3 @@ class UnsupportedDevice(Device):
     allow a user to see that something is discovered and manually interact with
     it as well as aide in creating a permenant class for the new product.
     """
-
-    def __repr__(self):
-        """Return a string representation of the device."""
-        return '<WeMo UnsupportedDevice "{name}">'.format(name=self.name)
-
-    @property
-    def device_type(self):
-        """Return what kind of WeMo this device is."""
-        return 'UnsupportedDevice'

--- a/pywemo/ouimeaux_device/bridge.py
+++ b/pywemo/ouimeaux_device/bridge.py
@@ -141,6 +141,7 @@ class LinkedDevice:
         self.bridge = bridge
         self.host = self.bridge.host
         self.port = self.bridge.port
+        self.name = None
         self.state = {}
         self.capabilities = []
         self._values = []
@@ -255,9 +256,13 @@ class LinkedDevice:
         return self._setdevicestatus(onoff=TOGGLE)
 
     @property
-    def device_type(self):
+    def device_type(self) -> str:
         """Return what kind of WeMo this device is."""
-        return "LinkedDevice"
+        return type(self).__name__
+
+    def __repr__(self) -> str:
+        """Return a string representation of the device."""
+        return f'<{self.device_type.upper()} "{self.name}">'
 
 
 class Light(LinkedDevice):
@@ -308,10 +313,6 @@ class Light(LinkedDevice):
             self._values = currentstate.split(',')
 
         super().update_state(status)
-
-    def __repr__(self):
-        """Return a string representation of the device."""
-        return '<LIGHT "{name}">'.format(name=self.name)
 
     def turn_on(self, level=None, transition=0, force_update=False):
         """Turn on the light."""
@@ -389,11 +390,6 @@ class Light(LinkedDevice):
         """Start ramping the brightness up or down."""
         return self._setdevicestatus(levelcontrol_stop='')
 
-    @property
-    def device_type(self):
-        """Return what kind of WeMo this device is."""
-        return "Light"
-
 
 class Group(LinkedDevice):
     """Representation of a Group of lights connected to the Bridge."""
@@ -422,12 +418,3 @@ class Group(LinkedDevice):
         if currentstate is not None:
             self._values = currentstate.split(',')
         super().update_state(status)
-
-    def __repr__(self):
-        """Return a string representation of the device."""
-        return '<GROUP "{name}">'.format(name=self.name)
-
-    @property
-    def device_type(self):
-        """Return what kind of WeMo this device is."""
-        return "Group"

--- a/pywemo/ouimeaux_device/bridge.py
+++ b/pywemo/ouimeaux_device/bridge.py
@@ -132,11 +132,6 @@ class Bridge(Device):
 
         return self.bridge.SetDeviceStatus(DeviceStatusList=send_state)
 
-    @property
-    def device_type(self):
-        """Return what kind of WeMo this device is."""
-        return "Bridge"
-
 
 class LinkedDevice:
     """Representation of a device connected to the bridge."""

--- a/pywemo/ouimeaux_device/coffeemaker.py
+++ b/pywemo/ouimeaux_device/coffeemaker.py
@@ -78,10 +78,6 @@ class CoffeeMaker(Switch):
         Switch.__init__(self, *args, **kwargs)
         self._attributes = {}
 
-    def __repr__(self):
-        """Return a string representation of the device."""
-        return '<WeMo CoffeeMaker "{name}">'.format(name=self.name)
-
     def update_attributes(self):
         """Request state from device."""
         resp = self.deviceevent.GetAttributes().get('attributeList')
@@ -96,11 +92,6 @@ class CoffeeMaker(Switch):
             return True
 
         return Switch.subscription_update(self, _type, _params)
-
-    @property
-    def device_type(self):
-        """Return what kind of WeMo this device is."""
-        return "CoffeeMaker"
 
     @property
     def mode(self):

--- a/pywemo/ouimeaux_device/dimmer.py
+++ b/pywemo/ouimeaux_device/dimmer.py
@@ -48,12 +48,3 @@ class Dimmer(Switch, LongPressMixin):
                 return False
             return True
         return super().subscription_update(_type, _param)
-
-    def __repr__(self):
-        """Return a string representation of the device."""
-        return '<WeMo Dimmer "{name}">'.format(name=self.name)
-
-    @property
-    def device_type(self):
-        """Return what kind of WeMo this device is."""
-        return "Dimmer"

--- a/pywemo/ouimeaux_device/humidifier.py
+++ b/pywemo/ouimeaux_device/humidifier.py
@@ -145,10 +145,6 @@ class Humidifier(Switch):
         self._attributes = {}
         self.update_attributes()
 
-    def __repr__(self):
-        """Return a string representation of the device."""
-        return '<WeMo Humidifier "{name}">'.format(name=self.name)
-
     def update_attributes(self):
         """Request state from device."""
         resp = self.deviceevent.GetAttributes().get('attributeList')
@@ -164,11 +160,6 @@ class Humidifier(Switch):
             return True
 
         return Switch.subscription_update(self, _type, _params)
-
-    @property
-    def device_type(self):
-        """Return what kind of WeMo this device is."""
-        return "Humidifier"
 
     @property
     def fan_mode(self):

--- a/pywemo/ouimeaux_device/insight.py
+++ b/pywemo/ouimeaux_device/insight.py
@@ -17,10 +17,6 @@ class Insight(Switch):
 
         self.update_insight_params()
 
-    def __repr__(self):
-        """Return a string representation of the device."""
-        return '<WeMo Insight "{name}">'.format(name=self.name)
-
     def update_insight_params(self):
         """Get and parse the device attributes."""
         params = self.insight.GetInsightParams().get('InsightParams')
@@ -76,11 +72,6 @@ class Insight(Switch):
             self.update_insight_params()
 
         return Switch.get_state(self, force_update)
-
-    @property
-    def device_type(self):
-        """Return what kind of WeMo this device is."""
-        return "Insight"
 
     @property
     def today_kwh(self):

--- a/pywemo/ouimeaux_device/lightswitch.py
+++ b/pywemo/ouimeaux_device/lightswitch.py
@@ -5,12 +5,3 @@ from .switch import Switch
 
 class LightSwitch(Switch, LongPressMixin):
     """Representation of a WeMo Motion device."""
-
-    def __repr__(self):
-        """Return a string representation of the device."""
-        return '<WeMo LightSwitch "{name}">'.format(name=self.name)
-
-    @property
-    def device_type(self):
-        """Return what kind of WeMo this device is."""
-        return "LightSwitch"

--- a/pywemo/ouimeaux_device/maker.py
+++ b/pywemo/ouimeaux_device/maker.py
@@ -44,10 +44,6 @@ class Maker(Switch):
         self.maker_params = {}
         self.get_state(force_update=True)
 
-    def __repr__(self):
-        """Return a string representation of the device."""
-        return '<WeMo Maker "{name}">'.format(name=self.name)
-
     def update_maker_params(self):
         """Get and parse the device attributes."""
         maker_resp = self.deviceevent.GetAttributes().get('attributeList')
@@ -79,11 +75,6 @@ class Maker(Switch):
         # the state is what you just set, so re-read it from the device
         self.basicevent.SetBinaryState(BinaryState=int(state))
         self.get_state(True)
-
-    @property
-    def device_type(self):
-        """Return what kind of WeMo this device is."""
-        return "Maker"
 
     @property
     def switch_state(self) -> int:

--- a/pywemo/ouimeaux_device/motion.py
+++ b/pywemo/ouimeaux_device/motion.py
@@ -4,12 +4,3 @@ from . import Device
 
 class Motion(Device):
     """Representation of a WeMo Motion device."""
-
-    def __repr__(self):
-        """Return a string representation of the device."""
-        return '<WeMo Motion "{name}">'.format(name=self.name)
-
-    @property
-    def device_type(self):
-        """Return what kind of WeMo this device is."""
-        return "Motion"

--- a/pywemo/ouimeaux_device/outdoor_plug.py
+++ b/pywemo/ouimeaux_device/outdoor_plug.py
@@ -4,12 +4,3 @@ from .switch import Switch
 
 class OutdoorPlug(Switch):
     """Representation of a WeMo Motion device."""
-
-    def __repr__(self):
-        """Return a string representation of the device."""
-        return '<WeMo OutdoorPlug "{name}">'.format(name=self.name)
-
-    @property
-    def device_type(self):
-        """Return what kind of WeMo this device is."""
-        return "OutdoorPlug"

--- a/pywemo/ouimeaux_device/switch.py
+++ b/pywemo/ouimeaux_device/switch.py
@@ -21,12 +21,3 @@ class Switch(Device):
     def toggle(self):
         """Toggle the switch's state."""
         return self.set_state(not self.get_state())
-
-    def __repr__(self):
-        """Return a string representation of the device."""
-        return '<WeMo Switch "{name}">'.format(name=self.name)
-
-    @property
-    def device_type(self):
-        """Return what kind of WeMo this device is."""
-        return "Switch"


### PR DESCRIPTION
## Description:

Standardize the `device_type` property and `__repr__` method for all instances of the `Device` class.

Remove all subclass implementations of these that would produce the same result

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] There is no commented out code in this PR.
  - [x] I have read and agree to the [CONTRIBUTING document](
        https://github.com/pavoni/pywemo/blob/master/CONTRIBUTING.md).