### PR TITLE
Raise exception for SOAP Fault errors

### DIFF
--- a/pywemo/exceptions.py
+++ b/pywemo/exceptions.py
@@ -17,7 +17,7 @@ class SOAPFault(ActionException):
     error_code: str = ""
     error_description: str = ""
 
-    def __init__(self, message, fault_element=None):
+    def __init__(self, message="", fault_element=None):
         """Initialize from a SOAP Fault lxml.etree Element."""
         details = ""
         if fault_element is not None:
@@ -26,13 +26,14 @@ class SOAPFault(ActionException):
                 "/{urn:schemas-upnp-org:control-1-0}UPnPError/"
                 "{urn:schemas-upnp-org:control-1-0}"
             )
-            self.fault_code = fault_element.findtext("faultcode")
-            self.fault_string = fault_element.findtext("faultstring")
-            self.error_code = fault_element.findtext(
-                f"{upnp_error_prefix}errorCode"
+            self.fault_code = fault_element.findtext("faultcode") or ""
+            self.fault_string = fault_element.findtext("faultstring") or ""
+            self.error_code = (
+                fault_element.findtext(f"{upnp_error_prefix}errorCode") or ""
             )
-            self.error_description = fault_element.findtext(
-                f"{upnp_error_prefix}errorDescription"
+            self.error_description = (
+                fault_element.findtext(f"{upnp_error_prefix}errorDescription")
+                or ""
             )
             details = (
                 f" SOAP Fault {self.fault_code}:{self.fault_string}, "

--- a/pywemo/exceptions.py
+++ b/pywemo/exceptions.py
@@ -9,6 +9,30 @@ class ActionException(PyWeMoException):
     """Generic exceptions when dealing with SOAP request Actions."""
 
 
+class SOAPFault(ActionException):
+    """Raised when the SOAP response contains a Fault message."""
+
+    def __init__(self, fault_element):
+        """Initialize from a SOAP Fault lxml.etree Element."""
+        upnp_error_prefix = (
+            "detail"
+            "/{urn:schemas-upnp-org:control-1-0}UPnPError/"
+            "{urn:schemas-upnp-org:control-1-0}"
+        )
+        self.fault_code = fault_element.findtext("faultcode")
+        self.fault_string = fault_element.findtext("faultstring")
+        self.error_code = fault_element.findtext(
+            f"{upnp_error_prefix}errorCode"
+        )
+        self.error_description = fault_element.findtext(
+            f"{upnp_error_prefix}errorDescription"
+        )
+        super().__init__(
+            f"SOAP Fault {self.fault_code}:{self.fault_string}, "
+            f"{self.error_code}:{self.error_description}"
+        )
+
+
 class SubscriptionRegistryFailed(PyWeMoException):
     """General exceptions related to the subscription registry."""
 

--- a/pywemo/exceptions.py
+++ b/pywemo/exceptions.py
@@ -12,25 +12,33 @@ class ActionException(PyWeMoException):
 class SOAPFault(ActionException):
     """Raised when the SOAP response contains a Fault message."""
 
-    def __init__(self, fault_element):
+    fault_code: str = ""
+    fault_string: str = ""
+    error_code: str = ""
+    error_description: str = ""
+
+    def __init__(self, message, fault_element=None):
         """Initialize from a SOAP Fault lxml.etree Element."""
-        upnp_error_prefix = (
-            "detail"
-            "/{urn:schemas-upnp-org:control-1-0}UPnPError/"
-            "{urn:schemas-upnp-org:control-1-0}"
-        )
-        self.fault_code = fault_element.findtext("faultcode")
-        self.fault_string = fault_element.findtext("faultstring")
-        self.error_code = fault_element.findtext(
-            f"{upnp_error_prefix}errorCode"
-        )
-        self.error_description = fault_element.findtext(
-            f"{upnp_error_prefix}errorDescription"
-        )
-        super().__init__(
-            f"SOAP Fault {self.fault_code}:{self.fault_string}, "
-            f"{self.error_code}:{self.error_description}"
-        )
+        details = ""
+        if fault_element is not None:
+            upnp_error_prefix = (
+                "detail"
+                "/{urn:schemas-upnp-org:control-1-0}UPnPError/"
+                "{urn:schemas-upnp-org:control-1-0}"
+            )
+            self.fault_code = fault_element.findtext("faultcode")
+            self.fault_string = fault_element.findtext("faultstring")
+            self.error_code = fault_element.findtext(
+                f"{upnp_error_prefix}errorCode"
+            )
+            self.error_description = fault_element.findtext(
+                f"{upnp_error_prefix}errorDescription"
+            )
+            details = (
+                f" SOAP Fault {self.fault_code}:{self.fault_string}, "
+                f"{self.error_code}:{self.error_description}"
+            )
+        super().__init__(f"{message}{details}")
 
 
 class SubscriptionRegistryFailed(PyWeMoException):

--- a/pywemo/ouimeaux_device/api/service.py
+++ b/pywemo/ouimeaux_device/api/service.py
@@ -225,7 +225,10 @@ class Action:
                     response_element.tag
                     == "{http://schemas.xmlsoap.org/soap/envelope/}Fault"
                 ):
-                    raise SOAPFault(response_element)
+                    raise SOAPFault(
+                        f"Error calling {self.soap_action}",
+                        fault_element=response_element,
+                    )
                 return {
                     response_item.tag: response_item.text
                     for response_item in response_element


### PR DESCRIPTION
## Description:

With this PR SOAP responses containing a device error will cause an exception to be raised. Prior to this PR, these errors were silently ignored when calling `get_state` (the internal `_state` variable was set to `0`) and the caller had no way of knowing if the call failed. This PR adds a new SOAPFault exception that is a child class of ActionException and is raised when a SOAP response message indicates a device failure.

I discovered this via Home Assistant. One of my devices wasn't controllable but there was no indication in the UI that it had failed. It was failing and was returning a SOAP Fault response. Raising the SOAPFault exception allows the client, HA in this case, to be aware of the failure and update the UI accordingly. In this case, making the failing device unavailable in the UI.

**Related issue (if applicable):** 

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] There is no commented out code in this PR.
  - [x] I have read and agree to the [CONTRIBUTING document](
        https://github.com/pavoni/pywemo/blob/master/CONTRIBUTING.md).