### PR TITLE
Remove Py2 IntEnum import helper classes

### DIFF
--- a/pywemo/ouimeaux_device/coffeemaker.py
+++ b/pywemo/ouimeaux_device/coffeemaker.py
@@ -1,22 +1,11 @@
 """Representation of a WeMo CoffeeMaker device."""
-import sys
+from enum import IntEnum
 
 from lxml import etree as et
 
 from pywemo.ouimeaux_device.api.xsd.device import quote_xml
 
 from .switch import Switch
-
-if sys.version_info[0] < 3:
-
-    class IntEnum:
-        """Enum class."""
-
-        pass
-
-
-else:
-    from enum import IntEnum
 
 
 # These enums were derived from the

--- a/pywemo/ouimeaux_device/humidifier.py
+++ b/pywemo/ouimeaux_device/humidifier.py
@@ -1,23 +1,11 @@
 """Representation of a WeMo Humidifier device."""
-
-import sys
+from enum import IntEnum
 
 from lxml import etree as et
 
 from pywemo.ouimeaux_device.api.xsd.device import quote_xml
 
 from .switch import Switch
-
-if sys.version_info[0] < 3:
-
-    class IntEnum:
-        """Enum class."""
-
-        pass
-
-
-else:
-    from enum import IntEnum
 
 
 # These enums were derived from Humidifier.deviceevent.GetAttributeList() and


### PR DESCRIPTION
## Description:

Python 2 is no longer supported in pyWeMo. Remove the Py2 IntEnum import helper classes.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] There is no commented out code in this PR.
  - [x] I have read and agree to the [CONTRIBUTING document](
        https://github.com/pavoni/pywemo/blob/master/CONTRIBUTING.md).