### PR TITLE
Add extra validation for xml & services

### DIFF
--- a/pywemo/discovery.py
+++ b/pywemo/discovery.py
@@ -7,10 +7,9 @@ from socket import gaierror, gethostbyname
 import requests
 
 from . import ssdp
-from .exceptions import ActionException, HTTPException
-from .ouimeaux_device import UnsupportedDevice, probe_wemo
+from .exceptions import PyWeMoException
+from .ouimeaux_device import UnsupportedDevice, parse_device_xsd, probe_wemo
 from .ouimeaux_device.api.service import REQUESTS_TIMEOUT
-from .ouimeaux_device.api.xsd import device as deviceParser
 from .ouimeaux_device.bridge import Bridge
 from .ouimeaux_device.coffeemaker import CoffeeMaker
 from .ouimeaux_device.crockpot import CrockPot
@@ -28,24 +27,15 @@ LOG = logging.getLogger(__name__)
 
 def discover_devices(debug=False, **kwargs):
     """Find WeMo devices on the local network."""
-    wemos = []
-
-    for entry in ssdp.scan(**kwargs):
-        if entry.match_device_description(
-            {'manufacturer': 'Belkin International Inc.'}
-        ):
-            try:
-                device = device_from_uuid_and_location(
-                    entry.udn, entry.location, debug
-                )
-            except (HTTPException, ActionException) as exc:
-                LOG.warning(
-                    'Could not connect to device %s (%s)', entry.location, exc
-                )
-            else:
-                wemos.append(device)
-
-    return wemos
+    return list(
+        filter(
+            bool,
+            (
+                device_from_uuid_and_location(entry.udn, entry.location, debug)
+                for entry in ssdp.scan(**kwargs)
+            ),
+        )
+    )
 
 
 def device_from_description(description_url, mac='deprecated', debug=False):
@@ -58,13 +48,17 @@ def device_from_description(description_url, mac='deprecated', debug=False):
         )
     try:
         xml = requests.get(description_url, timeout=REQUESTS_TIMEOUT)
-    except requests.RequestException as err:
-        raise HTTPException(err) from err
-    parsed = deviceParser.parseString(
-        xml.content, silence=True, print_warnings=False
-    )
-    uuid = parsed.device.UDN
+    except requests.RequestException:
+        LOG.exception("Failed to fetch description %s", description_url)
+        return None
 
+    try:
+        parsed = parse_device_xsd(xml.content)
+    except PyWeMoException:
+        LOG.exception("Failed to parse description %s", description_url)
+        return None
+
+    uuid = parsed.device.UDN
     return device_from_uuid_and_location(uuid, description_url, debug)
 
 
@@ -72,47 +66,57 @@ def device_from_uuid_and_location(uuid, location, debug=False):
     """Determine device class based on the device uuid."""
     if not (uuid and location):
         return None
-    if uuid.startswith('uuid:Socket'):
-        return Switch(location)
-    if uuid.startswith('uuid:Lightswitch-1_0'):
-        return LightSwitchLongPress(location)
-    if uuid.startswith('uuid:Lightswitch-2_0'):
-        return LightSwitchLongPress(location)
-    if uuid.startswith('uuid:Lightswitch-3_0'):
-        return LightSwitchLongPress(location)
-    if uuid.startswith('uuid:Lightswitch'):
-        return LightSwitch(location)
-    if uuid.startswith('uuid:Dimmer-1_0'):
-        return DimmerV1(location)
-    if uuid.startswith('uuid:Dimmer'):
-        return Dimmer(location)
-    if uuid.startswith('uuid:Insight'):
-        return Insight(location)
-    if uuid.startswith('uuid:Sensor'):
-        return Motion(location)
-    if uuid.startswith('uuid:Maker'):
-        return Maker(location)
-    if uuid.startswith('uuid:Bridge'):
-        return Bridge(location)
-    if uuid.startswith('uuid:CoffeeMaker'):
-        return CoffeeMaker(location)
-    if uuid.startswith('uuid:Crockpot'):
-        return CrockPot(location)
-    if uuid.startswith('uuid:Humidifier'):
-        return Humidifier(location)
-    if uuid.startswith('uuid:OutdoorPlug'):
-        return OutdoorPlug(location)
+    try:
+        if uuid.startswith('uuid:Socket'):
+            return Switch(location)
+        if uuid.startswith('uuid:Lightswitch-1_0'):
+            return LightSwitchLongPress(location)
+        if uuid.startswith('uuid:Lightswitch-2_0'):
+            return LightSwitchLongPress(location)
+        if uuid.startswith('uuid:Lightswitch-3_0'):
+            return LightSwitchLongPress(location)
+        if uuid.startswith('uuid:Lightswitch'):
+            return LightSwitch(location)
+        if uuid.startswith('uuid:Dimmer-1_0'):
+            return DimmerV1(location)
+        if uuid.startswith('uuid:Dimmer'):
+            return Dimmer(location)
+        if uuid.startswith('uuid:Insight'):
+            return Insight(location)
+        if uuid.startswith('uuid:Sensor'):
+            return Motion(location)
+        if uuid.startswith('uuid:Maker'):
+            return Maker(location)
+        if uuid.startswith('uuid:Bridge'):
+            return Bridge(location)
+        if uuid.startswith('uuid:CoffeeMaker'):
+            return CoffeeMaker(location)
+        if uuid.startswith('uuid:Crockpot'):
+            return CrockPot(location)
+        if uuid.startswith('uuid:Humidifier'):
+            return Humidifier(location)
+        if uuid.startswith('uuid:OutdoorPlug'):
+            return OutdoorPlug(location)
+    except PyWeMoException:
+        LOG.exception("Device setup failed %s %s", uuid, location)
+        # Fall-through: Try UnsupportedDevice if debug is enabled.
+
     if uuid.startswith('uuid:') and debug:
         # unsupported device, but if this function was called from
         # discover_devices then this should be a Belkin product and is probably
         # a WeMo product without a custom class yet.  So attempt to return a
         # basic object to allow manual interaction.
-        LOG.info(
-            'Device with %s is not supported by pywemo, returning '
-            'UnsupportedDevice object to allow manual interaction',
-            uuid,
-        )
-        return UnsupportedDevice(location)
+        try:
+            device = UnsupportedDevice(location)
+        except PyWeMoException:
+            LOG.exception("Device setup failed %s %s", uuid, location)
+        else:
+            LOG.info(
+                'Device with %s is not supported by pywemo, returning '
+                'UnsupportedDevice object to allow manual interaction',
+                uuid,
+            )
+            return device
 
     return None
 

--- a/pywemo/discovery.py
+++ b/pywemo/discovery.py
@@ -8,7 +8,7 @@ import requests
 
 from . import ssdp
 from .exceptions import PyWeMoException
-from .ouimeaux_device import UnsupportedDevice, parse_device_xsd, probe_wemo
+from .ouimeaux_device import UnsupportedDevice, parse_device_xml, probe_wemo
 from .ouimeaux_device.api.service import REQUESTS_TIMEOUT
 from .ouimeaux_device.bridge import Bridge
 from .ouimeaux_device.coffeemaker import CoffeeMaker
@@ -53,7 +53,7 @@ def device_from_description(description_url, mac='deprecated', debug=False):
         return None
 
     try:
-        parsed = parse_device_xsd(xml.content)
+        parsed = parse_device_xml(xml.content)
     except PyWeMoException:
         LOG.exception("Failed to parse description %s", description_url)
         return None

--- a/pywemo/discovery.py
+++ b/pywemo/discovery.py
@@ -62,7 +62,7 @@ def device_from_description(description_url, mac='deprecated', debug=False):
     return device_from_uuid_and_location(uuid, description_url, debug)
 
 
-def device_from_uuid_and_location(uuid, location, debug=False):
+def device_from_uuid_and_location(uuid, location, debug=False):  # noqa: C901
     """Determine device class based on the device uuid."""
     if not (uuid and location):
         return None

--- a/pywemo/exceptions.py
+++ b/pywemo/exceptions.py
@@ -80,3 +80,11 @@ class RulesDbError(Exception):
 
 class RulesDbQueryError(RulesDbError):
     """Exception when querying the rules database."""
+
+
+class InvalidSchemaError(PyWeMoException):
+    """Raised when an unexpected XML response is received."""
+
+
+class MissingServiceError(PyWeMoException):
+    """All required services were not found in the device schema."""

--- a/pywemo/ouimeaux_device/__init__.py
+++ b/pywemo/ouimeaux_device/__init__.py
@@ -1,4 +1,5 @@
 """Base WeMo Device class."""
+from __future__ import annotations
 
 import base64
 import logging
@@ -13,19 +14,60 @@ from lxml import etree as et
 from ..exceptions import (
     ActionException,
     APNotFound,
+    InvalidSchemaError,
     ResetException,
     SetupException,
     ShortPassword,
     UnknownService,
 )
 from .api.long_press import LongPressMixin
-from .api.service import REQUESTS_TIMEOUT, Service, Session
+from .api.service import (
+    REQUESTS_TIMEOUT,
+    RequiredService,
+    RequiredServicesMixin,
+    Service,
+    Session,
+)
 from .api.xsd import device as deviceParser
 
 LOG = logging.getLogger(__name__)
 
 # Start with the most commonly used port
 PROBE_PORTS = (49153, 49152, 49154, 49151, 49155, 49156, 49157, 49158, 49159)
+
+
+def parse_device_xsd(xml_content: bytes) -> deviceParser.root:
+    """Parse setup.xml into a Python xsd object."""
+    try:
+        try:
+            root = deviceParser.parseString(
+                xml_content, silence=True, print_warnings=False
+            )
+        except Exception as err:
+            raise InvalidSchemaError("Could not parse schema") from err
+
+        device = root.get_device()
+        if device is None:
+            raise InvalidSchemaError("Missing root.device element")
+        for required_element in (
+            "deviceType",
+            "friendlyName",
+            "manufacturer",
+            "modelName",
+            "UDN",
+        ):
+            if not getattr(device, f"get_{required_element}")():
+                raise InvalidSchemaError(
+                    f"Missing device element: {required_element}"
+                )
+        if device.get_manufacturer() != "Belkin International Inc.":
+            raise InvalidSchemaError(
+                f"Unexpected manufacturer: {device.get_manufacturer()}"
+            )
+    except InvalidSchemaError:
+        LOG.debug("Received invalid schema: %r", xml_content)
+        raise
+    return root
 
 
 def probe_wemo(
@@ -43,20 +85,18 @@ def probe_wemo(
             response = requests.get(
                 f'http://{host}:{port}/setup.xml', timeout=probe_timeout
             )
-            if not (('WeMo' in response.text) or ('Belkin' in response.text)):
+            try:
+                device = parse_device_xsd(response.content).device
+            except InvalidSchemaError:
                 continue
-            if match_udn:
-                device = deviceParser.parseString(
-                    response.content, silence=True, print_warnings=False
-                ).device
-                if match_udn != device.get_UDN():
-                    LOG.error(
-                        'Reconnected to a different WeMo. '
-                        'Expected %s / Received %s',
-                        match_udn,
-                        device.get_UDN(),
-                    )
-                    continue
+            if match_udn and match_udn != device.get_UDN():
+                LOG.error(
+                    'Reconnected to a different WeMo. '
+                    'Expected %s / Received %s',
+                    match_udn,
+                    device.get_UDN(),
+                )
+                continue
             return port
         except requests.ConnectTimeout:
             # If we timed out connecting, then the wemo is gone,
@@ -91,10 +131,10 @@ def probe_device(device):
     return probe_wemo(device.host, ports, match_udn=device.udn)
 
 
-class Device:
+class Device(RequiredServicesMixin):
     """Base object for WeMo devices."""
 
-    def __init__(self, url, mac='deprecated'):
+    def __init__(self, url: str, mac: str = 'deprecated') -> None:
         """Create a WeMo device."""
         if mac != 'deprecated':
             warnings.warn(
@@ -106,10 +146,10 @@ class Device:
         self.basic_state_params = {}
         self._reconnect_lock = threading.Lock()
         self.session = Session(url)
+
         xml = self.session.get(url)
-        self._config = deviceParser.parseString(
-            xml.content, silence=True, print_warnings=False
-        ).device
+        self._config = parse_device_xsd(xml.content).device
+
         # The 'xs:any' values for the xs:complexType DeviceType in device.xsd.
         xs_any = (et.fromstring(extra) for extra in self._config.anytypeobjs_)
         self._config_any = {
@@ -117,11 +157,20 @@ class Device:
             for tag in xs_any
             if tag.text and tag.text.strip()
         }
+
         self.services = {}
-        for svc in self._config.serviceList.service:
-            service = Service(self, svc)
-            self.services[service.name] = service
-            setattr(self, service.name, service)
+        if self._config.serviceList and self._config.serviceList.service:
+            for svc in self._config.serviceList.service:
+                service = Service(self, svc)
+                self.services[service.name] = service
+                setattr(self, service.name, service)
+        self._check_required_services(self.services.values())
+
+    @property
+    def _required_services(self):
+        return super()._required_services + [
+            RequiredService(name="basicevent", actions=["GetBinaryState"])
+        ]
 
     def _reconnect_with_device_by_discovery(self):
         """
@@ -663,12 +712,12 @@ class Device:
     @property
     def mac(self):
         """Return the mac address from the device description."""
-        return self._config.get_macAddress()
+        return self._config.get_macAddress() or ""
 
     @property
     def model(self):
         """Return the model description of the device."""
-        return self._config.get_modelDescription()
+        return self._config.get_modelDescription() or ""
 
     @property
     def model_name(self):
@@ -683,7 +732,7 @@ class Device:
     @property
     def serialnumber(self):
         """Return the serial number of the device."""
-        return self._config.get_serialNumber()
+        return self._config.get_serialNumber() or ""
 
     @property
     def udn(self) -> str:

--- a/pywemo/ouimeaux_device/__init__.py
+++ b/pywemo/ouimeaux_device/__init__.py
@@ -36,7 +36,7 @@ LOG = logging.getLogger(__name__)
 PROBE_PORTS = (49153, 49152, 49154, 49151, 49155, 49156, 49157, 49158, 49159)
 
 
-def parse_device_xsd(xml_content: bytes) -> deviceParser.root:
+def parse_device_xml(xml_content: bytes) -> deviceParser.root:
     """Parse setup.xml into a Python xsd object."""
     try:
         try:
@@ -86,7 +86,7 @@ def probe_wemo(
                 f'http://{host}:{port}/setup.xml', timeout=probe_timeout
             )
             try:
-                device = parse_device_xsd(response.content).device
+                device = parse_device_xml(response.content).device
             except InvalidSchemaError:
                 continue
             if match_udn and match_udn != device.get_UDN():
@@ -148,7 +148,7 @@ class Device(RequiredServicesMixin):
         self.session = Session(url)
 
         xml = self.session.get(url)
-        self._config = parse_device_xsd(xml.content).device
+        self._config = parse_device_xml(xml.content).device
 
         # The 'xs:any' values for the xs:complexType DeviceType in device.xsd.
         xs_any = (et.fromstring(extra) for extra in self._config.anytypeobjs_)

--- a/pywemo/ouimeaux_device/api/long_press.py
+++ b/pywemo/ouimeaux_device/api/long_press.py
@@ -12,6 +12,7 @@ from enum import Enum
 from typing import FrozenSet, Iterable, Optional
 
 from .rules_db import RuleDevicesRow, RulesDb, RulesRow, rules_db_from_device
+from .service import RequiredService, RequiredServicesMixin
 
 LOG = logging.getLogger(__name__)
 
@@ -83,8 +84,14 @@ def ensure_long_press_rule_exists(
     return new_rule
 
 
-class LongPressMixin:
+class LongPressMixin(RequiredServicesMixin):
     """Methods to make changes to the long press rules for a device."""
+
+    @property
+    def _required_services(self):
+        return super()._required_services + [
+            RequiredService(name="rules", actions=["FetchRules", "StoreRules"])
+        ]
 
     # pylint: disable=unsubscriptable-object
     # https://github.com/PyCQA/pylint/issues/3882#issuecomment-745148724

--- a/pywemo/ouimeaux_device/bridge.py
+++ b/pywemo/ouimeaux_device/bridge.py
@@ -7,6 +7,7 @@ from lxml import etree as et
 
 from ..color import get_profiles, limit_to_gamut
 from . import Device
+from .api.service import RequiredService
 
 CAPABILITY_ID2NAME = dict(
     (
@@ -52,6 +53,21 @@ class Bridge(Device):
         ).format(
             name=self.name, lights=len(self.Lights), groups=len(self.Groups)
         )
+
+    @property
+    def _required_services(self):
+        return super()._required_services + [
+            RequiredService(name="basicevent", actions=["GetMacAddr"]),
+            RequiredService(
+                name="bridge",
+                actions=[
+                    "GetEndDevicesWithStatus",
+                    "GetEndDevices",
+                    "GetDeviceStatus",
+                    "SetDeviceStatus",
+                ],
+            ),
+        ]
 
     def bridge_update(self, force_update=True):
         """Get updated status information for the bridge and its lights."""

--- a/pywemo/ouimeaux_device/bridge.py
+++ b/pywemo/ouimeaux_device/bridge.py
@@ -60,12 +60,7 @@ class Bridge(Device):
             RequiredService(name="basicevent", actions=["GetMacAddr"]),
             RequiredService(
                 name="bridge",
-                actions=[
-                    "GetEndDevicesWithStatus",
-                    "GetEndDevices",
-                    "GetDeviceStatus",
-                    "SetDeviceStatus",
-                ],
+                actions=["GetDeviceStatus", "SetDeviceStatus"],
             ),
         ]
 

--- a/pywemo/ouimeaux_device/coffeemaker.py
+++ b/pywemo/ouimeaux_device/coffeemaker.py
@@ -5,6 +5,7 @@ from lxml import etree as et
 
 from pywemo.ouimeaux_device.api.xsd.device import quote_xml
 
+from .api.service import RequiredService
 from .switch import Switch
 
 
@@ -66,6 +67,14 @@ class CoffeeMaker(Switch):
         """Create a WeMo CoffeeMaker device."""
         Switch.__init__(self, *args, **kwargs)
         self._attributes = {}
+
+    @property
+    def _required_services(self):
+        return super()._required_services + [
+            RequiredService(
+                name="deviceevent", actions=["GetAttributes", "SetAttributes"]
+            ),
+        ]
 
     def update_attributes(self):
         """Request state from device."""

--- a/pywemo/ouimeaux_device/crockpot.py
+++ b/pywemo/ouimeaux_device/crockpot.py
@@ -1,6 +1,7 @@
 """Representation of a WeMo CrockPot device."""
 from enum import IntEnum
 
+from .api.service import RequiredService
 from .switch import Switch
 
 
@@ -31,6 +32,15 @@ class CrockPot(Switch):
         """Create a WeMo CrockPot device."""
         Switch.__init__(self, *args, **kwargs)
         self._attributes = {}
+
+    @property
+    def _required_services(self):
+        return super()._required_services + [
+            RequiredService(
+                name="basicevent",
+                actions=["GetCrockpotState", "SetCrockpotState"],
+            ),
+        ]
 
     def update_attributes(self):
         """Request state from device."""

--- a/pywemo/ouimeaux_device/dimmer.py
+++ b/pywemo/ouimeaux_device/dimmer.py
@@ -1,5 +1,6 @@
 """Representation of a WeMo Dimmer device."""
 from .api.long_press import LongPressMixin
+from .api.service import RequiredService
 from .switch import Switch
 
 
@@ -10,6 +11,12 @@ class Dimmer(Switch):
         """Create a WeMo Dimmer device."""
         Switch.__init__(self, *args, **kwargs)
         self._brightness = None
+
+    @property
+    def _required_services(self):
+        return super()._required_services + [
+            RequiredService(name="basicevent", actions=["SetBinaryState"]),
+        ]
 
     def get_brightness(self, force_update=False):
         """Get brightness from device."""

--- a/pywemo/ouimeaux_device/humidifier.py
+++ b/pywemo/ouimeaux_device/humidifier.py
@@ -3,8 +3,8 @@ from enum import IntEnum
 
 from lxml import etree as et
 
-from pywemo.ouimeaux_device.api.xsd.device import quote_xml
-
+from .api.service import RequiredService
+from .api.xsd.device import quote_xml
 from .switch import Switch
 
 
@@ -132,6 +132,14 @@ class Humidifier(Switch):
         Switch.__init__(self, *args, **kwargs)
         self._attributes = {}
         self.update_attributes()
+
+    @property
+    def _required_services(self):
+        return super()._required_services + [
+            RequiredService(
+                name="deviceevent", actions=["GetAttributes", "SetAttributes"]
+            ),
+        ]
 
     def update_attributes(self):
         """Request state from device."""

--- a/pywemo/ouimeaux_device/insight.py
+++ b/pywemo/ouimeaux_device/insight.py
@@ -2,6 +2,7 @@
 import logging
 from datetime import datetime
 
+from .api.service import RequiredService
 from .switch import Switch
 
 LOG = logging.getLogger(__name__)
@@ -16,6 +17,12 @@ class Insight(Switch):
         self.insight_params = {}
 
         self.update_insight_params()
+
+    @property
+    def _required_services(self):
+        return super()._required_services + [
+            RequiredService(name="insight", actions=["GetInsightParams"]),
+        ]
 
     def update_insight_params(self):
         """Get and parse the device attributes."""

--- a/pywemo/ouimeaux_device/maker.py
+++ b/pywemo/ouimeaux_device/maker.py
@@ -3,6 +3,7 @@ from typing import Dict
 
 from lxml import etree as et
 
+from .api.service import RequiredService
 from .switch import Switch
 
 
@@ -43,6 +44,15 @@ class Maker(Switch):
         super().__init__(*args, **kwargs)
         self.maker_params = {}
         self.get_state(force_update=True)
+
+    @property
+    def _required_services(self):
+        return super()._required_services + [
+            RequiredService(name="basicevent", actions=["SetBinaryState"]),
+            RequiredService(
+                name="deviceevent", actions=["GetAttributes", "SetAttributes"]
+            ),
+        ]
 
     def update_maker_params(self):
         """Get and parse the device attributes."""

--- a/pywemo/ouimeaux_device/switch.py
+++ b/pywemo/ouimeaux_device/switch.py
@@ -1,9 +1,16 @@
 """Representation of a WeMo Switch device."""
 from . import Device
+from .api.service import RequiredService
 
 
 class Switch(Device):
     """Representation of a WeMo Switch device."""
+
+    @property
+    def _required_services(self):
+        return super()._required_services + [
+            RequiredService(name="basicevent", actions=["SetBinaryState"]),
+        ]
 
     def set_state(self, state):
         """Set the state of this device to on or off."""

--- a/tests/ouimeaux_device/api/unit/long_press_helpers.py
+++ b/tests/ouimeaux_device/api/unit/long_press_helpers.py
@@ -69,3 +69,11 @@ class TestLongPress:
 
         device.remove_long_press_virtual_device()
         assert device.list_long_press_udns() == frozenset()
+
+    def test_required_services(self, device):
+        assert (
+            long_press.RequiredService(
+                name="rules", actions=["FetchRules", "StoreRules"]
+            )
+            in device._required_services
+        )

--- a/tests/ouimeaux_device/test_device.py
+++ b/tests/ouimeaux_device/test_device.py
@@ -17,7 +17,7 @@ from pywemo.ouimeaux_device import (
     SetupException,
     ShortPassword,
     UnknownService,
-    parse_device_xsd,
+    parse_device_xml,
 )
 
 RESPONSE_SETUP = '''<?xml version="1.0"?>
@@ -518,15 +518,15 @@ class TestDevice:
             device.reconnect_with_device()
             url_mock.assert_not_called()
 
-    def test_parse_device_xsd_raises(self):
+    def test_parse_device_xml_raises(self):
         with pytest.raises(InvalidSchemaError, match="Could not parse schema"):
-            parse_device_xsd("invalid xml content")
+            parse_device_xml("invalid xml content")
 
         missing_device = RESPONSE_SETUP.replace("device>", "something>")
         with pytest.raises(
             InvalidSchemaError, match="Missing root.device element"
         ):
-            parse_device_xsd(missing_device.encode())
+            parse_device_xml(missing_device.encode())
 
         missing_deviceType = RESPONSE_SETUP.replace(
             "<deviceType>urn:Belkin:device:controllee:1</deviceType>", ""
@@ -534,7 +534,7 @@ class TestDevice:
         with pytest.raises(
             InvalidSchemaError, match="Missing device element: deviceType"
         ):
-            parse_device_xsd(missing_deviceType.encode())
+            parse_device_xml(missing_deviceType.encode())
 
         wrong_manufacturer = RESPONSE_SETUP.replace(
             "Belkin International Inc.", "pyWeMoTest"
@@ -542,4 +542,4 @@ class TestDevice:
         with pytest.raises(
             InvalidSchemaError, match="Unexpected manufacturer"
         ):
-            parse_device_xsd(wrong_manufacturer.encode())
+            parse_device_xml(wrong_manufacturer.encode())

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -69,7 +69,7 @@ def test_device_from_description_returns_none():
         )
 
     with mock.patch("requests.get"), mock.patch(
-        "pywemo.discovery.parse_device_xsd"
+        "pywemo.discovery.parse_device_xml"
     ) as mock_parse:
         mock_parse.side_effect = exceptions.InvalidSchemaError
         assert (


### PR DESCRIPTION
## Description:

There exist software emulators for WeMo devices. Some of these emulators are not fully featured and cause pyWeMo to break unexpectedly when the emulated devices are discovered (https://github.com/home-assistant/core/issues/62259).

This PR adds extra validation logic to avoid breaking on these emulators.

1. Better checking of device xml responses to ensure it conforms with the XSD schemas,
2. Extra validation for the services and their actions that pyWeMo depends upon.

The end goal of this PR is to have discovery return `None` for these devices and to not include such devices in the list returned from `discover_devices`

**Related issue (if applicable):** https://github.com/home-assistant/core/issues/62259

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] There is no commented out code in this PR.
  - [x] I have read and agree to the [CONTRIBUTING document](
        https://github.com/pavoni/pywemo/blob/master/CONTRIBUTING.md).