### PR TITLE
Insight devices require polling after turned off

### DIFF
--- a/pywemo/ouimeaux_device/insight.py
+++ b/pywemo/ouimeaux_device/insight.py
@@ -32,7 +32,14 @@ class Insight(Switch):
         if _type == "InsightParams":
             self.insight_params = self.parse_insight_params(_params)
             return True
-        return Switch.subscription_update(self, _type, _params)
+        updated = Switch.subscription_update(self, _type, _params)
+        if _type == "BinaryState" and updated:
+            # Special case: When an Insight device turns off, it also stops
+            # sending InsightParams updates. Return False in this case to
+            # indicate that the current state of the device hasn't been fully
+            # updated.
+            return self._state != 0
+        return updated
 
     @staticmethod
     def parse_insight_params(params):

--- a/pywemo/ouimeaux_device/insight.py
+++ b/pywemo/ouimeaux_device/insight.py
@@ -32,7 +32,7 @@ class Insight(Switch):
         if _type == "InsightParams":
             self.insight_params = self.parse_insight_params(_params)
             return True
-        updated = Switch.subscription_update(self, _type, _params)
+        updated = super().subscription_update(_type, _params)
         if _type == "BinaryState" and updated:
             # Special case: When an Insight device turns off, it also stops
             # sending InsightParams updates. Return False in this case to

--- a/tests/ouimeaux_device/test_insight.py
+++ b/tests/ouimeaux_device/test_insight.py
@@ -88,3 +88,13 @@ class Test_Insight:
         assert insight.get_standby_state == 'standby'
 
         subscription_registry.unregister(insight)
+
+    def test_subscription_update(self, insight):
+        assert insight.subscription_update("BinaryState", "8") is True
+        assert insight.subscription_update("BinaryState", "1") is True
+        assert insight.subscription_update("BinaryState", "0") is False
+        params = (
+            "8|1611105078|2607|0|12416|1209600|328|500|457600|69632638|9500"
+        )
+        assert insight.subscription_update("InsightParams", params) is True
+        assert insight.subscription_update("UnknownParam", "1") is False


### PR DESCRIPTION
## Description:

There is an edge case for the Insight devices where they no longer push updates for energy consumption (`InsightParams`) when turned off. That causes the previous Insight values to remain fixed until the device is turned on again. In particular, `currentpower` isn't updated and it should be `0` when off.

This was discovered by @u8915055 in https://github.com/home-assistant/core/issues/54113. To fix this, I'm changing the `subscription_update` method to return `False` when the device reports that it has turned off. `False` indicates that the subscription push message did not contain enough information to fully update the state; and the caller should call `get_state(force_update=True)` to poll for the current state.

An alternate solution could be to set the `currentpower` attribute to `0` when the BinaryState is updated to `0`. That would avoid needing to poll the state with `get_state`. I ended up not doing that just in case some of the other Insight parameters also changed (`lastchange`, for example). It seemed safer to just poll.

**Related issue (if applicable):** https://github.com/home-assistant/core/issues/54113

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] There is no commented out code in this PR.
  - [x] I have read and agree to the [CONTRIBUTING document](
        https://github.com/pavoni/pywemo/blob/master/CONTRIBUTING.md).