### PR TITLE
Use separate classes for the V1 & V2 dimmers

### DIFF
--- a/pywemo/__init__.py
+++ b/pywemo/__init__.py
@@ -7,7 +7,7 @@ from .ouimeaux_device import Device as WeMoDevice
 from .ouimeaux_device.bridge import Bridge
 from .ouimeaux_device.coffeemaker import CoffeeMaker
 from .ouimeaux_device.crockpot import CrockPot
-from .ouimeaux_device.dimmer import Dimmer
+from .ouimeaux_device.dimmer import Dimmer, DimmerV1
 from .ouimeaux_device.humidifier import Humidifier
 from .ouimeaux_device.insight import Insight
 from .ouimeaux_device.lightswitch import LightSwitch

--- a/pywemo/discovery.py
+++ b/pywemo/discovery.py
@@ -14,7 +14,7 @@ from .ouimeaux_device.api.xsd import device as deviceParser
 from .ouimeaux_device.bridge import Bridge
 from .ouimeaux_device.coffeemaker import CoffeeMaker
 from .ouimeaux_device.crockpot import CrockPot
-from .ouimeaux_device.dimmer import Dimmer
+from .ouimeaux_device.dimmer import Dimmer, DimmerV1
 from .ouimeaux_device.humidifier import Humidifier
 from .ouimeaux_device.insight import Insight
 from .ouimeaux_device.lightswitch import LightSwitch
@@ -76,6 +76,8 @@ def device_from_uuid_and_location(uuid, location, debug=False):
         return Switch(location)
     if uuid.startswith('uuid:Lightswitch'):
         return LightSwitch(location)
+    if uuid.startswith('uuid:Dimmer-1_0'):
+        return DimmerV1(location)
     if uuid.startswith('uuid:Dimmer'):
         return Dimmer(location)
     if uuid.startswith('uuid:Insight'):

--- a/pywemo/ouimeaux_device/dimmer.py
+++ b/pywemo/ouimeaux_device/dimmer.py
@@ -3,7 +3,7 @@ from .api.long_press import LongPressMixin
 from .switch import Switch
 
 
-class Dimmer(Switch, LongPressMixin):
+class Dimmer(Switch):
     """Representation of a WeMo Dimmer device."""
 
     def __init__(self, *args, **kwargs):

--- a/pywemo/ouimeaux_device/dimmer.py
+++ b/pywemo/ouimeaux_device/dimmer.py
@@ -48,3 +48,7 @@ class Dimmer(Switch, LongPressMixin):
                 return False
             return True
         return super().subscription_update(_type, _param)
+
+
+class DimmerV1(Dimmer, LongPressMixin):
+    """WeMo Dimmer device that supports long press."""

--- a/tests/ouimeaux_device/test_dimmer.py
+++ b/tests/ouimeaux_device/test_dimmer.py
@@ -2,7 +2,7 @@
 
 import pytest
 
-from pywemo import Dimmer
+from pywemo import Dimmer, DimmerV1
 
 from .api.unit import long_press_helpers
 
@@ -49,6 +49,15 @@ class Test_PVT_OWRT_Dimmer_v1(Base, long_press_helpers.TestLongPress):
     @pytest.fixture
     def dimmer(self, vcr):
         with vcr.use_cassette('WeMo_WW_2.00.11453.PVT-OWRT-Dimmer'):
-            return Dimmer('http://192.168.1.100:49153/setup.xml')
+            return DimmerV1('http://192.168.1.100:49153/setup.xml')
 
     device = dimmer  # for TestLongPress
+
+
+class Test_PVT_RTOS_Dimmer_v2(Base):
+    """Tests for the WeMo Dimmer, hardware version v2."""
+
+    @pytest.fixture
+    def dimmer(self, vcr):
+        with vcr.use_cassette('WEMO_WW_2.00.20110904.PVT-RTOS-DimmerV2'):
+            return Dimmer('http://192.168.1.100:49153/setup.xml')

--- a/tests/vcr/tests.ouimeaux_device.test_dimmer/Test_PVT_RTOS_Dimmer_v2.test_set_brightness[0-0-100].yaml
+++ b/tests/vcr/tests.ouimeaux_device.test_dimmer/Test_PVT_RTOS_Dimmer_v2.test_set_brightness[0-0-100].yaml
@@ -1,0 +1,75 @@
+interactions:
+- request:
+    body: '<?xml version="1.0" encoding="utf-8"?>
+
+      <s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/" s:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/">
+
+      <s:Body>
+
+      <u:SetBinaryState xmlns:u="urn:Belkin:service:basicevent:1">
+
+      <BinaryState>0</BinaryState>
+
+      </u:SetBinaryState>
+
+      </s:Body>
+
+      </s:Envelope>'
+    headers:
+      Content-Type:
+      - text/xml
+      SOAPACTION:
+      - '"urn:Belkin:service:basicevent:1#SetBinaryState"'
+    method: POST
+    uri: http://192.168.1.100:49153/upnp/control/basicevent1
+  response:
+    body:
+      string: "<s:Envelope xmlns:s=\"http://schemas.xmlsoap.org/soap/envelope/\" s:encodingStyle=\"http://schemas.xmlsoap.org/soap/encoding/\">\r\n<s:Body>\r\n<u:SetBinaryStateResponse
+        xmlns:u=\"urn:Belkin:service:basicevent:1\"><BinaryState>0</BinaryState><brightness>100</brightness><CountdownEndTime>0</CountdownEndTime><deviceCurrentTime>1639275937</deviceCurrentTime></u:SetBinaryStateResponse></s:Body>\r\n</s:Envelope>"
+    headers:
+      Connection:
+      - close
+      Content-Length:
+      - '398'
+      Content-Type:
+      - text/xml
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '<?xml version="1.0" encoding="utf-8"?>
+
+      <s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/" s:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/">
+
+      <s:Body>
+
+      <u:GetBinaryState xmlns:u="urn:Belkin:service:basicevent:1">
+
+
+      </u:GetBinaryState>
+
+      </s:Body>
+
+      </s:Envelope>'
+    headers:
+      Content-Type:
+      - text/xml
+      SOAPACTION:
+      - '"urn:Belkin:service:basicevent:1#GetBinaryState"'
+    method: POST
+    uri: http://192.168.1.100:49153/upnp/control/basicevent1
+  response:
+    body:
+      string: "<s:Envelope xmlns:s=\"http://schemas.xmlsoap.org/soap/envelope/\" s:encodingStyle=\"http://schemas.xmlsoap.org/soap/encoding/\">\r\n<s:Body>\r\n<u:GetBinaryStateResponse
+        xmlns:u=\"urn:Belkin:service:basicevent:1\"><BinaryState>0</BinaryState><brightness>100</brightness></u:GetBinaryStateResponse></s:Body>\r\n</s:Envelope>"
+    headers:
+      Connection:
+      - close
+      Content-Length:
+      - '311'
+      Content-Type:
+      - text/xml
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/vcr/tests.ouimeaux_device.test_dimmer/Test_PVT_RTOS_Dimmer_v2.test_set_brightness[100-1-100].yaml
+++ b/tests/vcr/tests.ouimeaux_device.test_dimmer/Test_PVT_RTOS_Dimmer_v2.test_set_brightness[100-1-100].yaml
@@ -1,0 +1,77 @@
+interactions:
+- request:
+    body: '<?xml version="1.0" encoding="utf-8"?>
+
+      <s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/" s:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/">
+
+      <s:Body>
+
+      <u:SetBinaryState xmlns:u="urn:Belkin:service:basicevent:1">
+
+      <BinaryState>1</BinaryState>
+
+      <brightness>100</brightness>
+
+      </u:SetBinaryState>
+
+      </s:Body>
+
+      </s:Envelope>'
+    headers:
+      Content-Type:
+      - text/xml
+      SOAPACTION:
+      - '"urn:Belkin:service:basicevent:1#SetBinaryState"'
+    method: POST
+    uri: http://192.168.1.100:49153/upnp/control/basicevent1
+  response:
+    body:
+      string: "<s:Envelope xmlns:s=\"http://schemas.xmlsoap.org/soap/envelope/\" s:encodingStyle=\"http://schemas.xmlsoap.org/soap/encoding/\">\r\n<s:Body>\r\n<u:SetBinaryStateResponse
+        xmlns:u=\"urn:Belkin:service:basicevent:1\"><BinaryState>1</BinaryState><brightness>100</brightness><CountdownEndTime>0</CountdownEndTime><deviceCurrentTime>1639275936</deviceCurrentTime></u:SetBinaryStateResponse></s:Body>\r\n</s:Envelope>"
+    headers:
+      Connection:
+      - close
+      Content-Length:
+      - '398'
+      Content-Type:
+      - text/xml
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '<?xml version="1.0" encoding="utf-8"?>
+
+      <s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/" s:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/">
+
+      <s:Body>
+
+      <u:GetBinaryState xmlns:u="urn:Belkin:service:basicevent:1">
+
+
+      </u:GetBinaryState>
+
+      </s:Body>
+
+      </s:Envelope>'
+    headers:
+      Content-Type:
+      - text/xml
+      SOAPACTION:
+      - '"urn:Belkin:service:basicevent:1#GetBinaryState"'
+    method: POST
+    uri: http://192.168.1.100:49153/upnp/control/basicevent1
+  response:
+    body:
+      string: "<s:Envelope xmlns:s=\"http://schemas.xmlsoap.org/soap/envelope/\" s:encodingStyle=\"http://schemas.xmlsoap.org/soap/encoding/\">\r\n<s:Body>\r\n<u:GetBinaryStateResponse
+        xmlns:u=\"urn:Belkin:service:basicevent:1\"><BinaryState>1</BinaryState><brightness>100</brightness></u:GetBinaryStateResponse></s:Body>\r\n</s:Envelope>"
+    headers:
+      Connection:
+      - close
+      Content-Length:
+      - '311'
+      Content-Type:
+      - text/xml
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/vcr/tests.ouimeaux_device.test_dimmer/Test_PVT_RTOS_Dimmer_v2.test_set_brightness[45-1-45].yaml
+++ b/tests/vcr/tests.ouimeaux_device.test_dimmer/Test_PVT_RTOS_Dimmer_v2.test_set_brightness[45-1-45].yaml
@@ -1,0 +1,77 @@
+interactions:
+- request:
+    body: '<?xml version="1.0" encoding="utf-8"?>
+
+      <s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/" s:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/">
+
+      <s:Body>
+
+      <u:SetBinaryState xmlns:u="urn:Belkin:service:basicevent:1">
+
+      <BinaryState>1</BinaryState>
+
+      <brightness>45</brightness>
+
+      </u:SetBinaryState>
+
+      </s:Body>
+
+      </s:Envelope>'
+    headers:
+      Content-Type:
+      - text/xml
+      SOAPACTION:
+      - '"urn:Belkin:service:basicevent:1#SetBinaryState"'
+    method: POST
+    uri: http://192.168.1.100:49153/upnp/control/basicevent1
+  response:
+    body:
+      string: "<s:Envelope xmlns:s=\"http://schemas.xmlsoap.org/soap/envelope/\" s:encodingStyle=\"http://schemas.xmlsoap.org/soap/encoding/\">\r\n<s:Body>\r\n<u:SetBinaryStateResponse
+        xmlns:u=\"urn:Belkin:service:basicevent:1\"><BinaryState>1</BinaryState><brightness>45</brightness><CountdownEndTime>0</CountdownEndTime><deviceCurrentTime>1639275938</deviceCurrentTime></u:SetBinaryStateResponse></s:Body>\r\n</s:Envelope>"
+    headers:
+      Connection:
+      - close
+      Content-Length:
+      - '397'
+      Content-Type:
+      - text/xml
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '<?xml version="1.0" encoding="utf-8"?>
+
+      <s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/" s:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/">
+
+      <s:Body>
+
+      <u:GetBinaryState xmlns:u="urn:Belkin:service:basicevent:1">
+
+
+      </u:GetBinaryState>
+
+      </s:Body>
+
+      </s:Envelope>'
+    headers:
+      Content-Type:
+      - text/xml
+      SOAPACTION:
+      - '"urn:Belkin:service:basicevent:1#GetBinaryState"'
+    method: POST
+    uri: http://192.168.1.100:49153/upnp/control/basicevent1
+  response:
+    body:
+      string: "<s:Envelope xmlns:s=\"http://schemas.xmlsoap.org/soap/envelope/\" s:encodingStyle=\"http://schemas.xmlsoap.org/soap/encoding/\">\r\n<s:Body>\r\n<u:GetBinaryStateResponse
+        xmlns:u=\"urn:Belkin:service:basicevent:1\"><BinaryState>1</BinaryState><brightness>45</brightness></u:GetBinaryStateResponse></s:Body>\r\n</s:Envelope>"
+    headers:
+      Connection:
+      - close
+      Content-Length:
+      - '310'
+      Content-Type:
+      - text/xml
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/vcr/tests.ouimeaux_device.test_dimmer/Test_PVT_RTOS_Dimmer_v2.test_turn_off.yaml
+++ b/tests/vcr/tests.ouimeaux_device.test_dimmer/Test_PVT_RTOS_Dimmer_v2.test_turn_off.yaml
@@ -1,0 +1,75 @@
+interactions:
+- request:
+    body: '<?xml version="1.0" encoding="utf-8"?>
+
+      <s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/" s:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/">
+
+      <s:Body>
+
+      <u:SetBinaryState xmlns:u="urn:Belkin:service:basicevent:1">
+
+      <BinaryState>0</BinaryState>
+
+      </u:SetBinaryState>
+
+      </s:Body>
+
+      </s:Envelope>'
+    headers:
+      Content-Type:
+      - text/xml
+      SOAPACTION:
+      - '"urn:Belkin:service:basicevent:1#SetBinaryState"'
+    method: POST
+    uri: http://192.168.1.100:49153/upnp/control/basicevent1
+  response:
+    body:
+      string: "<s:Envelope xmlns:s=\"http://schemas.xmlsoap.org/soap/envelope/\" s:encodingStyle=\"http://schemas.xmlsoap.org/soap/encoding/\">\r\n<s:Body>\r\n<u:SetBinaryStateResponse
+        xmlns:u=\"urn:Belkin:service:basicevent:1\"><BinaryState>0</BinaryState><brightness>60</brightness><CountdownEndTime>0</CountdownEndTime><deviceCurrentTime>1639275934</deviceCurrentTime></u:SetBinaryStateResponse></s:Body>\r\n</s:Envelope>"
+    headers:
+      Connection:
+      - close
+      Content-Length:
+      - '397'
+      Content-Type:
+      - text/xml
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '<?xml version="1.0" encoding="utf-8"?>
+
+      <s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/" s:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/">
+
+      <s:Body>
+
+      <u:GetBinaryState xmlns:u="urn:Belkin:service:basicevent:1">
+
+
+      </u:GetBinaryState>
+
+      </s:Body>
+
+      </s:Envelope>'
+    headers:
+      Content-Type:
+      - text/xml
+      SOAPACTION:
+      - '"urn:Belkin:service:basicevent:1#GetBinaryState"'
+    method: POST
+    uri: http://192.168.1.100:49153/upnp/control/basicevent1
+  response:
+    body:
+      string: "<s:Envelope xmlns:s=\"http://schemas.xmlsoap.org/soap/envelope/\" s:encodingStyle=\"http://schemas.xmlsoap.org/soap/encoding/\">\r\n<s:Body>\r\n<u:GetBinaryStateResponse
+        xmlns:u=\"urn:Belkin:service:basicevent:1\"><BinaryState>0</BinaryState><brightness>60</brightness></u:GetBinaryStateResponse></s:Body>\r\n</s:Envelope>"
+    headers:
+      Connection:
+      - close
+      Content-Length:
+      - '310'
+      Content-Type:
+      - text/xml
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/vcr/tests.ouimeaux_device.test_dimmer/Test_PVT_RTOS_Dimmer_v2.test_turn_on.yaml
+++ b/tests/vcr/tests.ouimeaux_device.test_dimmer/Test_PVT_RTOS_Dimmer_v2.test_turn_on.yaml
@@ -1,0 +1,75 @@
+interactions:
+- request:
+    body: '<?xml version="1.0" encoding="utf-8"?>
+
+      <s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/" s:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/">
+
+      <s:Body>
+
+      <u:SetBinaryState xmlns:u="urn:Belkin:service:basicevent:1">
+
+      <BinaryState>1</BinaryState>
+
+      </u:SetBinaryState>
+
+      </s:Body>
+
+      </s:Envelope>'
+    headers:
+      Content-Type:
+      - text/xml
+      SOAPACTION:
+      - '"urn:Belkin:service:basicevent:1#SetBinaryState"'
+    method: POST
+    uri: http://192.168.1.100:49153/upnp/control/basicevent1
+  response:
+    body:
+      string: "<s:Envelope xmlns:s=\"http://schemas.xmlsoap.org/soap/envelope/\" s:encodingStyle=\"http://schemas.xmlsoap.org/soap/encoding/\">\r\n<s:Body>\r\n<u:SetBinaryStateResponse
+        xmlns:u=\"urn:Belkin:service:basicevent:1\"><BinaryState>1</BinaryState><brightness>60</brightness><CountdownEndTime>0</CountdownEndTime><deviceCurrentTime>1639275933</deviceCurrentTime></u:SetBinaryStateResponse></s:Body>\r\n</s:Envelope>"
+    headers:
+      Connection:
+      - close
+      Content-Length:
+      - '397'
+      Content-Type:
+      - text/xml
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '<?xml version="1.0" encoding="utf-8"?>
+
+      <s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/" s:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/">
+
+      <s:Body>
+
+      <u:GetBinaryState xmlns:u="urn:Belkin:service:basicevent:1">
+
+
+      </u:GetBinaryState>
+
+      </s:Body>
+
+      </s:Envelope>'
+    headers:
+      Content-Type:
+      - text/xml
+      SOAPACTION:
+      - '"urn:Belkin:service:basicevent:1#GetBinaryState"'
+    method: POST
+    uri: http://192.168.1.100:49153/upnp/control/basicevent1
+  response:
+    body:
+      string: "<s:Envelope xmlns:s=\"http://schemas.xmlsoap.org/soap/envelope/\" s:encodingStyle=\"http://schemas.xmlsoap.org/soap/encoding/\">\r\n<s:Body>\r\n<u:GetBinaryStateResponse
+        xmlns:u=\"urn:Belkin:service:basicevent:1\"><BinaryState>1</BinaryState><brightness>60</brightness></u:GetBinaryStateResponse></s:Body>\r\n</s:Envelope>"
+    headers:
+      Connection:
+      - close
+      Content-Length:
+      - '310'
+      Content-Type:
+      - text/xml
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/vcr/tests.ouimeaux_device.test_dimmer/WEMO_WW_2.00.20110904.PVT-RTOS-DimmerV2.yaml
+++ b/tests/vcr/tests.ouimeaux_device.test_dimmer/WEMO_WW_2.00.20110904.PVT-RTOS-DimmerV2.yaml
@@ -1,0 +1,300 @@
+interactions:
+- request:
+    body: null
+    headers: {}
+    method: GET
+    uri: http://192.168.1.100:49153/setup.xml
+  response:
+    body:
+      string: "<?xml version=\"1.0\"?><root xmlns=\"urn:Belkin:device-1-0\"><specVersion><major>1</major><minor>0</minor></specVersion><device><rtos>1</rtos><deviceType>urn:Belkin:device:dimmer:1</deviceType><friendlyName>WeMo
+        Device</friendlyName><presentationURL>/pluginpres.html</presentationURL><serialNumber>SERIALNUMBER</serialNumber><modelName>Dimmer</modelName><modelNumber>1.0</modelNumber><modelURL>http://www.belkin.com/plugin/</modelURL><manufacturer>Belkin
+        International Inc.</manufacturer><manufacturerURL>http://www.belkin.com</manufacturerURL><modelDescription>Belkin
+        Plugin Dimmer 1.0</modelDescription><UDN>uuid:Dimmer-2_0-SERIALNUMBER</UDN><UPC>123456789</UPC><hwVersion>v2</hwVersion><macAddress>001122334455</macAddress><firmwareVersion>WEMO_WW_2.00.20110904.PVT-RTOS-DimmerV2</firmwareVersion><iconVersion>1|49152</iconVersion><hkSetupCode>012-34-567</hkSetupCode><binaryState>0</binaryState><new_algo>1</new_algo><iconList><icon><mimetype>jpg</mimetype><width>100</width><height>100</height><depth>100</depth><url>icon.jpg</url></icon></iconList><serviceList><service><serviceType>urn:Belkin:service:WiFiSetup:1</serviceType><serviceId>urn:Belkin:serviceId:WiFiSetup1</serviceId><controlURL>/upnp/control/WiFiSetup1</controlURL><eventSubURL>/upnp/event/WiFiSetup1</eventSubURL><SCPDURL>/setupservice.xml</SCPDURL></service><service><serviceType>urn:Belkin:service:smartsetup:1</serviceType><serviceId>urn:Belkin:serviceId:smartsetup1</serviceId><controlURL>/upnp/control/smartsetup1</controlURL><eventSubURL>/upnp/event/smartsetup1</eventSubURL><SCPDURL>/smartsetup.xml</SCPDURL></service><service><serviceType>urn:Belkin:service:metainfo:1</serviceType><serviceId>urn:Belkin:serviceId:metainfo1</serviceId><controlURL>/upnp/control/metainfo1</controlURL><eventSubURL>/upnp/event/metainfo1</eventSubURL><SCPDURL>/metainfoservice.xml</SCPDURL></service><service><serviceType>urn:Belkin:service:timesync:1</serviceType><serviceId>urn:Belkin:serviceId:timesync1</serviceId><controlURL>/upnp/control/timesync1</controlURL><eventSubURL>/upnp/event/timesync1</eventSubURL><SCPDURL>/timesyncservice.xml</SCPDURL></service><service><serviceType>urn:Belkin:service:basicevent:1</serviceType><serviceId>urn:Belkin:serviceId:basicevent1</serviceId><controlURL>/upnp/control/basicevent1</controlURL><eventSubURL>/upnp/event/basicevent1</eventSubURL><SCPDURL>/eventservice.xml</SCPDURL></service><service><serviceType>urn:Belkin:service:rules:1</serviceType><serviceId>urn:Belkin:serviceId:rules1</serviceId><controlURL>/upnp/control/rules1</controlURL><eventSubURL>/upnp/event/rules1</eventSubURL><SCPDURL>/rulesservice.xml</SCPDURL></service><service><serviceType>urn:Belkin:service:deviceinfo:1</serviceType><serviceId>urn:Belkin:serviceId:deviceinfo1</serviceId><controlURL>/upnp/control/deviceinfo1</controlURL><eventSubURL>/upnp/event/deviceinfo1</eventSubURL><SCPDURL>/deviceinfoservice.xml</SCPDURL></service><service><serviceType>urn:Belkin:service:firmwareupdate:1</serviceType><serviceId>urn:Belkin:serviceId:firmwareupdate1</serviceId><controlURL>/upnp/control/firmwareupdate1</controlURL><eventSubURL>/upnp/event/firmwareupdate1</eventSubURL><SCPDURL>/firmwareupdate.xml</SCPDURL></service><service><serviceType>urn:Belkin:service:manufacture:1</serviceType><serviceId>urn:Belkin:serviceId:manufacture1</serviceId><controlURL>/upnp/control/manufacture1</controlURL><eventSubURL>/upnp/event/manufacture1</eventSubURL><SCPDURL>/manufacture.xml</SCPDURL></service></serviceList></device></root>\r\n\r\n"
+    headers:
+      Connection:
+      - close
+      Content-Length:
+      - '3506'
+      Content-Type:
+      - text/xml
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers: {}
+    method: GET
+    uri: http://192.168.1.100:49153/setupservice.xml
+  response:
+    body:
+      string: "<?xml version=\"1.0\"?><scpd xmlns=\"urn:Belkin:service-1-0\"><specVersion><major>1</major><minor>0</minor></specVersion><actionList>\r\n<action><name>GetApList</name><argumentList><argument><retval
+        /><name>ApList</name><relatedStateVariable>ApList</relatedStateVariable><direction>out</direction></argument></argumentList></action><action><name>GetNetworkList</name><argumentList><argument><retval
+        /><name>NetworkList</name><relatedStateVariable>NetworkList</relatedStateVariable><direction>out</direction></argument></argumentList></action><action><name>ConnectHomeNetwork</name><argumentList><argument><name>ssid</name><relatedStateVariable>ssid</relatedStateVariable><direction>in</direction></argument><argument><name>auth</name><relatedStateVariable>auth</relatedStateVariable><direction>in</direction></argument><argument><name>password</name><relatedStateVariable>password</relatedStateVariable><direction>in</direction></argument><argument><name>encrypt</name><relatedStateVariable>encrypt</relatedStateVariable><direction>in</direction></argument></argumentList></action><action><name>GetNetworkStatus</name><argumentList><argument><retval
+        /><name>NetworkStatus</name><relatedStateVariable>NetworkStatus</relatedStateVariable><direction>out</direction></argument></argumentList></action></actionList>\r\n<serviceStateTable>\r\n<stateVariable
+        sendEvents=\"yes\"><name>ApList</name><dataType>string</dataType></stateVariable><stateVariable
+        sendEvents=\"yes\"><name>NetworkList</name><dataType>string</dataType></stateVariable><stateVariable
+        sendEvents=\"yes\"><name>NetworkStatus</name><dataType>string</dataType></stateVariable><stateVariable
+        sendEvents=\"yes\"><name>ssid</name><dataType>string</dataType></stateVariable><stateVariable
+        sendEvents=\"yes\"><name>password</name><dataType>string</dataType></stateVariable><stateVariable
+        sendEvents=\"yes\"><name>auth</name><dataType>string</dataType></stateVariable><stateVariable
+        sendEvents=\"yes\"><name>encrypt</name><dataType>string</dataType></stateVariable></serviceStateTable>\r\n</scpd>\r\n\r\n"
+    headers:
+      Connection:
+      - close
+      Content-Length:
+      - '2029'
+      Content-Type:
+      - text/xml
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers: {}
+    method: GET
+    uri: http://192.168.1.100:49153/smartsetup.xml
+  response:
+    body:
+      string: "<?xml version=\"1.0\"?><scpd xmlns=\"urn:Belkin:service-1-0\"><specVersion><major>1</major><minor>0</minor></specVersion><actionList>\r\n<action><name>PairAndRegister</name><argumentList><argument><name>PairingData</name><relatedStateVariable>PairingData</relatedStateVariable><direction>in</direction></argument><argument><name>RegistrationData</name><relatedStateVariable>RegistrationData</relatedStateVariable><direction>in</direction></argument><argument><retval
+        /><name>PairingStatus</name><relatedStateVariable>PairingStatus</relatedStateVariable><direction>out</direction></argument></argumentList></action><action><name>GetRegistrationData</name><argumentList><argument><retval
+        /><name>Authorization</name><direction>out</direction></argument><argument><retval
+        /><name>X-Wemo-ALT-Token</name><direction>out</direction></argument><argument><retval
+        /><name>deviceId</name><direction>out</direction></argument><argument><retval
+        /><name>uniqueId</name><direction>out</direction></argument><argument><retval
+        /><name>friendlyName</name><direction>out</direction></argument><argument><retval
+        /><name>groupId</name><direction>out</direction></argument><argument><retval
+        /><name>smartDeviceUniqueId</name><direction>out</direction></argument><argument><retval
+        /><name>reRegister</name><direction>out</direction></argument><argument><retval
+        /><name>provisionedBy</name><direction>out</direction></argument><argument><retval
+        /><name>timeStamp</name><direction>out</direction></argument></argumentList></action><action><name>GetRegistrationStatus</name><argumentList><argument><retval
+        /><name>RegistrationStatus</name><direction>out</direction></argument><argument><retval
+        /><name>StatusCode</name><direction>out</direction></argument><argument><retval
+        /><name>groupId</name><direction>out</direction></argument><argument><retval
+        /><name>deviceId</name><direction>out</direction></argument><argument><retval
+        /><name>deviceToken</name><direction>out</direction></argument><argument><retval
+        /><name>timeStamp</name><direction>out</direction></argument></argumentList></action></actionList>\r\n<serviceStateTable>\r\n</serviceStateTable>\r\n</scpd>\r\n\r\n"
+    headers:
+      Connection:
+      - close
+      Content-Length:
+      - '2133'
+      Content-Type:
+      - text/xml
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers: {}
+    method: GET
+    uri: http://192.168.1.100:49153/metainfoservice.xml
+  response:
+    body:
+      string: "<?xml version=\"1.0\"?><scpd xmlns=\"urn:Belkin:service-1-0\"><specVersion><major>1</major><minor>0</minor></specVersion><actionList>\r\n<action><name>GetMetaInfo</name><argumentList><argument><retval
+        /><name>MetaInfo</name><relatedStateVariable>MetaInfo</relatedStateVariable><direction>out</direction></argument></argumentList></action><action><name>GetExtMetaInfo</name><argumentList><argument><retval
+        /><name>ExtMetaInfo</name><relatedStateVariable>ExtMetaInfo</relatedStateVariable><direction>out</direction></argument></argumentList></action></actionList>\r\n<serviceStateTable>\r\n<stateVariable
+        sendEvents=\"no\"><name>ExtMetaInfo</name><dataType>string</dataType></stateVariable><stateVariable
+        sendEvents=\"yes\"><name>MetaInfo</name><dataType>string</dataType></stateVariable></serviceStateTable>\r\n</scpd>\r\n\r\n"
+    headers:
+      Connection:
+      - close
+      Content-Length:
+      - '805'
+      Content-Type:
+      - text/xml
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers: {}
+    method: GET
+    uri: http://192.168.1.100:49153/timesyncservice.xml
+  response:
+    body:
+      string: "<?xml version=\"1.0\"?><scpd xmlns=\"urn:Belkin:service-1-0\"><specVersion><major>1</major><minor>0</minor></specVersion><actionList>\r\n<action><name>TimeSync</name><argumentList><argument><!--
+        UTC value, long --><name>UTC</name><relatedStateVariable>UTC</relatedStateVariable><direction>in</direction></argument><argument><name>TimeZone</name><relatedStateVariable>TimeZone</relatedStateVariable><direction>in</direction></argument><argument><name>dst</name><relatedStateVariable>dst</relatedStateVariable><direction>in</direction></argument><argument><name>DstSupported</name><relatedStateVariable>DstSupported</relatedStateVariable><direction>in</direction></argument></argumentList></action></actionList>\r\n<serviceStateTable>\r\n<stateVariable
+        sendEvents=\"no\"><name>UTC</name><dataType>long</dataType></stateVariable><stateVariable
+        sendEvents=\"no\"><name>TimeZone</name><dataType>int</dataType></stateVariable><stateVariable
+        sendEvents=\"no\"><name>dst</name><dataType>Boolean</dataType></stateVariable><stateVariable
+        sendEvents=\"no\"><name>DstSupported</name><dataType>Boolean</dataType></stateVariable></serviceStateTable>\r\n</scpd>\r\n\r\n"
+    headers:
+      Connection:
+      - close
+      Content-Length:
+      - '1130'
+      Content-Type:
+      - text/xml
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers: {}
+    method: GET
+    uri: http://192.168.1.100:49153/eventservice.xml
+  response:
+    body:
+      string: "<?xml version=\"1.0\"?><scpd xmlns=\"urn:Belkin:service-1-0\"><specVersion><major>1</major><minor>0</minor></specVersion><actionList>\r\n<action><name>SetBinaryState</name><argumentList><argument><name>BinaryState</name><relatedStateVariable>BinaryState</relatedStateVariable><direction>in</direction></argument><argument><name>Duration</name><relatedStateVariable>Duration</relatedStateVariable><direction>in</direction></argument><argument><name>EndAction</name><relatedStateVariable>EndAction</relatedStateVariable><direction>in</direction></argument><argument><name>brightness</name><relatedStateVariable>brightness</relatedStateVariable><direction>in</direction></argument><argument><name>fader</name><relatedStateVariable>fader</relatedStateVariable><direction>in</direction></argument><argument><name>RawBrightness</name><relatedStateVariable>RawBrightness</relatedStateVariable><direction>in</direction></argument><argument><name>UDN</name><relatedStateVariable>UDN</relatedStateVariable><direction>in</direction></argument><argument><retval
+        /><name>CountdownEndTime</name><relatedStateVariable>CountdownEndTime</relatedStateVariable><direction>out</direction></argument><argument><retval
+        /><name>deviceCurrentTime</name><relatedStateVariable>deviceCurrentTime</relatedStateVariable><direction>out</direction></argument></argumentList></action><action><name>GetBinaryState</name><argumentList><argument><retval
+        /><name>BinaryState</name><relatedStateVariable>BinaryState</relatedStateVariable><direction>out</direction></argument></argumentList></action><action><name>SimulateOverTemp</name><argumentList><argument><name>overTemp</name><direction>in</direction><relatedStateVariable>overTemp</relatedStateVariable></argument><argument><retval
+        /><name>overTempStatus</name><direction>out</direction><relatedStateVariable>overTempStatus</relatedStateVariable></argument></argumentList></action><action><name>GetFriendlyName</name><argumentList><argument><retval
+        /><name>FriendlyName</name><relatedStateVariable>FriendlyName</relatedStateVariable><direction>out</direction></argument></argumentList></action><action><name>ChangeFriendlyName</name><argumentList><argument><name>FriendlyName</name><relatedStateVariable>FriendlyName</relatedStateVariable><direction>in</direction></argument></argumentList></action><action><name>GetIconVersion</name><argumentList><argument><retval
+        /><name>IconVersion</name><relatedStateVariable>IconVersion</relatedStateVariable><direction>out</direction></argument></argumentList></action><action><name>ReSetup</name><argumentList><argument><name>Reset</name><relatedStateVariable>Reset</relatedStateVariable><direction>in</direction></argument></argumentList></action><action><name>setHKSetupState</name><argumentList><argument><name>HKSetupDone</name><relatedStateVariable>HKSetupDone</relatedStateVariable><direction>in</direction></argument></argumentList></action><action><name>getHKSetupState</name><argumentList><argument><retval
+        /><name>HKSetupDone</name><relatedStateVariable>HKSetupDone</relatedStateVariable><direction>out</direction></argument></argumentList></action><action><name>GetHKSetupInfo</name><argumentList><argument><retval
+        /><name>HKSetupKey</name><direction>out</direction></argument><argument><retval
+        /><name>HKSetupCode</name><direction>out</direction></argument></argumentList></action><action><name>removeHomekitData</name></action><action><name>SetAwayRuleTask</name><argumentList><argument><name>EnableAwayTask</name><relatedStateVariable>EnableAwayTask</relatedStateVariable><direction>in</direction></argument><argument><name>RuleID</name><relatedStateVariable>RuleID</relatedStateVariable><direction>in</direction></argument><argument><retval
+        /><name>actionStatus</name><relatedStateVariable>actionStatus</relatedStateVariable><direction>out</direction></argument></argumentList></action><action><name>NotifyManualToggle</name><argumentList><argument><name>UDN</name><direction>in</direction><relatedStateVariable>UDN</relatedStateVariable></argument><argument><name>ManualToggle</name><relatedStateVariable>ManualToggle</relatedStateVariable><direction>out</direction></argument></argumentList></action><action><name>GetSimulatedRuleData</name><argumentList><argument><name>UDN</name><direction>in</direction><relatedStateVariable>UDN</relatedStateVariable></argument><argument><retval
+        /><name>RuleData</name><relatedStateVariable>RuleData</relatedStateVariable><direction>out</direction></argument></argumentList></action><action><name>SetBulbType</name><argumentList><argument><name>bulbType</name><relatedStateVariable>bulbType</relatedStateVariable><direction>in</direction></argument><argument><retval
+        /><name>minLevel</name><relatedStateVariable>minLevel</relatedStateVariable><direction>out</direction></argument><argument><retval
+        /><name>maxLevel</name><relatedStateVariable>maxLevel</relatedStateVariable><direction>out</direction></argument><argument><retval
+        /><name>turnOnLevel</name><relatedStateVariable>turnOnLevel</relatedStateVariable><direction>out</direction></argument></argumentList></action><action><name>Calibrate</name><argumentList><argument><name>binaryState</name><relatedStateVariable>binaryState</relatedStateVariable><direction>in</direction></argument><argument><name>level</name><relatedStateVariable>level</relatedStateVariable><direction>in</direction></argument><argument><name>fader</name><relatedStateVariable>fader</relatedStateVariable><direction>in</direction></argument><argument><retval
+        /><name>actionStatus</name><relatedStateVariable>actionStatus</relatedStateVariable><direction>out</direction></argument></argumentList></action><action><name>ConfigureDimmingRange</name><argumentList><argument><name>minLevel</name><relatedStateVariable>minLevel</relatedStateVariable><direction>in</direction></argument><argument><name>maxLevel</name><relatedStateVariable>maxLevel</relatedStateVariable><direction>in</direction></argument><argument><name>turnOnLevel</name><relatedStateVariable>turnOnLevel</relatedStateVariable><direction>in</direction></argument><argument><retval
+        /><name>dimmingRangeStatus</name><relatedStateVariable>dimmingRangeStatus</relatedStateVariable><direction>out</direction></argument></argumentList></action><action><name>ConfigureNightMode</name><argumentList><argument><name>nightMode</name><relatedStateVariable>nightMode</relatedStateVariable><direction>in</direction></argument><argument><name>startTime</name><relatedStateVariable>startTime</relatedStateVariable><direction>in</direction></argument><argument><name>endTime</name><relatedStateVariable>endTime</relatedStateVariable><direction>in</direction></argument><argument><name>nightModeBrightness</name><relatedStateVariable>nightModeBrightness</relatedStateVariable><direction>in</direction></argument><argument><retval
+        /><name>status</name><relatedStateVariable>status</relatedStateVariable><direction>out</direction></argument></argumentList></action><action><name>GetNightModeConfiguration</name><argumentList><argument><retval
+        /><name>nightMode</name><relatedStateVariable>nightMode</relatedStateVariable><direction>out</direction></argument><argument><retval
+        /><name>startTime</name><relatedStateVariable>startTime</relatedStateVariable><direction>out</direction></argument><argument><retval
+        /><name>endTime</name><relatedStateVariable>endTime</relatedStateVariable><direction>out</direction></argument><argument><retval
+        /><name>nightModeBrightness</name><relatedStateVariable>nightModeBrightness</relatedStateVariable><direction>out</direction></argument></argumentList></action><action><name>ConfigureHushMode</name><argumentList><argument><name>hushMode</name><relatedStateVariable>hushMode</relatedStateVariable><direction>in</direction></argument><argument><retval
+        /><name>hushStatus</name><relatedStateVariable>hushStatus</relatedStateVariable><direction>out</direction></argument></argumentList></action></actionList>\r\n<serviceStateTable>\r\n<stateVariable
+        sendEvents=\"yes\"><name>BinaryState</name><dataType>string</dataType></stateVariable><stateVariable
+        sendEvents=\"no\"><name>Duration</name><dataType>string</dataType></stateVariable><stateVariable
+        sendEvents=\"no\"><name>EndAction</name><dataType>string</dataType></stateVariable><stateVariable
+        sendEvents=\"no\"><name>brightness</name><dataType>string</dataType></stateVariable><stateVariable
+        sendEvents=\"no\"><name>fader</name><dataType>string</dataType></stateVariable><stateVariable
+        sendEvents=\"no\"><name>RawBrightness</name><dataType>string</dataType></stateVariable><stateVariable
+        sendEvents=\"no\"><name>bulbType</name><dataType>string</dataType></stateVariable><stateVariable
+        sendEvents=\"no\"><name>minLevel</name><dataType>string</dataType></stateVariable><stateVariable
+        sendEvents=\"no\"><name>maxLevel</name><dataType>string</dataType></stateVariable><stateVariable
+        sendEvents=\"no\"><name>turnOnLevel</name><dataType>string</dataType></stateVariable><stateVariable
+        sendEvents=\"no\"><name>binaryState</name><dataType>string</dataType></stateVariable><stateVariable
+        sendEvents=\"no\"><name>level</name><dataType>string</dataType></stateVariable><stateVariable
+        sendEvents=\"no\"><name>nightMode</name><dataType>string</dataType></stateVariable><stateVariable
+        sendEvents=\"no\"><name>startTime</name><dataType>string</dataType></stateVariable><stateVariable
+        sendEvents=\"no\"><name>endTime</name><dataType>string</dataType></stateVariable><stateVariable
+        sendEvents=\"no\"><name>nightModeBrightness</name><dataType>string</dataType></stateVariable><stateVariable
+        sendEvents=\"no\"><name>hushMode</name><dataType>string</dataType></stateVariable><stateVariable
+        sendEvents=\"no\"><name>hushStatus</name><dataType>string</dataType></stateVariable><stateVariable
+        sendEvents=\"no\"><name>Status</name><dataType>string</dataType></stateVariable><stateVariable
+        sendEvents=\"no\"><name>dimmingRangeStatus</name><dataType>string</dataType></stateVariable><stateVariable
+        sendEvents=\"no\"><name>UDN</name><dataType>string</dataType></stateVariable><stateVariable
+        sendEvents=\"yes\"><name>CountdownEndTime</name><dataType>string</dataType></stateVariable><stateVariable
+        sendEvents=\"yes\"><name>deviceCurrentTime</name><dataType>string</dataType></stateVariable><stateVariable
+        sendEvents=\"yes\"><name>FriendlyName</name><dataType>string</dataType></stateVariable><stateVariable
+        sendEvents=\"yes\"><name>IconVersion</name><dataType>string</dataType></stateVariable><stateVariable
+        sendEvents=\"yes\"><name>Reset</name><dataType>string</dataType></stateVariable><stateVariable
+        sendEvents=\"yes\"><name>overTemp</name><dataType>string</dataType></stateVariable><stateVariable
+        sendEvents=\"no\"><name>overTempStatus</name><dataType>string</dataType></stateVariable><stateVariable
+        sendEvents=\"yes\"><name>HKSetupDone</name><dataType>string</dataType></stateVariable><stateVariable
+        sendEvents=\"no\"><name>EnableAwayTask</name><dataType>string</dataType></stateVariable><stateVariable
+        sendEvents=\"no\"><name>RuleID</name><dataType>string</dataType></stateVariable><stateVariable
+        sendEvents=\"no\"><name>actionStatus</name><dataType>string</dataType></stateVariable><stateVariable
+        sendEvents=\"no\"><name>ManualToggle</name><dataType>string</dataType></stateVariable><stateVariable
+        sendEvents=\"no\"><name>RuleData</name><dataType>string</dataType></stateVariable></serviceStateTable>\r\n</scpd>\r\n\r\n"
+    headers:
+      Connection:
+      - close
+      Content-Length:
+      - '11286'
+      Content-Type:
+      - text/xml
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers: {}
+    method: GET
+    uri: http://192.168.1.100:49153/rulesservice.xml
+  response:
+    body:
+      string: "<?xml version=\"1.0\"?><scpd xmlns=\"urn:Belkin:service-1-0\"><specVersion><major>1</major><minor>0</minor></specVersion><actionList>\r\n<action><name>GetRulesDBPath</name><argumentList><argument><retval
+        /><name>RulesDBPath</name><relatedStateVariable>RulesDBPath</relatedStateVariable><direction>out</direction></argument></argumentList></action><action><name>StoreRules</name><argumentList><argument><name>ruleDbVersion</name><relatedStateVariable>ruleDbVersion</relatedStateVariable><direction>in</direction></argument><argument><name>processDb</name><relatedStateVariable>processDb</relatedStateVariable><direction>in</direction></argument><argument><name>ruleDbBody</name><relatedStateVariable>ruleDbBody</relatedStateVariable><direction>in</direction></argument><argument><retval></retval><name>errorInfo</name><relatedStateVariable>errorInfo</relatedStateVariable><direction>out</direction></argument></argumentList></action></actionList>\r\n<serviceStateTable>\r\n<stateVariable
+        sendEvents=\"no\"><name>RulesDBPath</name><dataType>string</dataType></stateVariable><stateVariable
+        sendEvents=\"no\"><name>ruleDbVersion</name><dataType>string</dataType></stateVariable><stateVariable
+        sendEvents=\"no\"><name>processDb</name><dataType>string</dataType></stateVariable><stateVariable
+        sendEvents=\"no\"><name>ruleDbBody</name><dataType>string</dataType></stateVariable><stateVariable
+        sendEvents=\"no\"><name>errorInfo</name><dataType>string</dataType></stateVariable></serviceStateTable>\r\n</scpd>\r\n\r\n"
+    headers:
+      Connection:
+      - close
+      Content-Length:
+      - '1482'
+      Content-Type:
+      - text/xml
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers: {}
+    method: GET
+    uri: http://192.168.1.100:49153/deviceinfoservice.xml
+  response:
+    body:
+      string: "<?xml version=\"1.0\"?><scpd xmlns=\"urn:Belkin:service-1-0\"><specVersion><major>1</major><minor>0</minor></specVersion><actionList>\r\n<action><name>GetInformation</name><argumentList><argument><retval
+        /><name>Information</name><relatedStateVariable>Information</relatedStateVariable><direction>out</direction></argument></argumentList></action><action><name>GetDeviceInformation</name><argumentList><argument><retval
+        /><name>DeviceInformation</name><relatedStateVariable>DeviceInformation</relatedStateVariable><direction>out</direction></argument><argument><retval
+        /><name>Payload</name><direction>out</direction></argument><argument><retval
+        /><name>HKSetupState</name><direction>out</direction></argument><argument><retval
+        /><name>ProvisionedBy</name><direction>out</direction></argument></argumentList></action></actionList>\r\n<serviceStateTable>\r\n<stateVariable
+        sendEvents=\"yes\"><name>Information</name><dataType>string</dataType></stateVariable><stateVariable
+        sendEvents=\"yes\"><name>DeviceInformation</name><dataType>string</dataType></stateVariable></serviceStateTable>\r\n</scpd>\r\n\r\n"
+    headers:
+      Connection:
+      - close
+      Content-Length:
+      - '1084'
+      Content-Type:
+      - text/xml
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers: {}
+    method: GET
+    uri: http://192.168.1.100:49153/firmwareupdate.xml
+  response:
+    body:
+      string: "<?xml version=\"1.0\"?><scpd xmlns=\"urn:Belkin:service-1-0\"><specVersion><major>1</major><minor>0</minor></specVersion><actionList>\r\n<action><name>UpdateFirmware</name><argumentList><argument><name>NewFirmwareVersion</name><relatedStateVariable>NewFirmwareVersion</relatedStateVariable><direction>in</direction></argument><argument><name>ReleaseDate</name><relatedStateVariable>ReleaseDate</relatedStateVariable><direction>in</direction></argument><argument><name>URL</name><relatedStateVariable>URL</relatedStateVariable><direction>in</direction></argument><argument><name>Signature</name><relatedStateVariable>Signature</relatedStateVariable><direction>in</direction></argument><argument><name>DownloadStartTime</name><relatedStateVariable>DownloadStartTime</relatedStateVariable><direction>in</direction></argument><argument><name>WithUnsignedImage</name><relatedStateVariable>WithUnsignedImage</relatedStateVariable><direction>in</direction></argument></argumentList></action><action><name>GetFirmwareVersion</name><argumentList><argument><retval
+        /><name>FirmwareVersion</name><relatedStateVariable>FirmwareVersion</relatedStateVariable><direction>out</direction></argument></argumentList></action></actionList>\r\n<serviceStateTable>\r\n<stateVariable
+        sendEvents=\"yes\"><name>FirmwareVersion</name><dataType>string</dataType></stateVariable><stateVariable
+        sendEvents=\"yes\"><name>WithUnsignedImage</name><dataType>string</dataType></stateVariable><stateVariable
+        sendEvents=\"no\"><name>NewFirmwareVersion</name><dataType>string</dataType></stateVariable><stateVariable
+        sendEvents=\"no\"><name>ReleaseDate</name><dataType>string</dataType></stateVariable><stateVariable
+        sendEvents=\"no\"><name>URL</name><dataType>string</dataType></stateVariable><stateVariable
+        sendEvents=\"no\"><name>Signature</name><dataType>string</dataType></stateVariable><stateVariable
+        sendEvents=\"no\"><name>DownloadStartTime</name><dataType>string</dataType></stateVariable></serviceStateTable>\r\n</scpd>\r\n\r\n"
+    headers:
+      Connection:
+      - close
+      Content-Length:
+      - '1970'
+      Content-Type:
+      - text/xml
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers: {}
+    method: GET
+    uri: http://192.168.1.100:49153/manufacture.xml
+  response:
+    body:
+      string: "<?xml version=\"1.0\"?><scpd xmlns=\"urn:Belkin:service-1-0\"><specVersion><major>1</major><minor>0</minor></specVersion><actionList>\r\n<action><name>GetManufactureData</name><argumentList><argument><retval
+        /><name>ManufactureData</name><direction>out</direction><relatedStateVariable>ManufactureData</relatedStateVariable></argument></argumentList></action></actionList>\r\n<serviceStateTable>\r\n<stateVariable
+        sendEvents=\"no\"><name>ManufactureData</name><dataType>string</dataType></stateVariable></serviceStateTable>\r\n</scpd>\r\n\r\n"
+    headers:
+      Connection:
+      - close
+      Content-Length:
+      - '524'
+      Content-Type:
+      - text/xml
+    status:
+      code: 200
+      message: OK
+version: 1


### PR DESCRIPTION
## Description:

The V2 dimmer does not include commands to modify the rules database. Remove long press support for the V2 dimmer and use separate classes for the V1 & V2 dimmers.

**Related issue (if applicable):** #296 

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] There is no commented out code in this PR.
  - [x] I have read and agree to the [CONTRIBUTING document](
        https://github.com/pavoni/pywemo/blob/master/CONTRIBUTING.md).