### PR TITLE
Add support for Wemo CrockPot Slow Cooker

### DIFF
--- a/pywemo/__init__.py
+++ b/pywemo/__init__.py
@@ -6,6 +6,7 @@ from .exceptions import PyWeMoException
 from .ouimeaux_device import Device as WeMoDevice
 from .ouimeaux_device.bridge import Bridge
 from .ouimeaux_device.coffeemaker import CoffeeMaker
+from .ouimeaux_device.crockpot import CrockPot
 from .ouimeaux_device.dimmer import Dimmer
 from .ouimeaux_device.humidifier import Humidifier
 from .ouimeaux_device.insight import Insight

--- a/pywemo/discovery.py
+++ b/pywemo/discovery.py
@@ -13,6 +13,7 @@ from .ouimeaux_device.api.service import REQUESTS_TIMEOUT
 from .ouimeaux_device.api.xsd import device as deviceParser
 from .ouimeaux_device.bridge import Bridge
 from .ouimeaux_device.coffeemaker import CoffeeMaker
+from .ouimeaux_device.crockpot import CrockPot
 from .ouimeaux_device.dimmer import Dimmer
 from .ouimeaux_device.humidifier import Humidifier
 from .ouimeaux_device.insight import Insight
@@ -87,6 +88,8 @@ def device_from_uuid_and_location(uuid, location, debug=False):
         return Bridge(location)
     if uuid.startswith('uuid:CoffeeMaker'):
         return CoffeeMaker(location)
+    if uuid.startswith('uuid:Crockpot'):
+        return CrockPot(location)
     if uuid.startswith('uuid:Humidifier'):
         return Humidifier(location)
     if uuid.startswith('uuid:OutdoorPlug'):

--- a/pywemo/ouimeaux_device/crockpot.py
+++ b/pywemo/ouimeaux_device/crockpot.py
@@ -1,6 +1,4 @@
 """Representation of a WeMo CrockPot device."""
-import sys
-
 from lxml import etree as et
 
 from pywemo.ouimeaux_device.api.xsd.device import quote_xml
@@ -27,6 +25,7 @@ MODE_NAMES = {
 
 class CrockPot(Switch):
     def __init__(self, *args, **kwargs):
+        """Create a WeMo CrockPot device."""
         Switch.__init__(self, *args, **kwargs)
         self._attributes = {}
 
@@ -40,8 +39,6 @@ class CrockPot(Switch):
         if stateAttributes is not None and stateAttributes["mode"] is not None and stateAttributes["time"] is not None and stateAttributes["cookedTime"] is not None:
             self._attributes = stateAttributes
             self._state = self.mode
-
-        logging.getLogger(__name__).info("Updated CrockPot attributes: " + str(self._attributes))
 
     def subscription_update(self, _type, _params):
         """
@@ -65,18 +62,22 @@ class CrockPot(Switch):
 
     @property
     def mode(self) -> int:
+        """Return the mode of the device."""
         return int(self._attributes.get('mode'))
 
     @property
     def mode_string(self) -> str:
+        """Return the mode of the device as a string."""
         return MODE_NAMES.get(self.mode, "Unknown")
 
     @property
     def remaining_time(self) -> int:
+        """Return the remaining time in minutes."""
         return int(self._attributes.get('time'))
 
     @property
     def cooked_time(self) -> int:
+        """Return the cooked time in minutes."""
         return int(self._attributes.get('cookedTime'))
 
     def get_state(self, force_update=False):
@@ -88,8 +89,7 @@ class CrockPot(Switch):
         if force_update or self.mode is None:
             self.update_attributes()
 
-        # Consider the CrockPot to be "on" if it's currently set to "Warm" or higher
-        return int(int(self.mode) >= CrockPotMode.Warm)
+        return int(self.mode != CrockPotMode.Off)
 
     def set_state(self, state):
         """

--- a/pywemo/ouimeaux_device/crockpot.py
+++ b/pywemo/ouimeaux_device/crockpot.py
@@ -35,9 +35,6 @@ class CrockPot(Switch):
         Switch.__init__(self, *args, **kwargs)
         self._attributes = {}
 
-    def __repr__(self):
-        return '<WeMo CrockPot "{name}">'.format(name=self.name)
-
     def update_attributes(self):
         """
         Request state from device
@@ -70,12 +67,6 @@ class CrockPot(Switch):
             return True
 
         return Switch.subscription_update(self, _type, _params)
-
-
-    @property
-    def device_type(self):
-        """Return what kind of WeMo this device is."""
-        return "SlowCooker"
 
     @property
     def mode(self):

--- a/pywemo/ouimeaux_device/crockpot.py
+++ b/pywemo/ouimeaux_device/crockpot.py
@@ -95,18 +95,17 @@ class CrockPot(Switch):
         """
         Set the state of this device to on or off.
         """
-
         if state:
-            self.basicevent.SetCrockpotState(mode=str(CrockPotMode.High), time=self._attributes.get('time'))
+            self.update_settings(CrockPotMode.High, int(self._attributes.get('time')))
         else:
-            self.basicevent.SetCrockpotState(mode=str(CrockPotMode.Off), time=self._attributes.get('time'))
+            self.update_settings(CrockPotMode.Off, 0)
+    
+    def update_settings(self, mode : CrockPotMode, time : int):
+        """
+        Update mode and cooking time
+        """
+        self.basicevent.SetCrockpotState(mode=str(int(mode)), time=str(time))
 
         # The CrockPot might not be ready - so it's not safe to assume the state is what you just set
         # so re-read it from the device
         self.get_state(True)
-    
-    def update_settings(self, mode, time):
-        """
-        Update mode and cooking time
-        """
-        self.basicevent.SetCrockpotState(mode=str(mode), time=str(time))

--- a/pywemo/ouimeaux_device/crockpot.py
+++ b/pywemo/ouimeaux_device/crockpot.py
@@ -24,7 +24,7 @@ class CrockPotMode(IntEnum):
     High = 52
 
 MODE_NAMES = {
-    CrockPotMode.Off: "Off",
+    CrockPotMode.Off: "Turned Off",
     CrockPotMode.Warm: "Warm",
     CrockPotMode.Low: "Low",
     CrockPotMode.High: "High",
@@ -74,7 +74,7 @@ class CrockPot(Switch):
 
     @property
     def mode_string(self):
-        return MODE_NAMES.get(self._state, "Unknown")
+        return MODE_NAMES.get(int(self.mode), "Unknown")
 
     @property
     def remaining_time(self):
@@ -90,11 +90,11 @@ class CrockPot(Switch):
         """
         # The base implementation using GetBinaryState doesn't work for CrockPot (always returns 0)
         # so use mode instead.
-        if force_update or self._state is None:
+        if force_update or self.mode is None:
             self.update_attributes()
 
         # Consider the CrockPot to be "on" if it's currently set to "Warm" or higher
-        return int(self._state >= CrockPotMode.Warm)
+        return int(int(self.mode) >= CrockPotMode.Warm)
 
     def set_state(self, state):
         """

--- a/pywemo/ouimeaux_device/crockpot.py
+++ b/pywemo/ouimeaux_device/crockpot.py
@@ -1,0 +1,126 @@
+"""Representation of a WeMo CrockPot device."""
+import sys
+
+from lxml import etree as et
+
+from pywemo.ouimeaux_device.api.xsd.device import quote_xml
+
+from .switch import Switch
+import logging
+
+if sys.version_info[0] < 3:
+    class IntEnum:
+        """Enum class."""
+        pass
+else:
+    from enum import IntEnum
+
+# These enums were derived from the CrockPot.basicevent.GetCrockpotState() service call
+# Thus these names/values were not chosen randomly and the numbers have meaning.
+class CrockPotMode(IntEnum):
+    Off = 0 
+    Warm = 50
+    Low = 51
+    High = 52
+
+MODE_NAMES = {
+    CrockPotMode.Off: "Off",
+    CrockPotMode.Warm: "Warm",
+    CrockPotMode.Low: "Low",
+    CrockPotMode.High: "High",
+}
+
+class CrockPot(Switch):
+    def __init__(self, *args, **kwargs):
+        Switch.__init__(self, *args, **kwargs)
+        self._attributes = {}
+
+    def __repr__(self):
+        return '<WeMo CrockPot "{name}">'.format(name=self.name)
+
+    def update_attributes(self):
+        """
+        Request state from device
+        """
+        stateAttributes = self.basicevent.GetCrockpotState()
+
+        # Only update our state on complete updates from the device
+        if stateAttributes is not None and stateAttributes["mode"] is not None and stateAttributes["time"] is not None and stateAttributes["cookedTime"] is not None:
+            self._attributes = stateAttributes
+            self._state = int(self.mode)
+
+        logging.getLogger(__name__).info("Updated CrockPot attributes: " + str(self._attributes))
+
+    def subscription_update(self, _type, _params):
+        """
+        Handle reports from device
+        """
+        if _params is None:
+            return False
+
+        if _type == "mode":
+            self._attributes['mode'] = str(_params)
+            self._state = int(self.mode)
+            return True
+        elif _type == "time":
+            self._attributes['time'] = str(_params)
+            return True
+        elif _type == "cookedTime":
+            self._attributes['cookedTime'] = str(_params)
+            return True
+
+        return Switch.subscription_update(self, _type, _params)
+
+
+    @property
+    def device_type(self):
+        """Return what kind of WeMo this device is."""
+        return "SlowCooker"
+
+    @property
+    def mode(self):
+        return self._attributes.get('mode')
+
+    @property
+    def mode_string(self):
+        return MODE_NAMES.get(self._state, "Unknown")
+
+    @property
+    def remaining_time(self):
+        return self._attributes.get('time')
+
+    @property
+    def cooked_time(self):
+        return self._attributes.get('cookedTime')
+
+    def get_state(self, force_update=False):
+        """
+        Returns 0 if off and 1 if on.
+        """
+        # The base implementation using GetBinaryState doesn't work for CrockPot (always returns 0)
+        # so use mode instead.
+        if force_update or self._state is None:
+            self.update_attributes()
+
+        # Consider the CrockPot to be "on" if it's currently set to "Warm" or higher
+        return int(self._state >= CrockPotMode.Warm)
+
+    def set_state(self, state):
+        """
+        Set the state of this device to on or off.
+        """
+
+        if state:
+            self.basicevent.SetCrockpotState(mode=str(int(CrockPotMode.High)), time=self._attributes.get('time'))
+        else:
+            self.basicevent.SetCrockpotState(mode=str(int(CrockPotMode.Off)), time=self._attributes.get('time'))
+
+        # The CrockPot might not be ready - so it's not safe to assume the state is what you just set
+        # so re-read it from the device
+        self.get_state(True)
+    
+    def update_settings(self, mode, time):
+        """
+        Update mode and cooking time
+        """
+        self.basicevent.SetCrockpotState(mode=str(mode), time=str(time))

--- a/pywemo/ouimeaux_device/crockpot.py
+++ b/pywemo/ouimeaux_device/crockpot.py
@@ -8,25 +8,20 @@ from pywemo.ouimeaux_device.api.xsd.device import quote_xml
 from .switch import Switch
 import logging
 
-if sys.version_info[0] < 3:
-    class IntEnum:
-        """Enum class."""
-        pass
-else:
-    from enum import IntEnum
+from enum import IntEnum
 
 # These enums were derived from the CrockPot.basicevent.GetCrockpotState() service call
 # Thus these names/values were not chosen randomly and the numbers have meaning.
 class CrockPotMode(IntEnum):
-    Off = 0 
+    Off  = 0 
     Warm = 50
-    Low = 51
+    Low  = 51
     High = 52
 
 MODE_NAMES = {
-    CrockPotMode.Off: "Turned Off",
+    CrockPotMode.Off:  "Turned Off",
     CrockPotMode.Warm: "Warm",
-    CrockPotMode.Low: "Low",
+    CrockPotMode.Low:  "Low",
     CrockPotMode.High: "High",
 }
 
@@ -44,7 +39,7 @@ class CrockPot(Switch):
         # Only update our state on complete updates from the device
         if stateAttributes is not None and stateAttributes["mode"] is not None and stateAttributes["time"] is not None and stateAttributes["cookedTime"] is not None:
             self._attributes = stateAttributes
-            self._state = int(self.mode)
+            self._state = self.mode
 
         logging.getLogger(__name__).info("Updated CrockPot attributes: " + str(self._attributes))
 
@@ -57,7 +52,7 @@ class CrockPot(Switch):
 
         if _type == "mode":
             self._attributes['mode'] = str(_params)
-            self._state = int(self.mode)
+            self._state = self.mode
             return True
         elif _type == "time":
             self._attributes['time'] = str(_params)
@@ -69,20 +64,20 @@ class CrockPot(Switch):
         return Switch.subscription_update(self, _type, _params)
 
     @property
-    def mode(self):
-        return self._attributes.get('mode')
+    def mode(self) -> int:
+        return int(self._attributes.get('mode'))
 
     @property
-    def mode_string(self):
-        return MODE_NAMES.get(int(self.mode), "Unknown")
+    def mode_string(self) -> str:
+        return MODE_NAMES.get(self.mode, "Unknown")
 
     @property
-    def remaining_time(self):
-        return self._attributes.get('time')
+    def remaining_time(self) -> int:
+        return int(self._attributes.get('time'))
 
     @property
-    def cooked_time(self):
-        return self._attributes.get('cookedTime')
+    def cooked_time(self) -> int:
+        return int(self._attributes.get('cookedTime'))
 
     def get_state(self, force_update=False):
         """
@@ -102,9 +97,9 @@ class CrockPot(Switch):
         """
 
         if state:
-            self.basicevent.SetCrockpotState(mode=str(int(CrockPotMode.High)), time=self._attributes.get('time'))
+            self.basicevent.SetCrockpotState(mode=str(CrockPotMode.High), time=self._attributes.get('time'))
         else:
-            self.basicevent.SetCrockpotState(mode=str(int(CrockPotMode.Off)), time=self._attributes.get('time'))
+            self.basicevent.SetCrockpotState(mode=str(CrockPotMode.Off), time=self._attributes.get('time'))
 
         # The CrockPot might not be ready - so it's not safe to assume the state is what you just set
         # so re-read it from the device

--- a/pywemo/ouimeaux_device/crockpot.py
+++ b/pywemo/ouimeaux_device/crockpot.py
@@ -1,27 +1,29 @@
 """Representation of a WeMo CrockPot device."""
-from lxml import etree as et
+import logging
+from enum import IntEnum
 
+from lxml import etree as et
 from pywemo.ouimeaux_device.api.xsd.device import quote_xml
 
 from .switch import Switch
-import logging
 
-from enum import IntEnum
 
 # These enums were derived from the CrockPot.basicevent.GetCrockpotState() service call
 # Thus these names/values were not chosen randomly and the numbers have meaning.
 class CrockPotMode(IntEnum):
-    Off  = 0 
+    Off = 0
     Warm = 50
-    Low  = 51
+    Low = 51
     High = 52
 
+
 MODE_NAMES = {
-    CrockPotMode.Off:  "Turned Off",
+    CrockPotMode.Off: "Turned Off",
     CrockPotMode.Warm: "Warm",
-    CrockPotMode.Low:  "Low",
+    CrockPotMode.Low: "Low",
     CrockPotMode.High: "High",
 }
+
 
 class CrockPot(Switch):
     def __init__(self, *args, **kwargs):
@@ -36,7 +38,12 @@ class CrockPot(Switch):
         stateAttributes = self.basicevent.GetCrockpotState()
 
         # Only update our state on complete updates from the device
-        if stateAttributes is not None and stateAttributes["mode"] is not None and stateAttributes["time"] is not None and stateAttributes["cookedTime"] is not None:
+        if (
+            stateAttributes is not None
+            and stateAttributes["mode"] is not None
+            and stateAttributes["time"] is not None
+            and stateAttributes["cookedTime"] is not None
+        ):
             self._attributes = stateAttributes
             self._state = self.mode
 
@@ -96,11 +103,13 @@ class CrockPot(Switch):
         Set the state of this device to on or off.
         """
         if state:
-            self.update_settings(CrockPotMode.High, int(self._attributes.get('time')))
+            self.update_settings(
+                CrockPotMode.High, int(self._attributes.get('time'))
+            )
         else:
             self.update_settings(CrockPotMode.Off, 0)
-    
-    def update_settings(self, mode : CrockPotMode, time : int):
+
+    def update_settings(self, mode: CrockPotMode, time: int):
         """
         Update mode and cooking time
         """


### PR DESCRIPTION
## Description:
Add support for [Wemo CrockPot Slow Cooker](https://www.belkin.com/us/support-article?articleNum=101177#:~:text=%20%20%201%20Step%201%3A%20Open%20the,instructions...%206%20Step%2010%3A%20Tap%20NEXT.%20More%20)

Old device that's probably out of production at this point but still supported by Wemo. I've been running with this for awhile but finally got around to contributing the changes after cleaning them up.

**Related issue (if applicable):** fixes #<pywemo issue number goes here>

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] There is no commented out code in this PR.
  - [x] I have read and agree to the [CONTRIBUTING document](
        https://github.com/pavoni/pywemo/blob/master/CONTRIBUTING.md).