### PR TITLE
Only enable long-press on light switches known to support it

### DIFF
--- a/pywemo/__init__.py
+++ b/pywemo/__init__.py
@@ -10,7 +10,7 @@ from .ouimeaux_device.crockpot import CrockPot
 from .ouimeaux_device.dimmer import Dimmer, DimmerV1
 from .ouimeaux_device.humidifier import Humidifier
 from .ouimeaux_device.insight import Insight
-from .ouimeaux_device.lightswitch import LightSwitch
+from .ouimeaux_device.lightswitch import LightSwitch, LightSwitchLongPress
 from .ouimeaux_device.maker import Maker
 from .ouimeaux_device.motion import Motion
 from .ouimeaux_device.switch import Switch

--- a/pywemo/discovery.py
+++ b/pywemo/discovery.py
@@ -17,7 +17,7 @@ from .ouimeaux_device.crockpot import CrockPot
 from .ouimeaux_device.dimmer import Dimmer, DimmerV1
 from .ouimeaux_device.humidifier import Humidifier
 from .ouimeaux_device.insight import Insight
-from .ouimeaux_device.lightswitch import LightSwitch
+from .ouimeaux_device.lightswitch import LightSwitch, LightSwitchLongPress
 from .ouimeaux_device.maker import Maker
 from .ouimeaux_device.motion import Motion
 from .ouimeaux_device.outdoor_plug import OutdoorPlug
@@ -74,6 +74,12 @@ def device_from_uuid_and_location(uuid, location, debug=False):
         return None
     if uuid.startswith('uuid:Socket'):
         return Switch(location)
+    if uuid.startswith('uuid:Lightswitch-1_0'):
+        return LightSwitchLongPress(location)
+    if uuid.startswith('uuid:Lightswitch-2_0'):
+        return LightSwitchLongPress(location)
+    if uuid.startswith('uuid:Lightswitch-3_0'):
+        return LightSwitchLongPress(location)
     if uuid.startswith('uuid:Lightswitch'):
         return LightSwitch(location)
     if uuid.startswith('uuid:Dimmer-1_0'):

--- a/pywemo/ouimeaux_device/lightswitch.py
+++ b/pywemo/ouimeaux_device/lightswitch.py
@@ -4,4 +4,8 @@ from .switch import Switch
 
 
 class LightSwitch(Switch, LongPressMixin):
-    """Representation of a WeMo Motion device."""
+    """Representation of a WeMo Light Switch device."""
+
+
+class LightSwitchLongPress(LightSwitch, LongPressMixin):
+    """WeMo Light Switch that supports long press notifications."""


### PR DESCRIPTION
## Description:

Avoid breaking pyWeMo if a new Light Switch is released that cannot support long press events. Only enable long-press on light switches known to support it.

**Related issue (if applicable):** fixes #<pywemo issue number goes here>

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] There is no commented out code in this PR.
  - [x] I have read and agree to the [CONTRIBUTING document](
        https://github.com/pavoni/pywemo/blob/master/CONTRIBUTING.md).