### PR TITLE
Insight property changes

### DIFF
--- a/pywemo/__init__.py
+++ b/pywemo/__init__.py
@@ -9,7 +9,7 @@ from .ouimeaux_device.coffeemaker import CoffeeMaker
 from .ouimeaux_device.crockpot import CrockPot
 from .ouimeaux_device.dimmer import Dimmer, DimmerV1
 from .ouimeaux_device.humidifier import Humidifier
-from .ouimeaux_device.insight import Insight
+from .ouimeaux_device.insight import Insight, StandbyState
 from .ouimeaux_device.lightswitch import LightSwitch, LightSwitchLongPress
 from .ouimeaux_device.maker import Maker
 from .ouimeaux_device.motion import Motion

--- a/pywemo/ouimeaux_device/insight.py
+++ b/pywemo/ouimeaux_device/insight.py
@@ -1,10 +1,19 @@
 """Representation of a WeMo Insight device."""
 import logging
 from datetime import datetime
+from enum import Enum
 
 from .switch import Switch
 
 LOG = logging.getLogger(__name__)
+
+
+class StandbyState(str, Enum):
+    """Standby state for the Insight device."""
+
+    ON = "on"
+    OFF = "off"
+    STANDBY = "standby"
 
 
 class Insight(Switch):
@@ -74,58 +83,72 @@ class Insight(Switch):
         return Switch.get_state(self, force_update)
 
     @property
-    def today_kwh(self):
-        """Return the kwh used today."""
-        return self.insight_params['todaymw'] * 1.6666667e-8
+    def today_kwh(self) -> float:
+        """Return the number of kWh consumed today."""
+        return float(self.insight_params['todaymw']) * 1.6666667e-8
 
     @property
-    def current_power(self):
+    def total_kwh(self) -> float:
+        """Return the total kWh consumed for the device."""
+        return float(self.insight_params['totalmw']) * 1.6666667e-8
+
+    @property
+    def current_power(self) -> int:
         """Return the current power usage in mW."""
         return self.insight_params['currentpower']
 
     @property
-    def wifi_power(self):
+    def current_power_watts(self) -> float:
+        """Return the current power usage in Watts."""
+        return float(self.current_power) / 1000.0
+
+    @property
+    def wifi_power(self) -> int:
         """Return the current rssi wifi signal."""
         return self.insight_params['wifipower']
 
     @property
-    def threshold_power(self):
-        """
-        Return the threshold power.
+    def threshold_power(self) -> int:
+        """Return the threshold power in mW.
 
         Above this the device is on, below it is standby.
         """
         return self.insight_params['powerthreshold']
 
     @property
-    def today_on_time(self):
-        """Return how long the device has been on today."""
+    def threshold_power_watts(self) -> float:
+        """Return the threshold power in watts."""
+        return float(self.threshold_power) / 1000.0
+
+    @property
+    def today_on_time(self) -> int:
+        """Return the number of seconds the device has been on today."""
         return self.insight_params['ontoday']
 
     @property
-    def on_for(self):
-        """Return how long the device has been on."""
+    def on_for(self) -> int:
+        """Return the number of seconds the device was last on for."""
         return self.insight_params['onfor']
 
     @property
-    def last_change(self):
+    def last_change(self) -> datetime:
         """Return the last change datetime."""
         return self.insight_params['lastchange']
 
     @property
-    def today_standby_time(self):
-        """Return how long the device has been in standby today."""
-        return self.insight_params['ontoday']
+    def total_on_time(self) -> int:
+        """Return the number of seconds the device has been on."""
+        return self.insight_params['ontotal']
 
     @property
-    def get_standby_state(self):
+    def get_standby_state(self) -> StandbyState:
         """Return the standby state of the device."""
         state = self.insight_params['state']
 
         if state == '0':
-            return 'off'
+            return StandbyState.OFF
 
         if state == '1':
-            return 'on'
+            return StandbyState.ON
 
-        return 'standby'
+        return StandbyState.STANDBY

--- a/pywemo/ouimeaux_device/insight.py
+++ b/pywemo/ouimeaux_device/insight.py
@@ -1,5 +1,6 @@
 """Representation of a WeMo Insight device."""
 import logging
+import warnings
 from datetime import datetime
 from enum import Enum
 
@@ -126,6 +127,22 @@ class Insight(Switch):
         return self.insight_params['ontoday']
 
     @property
+    def today_standby_time(self) -> int:
+        """Return how long the device has been in standby today."""
+        warnings.warn(
+            "The Insight.today_standby_time property should not be used and "
+            "will be removed in a future version of pyWeMo. Switch to using "
+            "the Insight.today_on_time property instead.",
+            DeprecationWarning,
+        )
+        return self.insight_params['ontoday']
+
+    @property
+    def total_on_time(self) -> int:
+        """Return the number of seconds the device has been on."""
+        return self.insight_params['ontotal']
+
+    @property
     def on_for(self) -> int:
         """Return the number of seconds the device was last on for."""
         return self.insight_params['onfor']
@@ -134,11 +151,6 @@ class Insight(Switch):
     def last_change(self) -> datetime:
         """Return the last change datetime."""
         return self.insight_params['lastchange']
-
-    @property
-    def total_on_time(self) -> int:
-        """Return the number of seconds the device has been on."""
-        return self.insight_params['ontotal']
 
     @property
     def get_standby_state(self) -> StandbyState:

--- a/tests/ouimeaux_device/test_insight.py
+++ b/tests/ouimeaux_device/test_insight.py
@@ -5,7 +5,7 @@ import threading
 
 import pytest
 
-from pywemo import Insight
+from pywemo import Insight, StandbyState
 from pywemo.subscribe import EVENT_TYPE_BINARY_STATE, EVENT_TYPE_INSIGHT_PARAMS
 
 
@@ -33,18 +33,22 @@ class Test_Insight:
     def test_insight_params(self, insight):
         insight.update_insight_params()
         assert insight.today_kwh == pytest.approx(0.0194118)
+        assert insight.total_kwh == pytest.approx(1.6638418)
         assert insight.current_power == 0
+        assert insight.current_power_watts == 0.0
         assert insight.wifi_power == 8
         assert insight.threshold_power == 8000
+        assert insight.threshold_power_watts == pytest.approx(8.0)
         assert insight.today_on_time == 300
         assert insight.on_for == 231
+        assert insight.total_on_time == 183183
         assert insight.last_change.astimezone(datetime.timezone.utc) == (
             datetime.datetime(
                 2021, 1, 25, 0, 2, 4, tzinfo=datetime.timezone.utc
             )
         )
-        assert insight.today_standby_time == 300
-        assert insight.get_standby_state == 'off'
+        assert insight.today_on_time == 300
+        assert insight.get_standby_state == StandbyState.OFF
 
     @pytest.mark.vcr()
     def test_subscribe(self, insight, subscription_registry):
@@ -74,18 +78,22 @@ class Test_Insight:
             '8|1611105078|2607|0|12416|1209600|328|500|457600|69632638|9500',
         )
         assert insight.today_kwh == pytest.approx(0.0076266668)
+        assert insight.total_kwh == pytest.approx(1.1605439898)
         assert insight.current_power == 500
+        assert insight.current_power_watts == pytest.approx(0.5)
         assert insight.wifi_power == 328
         assert insight.threshold_power == 9500
+        assert insight.threshold_power_watts == pytest.approx(9.5)
         assert insight.today_on_time == 0
         assert insight.on_for == 2607
+        assert insight.total_on_time == 12416
         assert insight.last_change.astimezone(datetime.timezone.utc) == (
             datetime.datetime(
                 2021, 1, 20, 1, 11, 18, tzinfo=datetime.timezone.utc
             )
         )
-        assert insight.today_standby_time == 0
-        assert insight.get_standby_state == 'standby'
+        assert insight.today_on_time == 0
+        assert insight.get_standby_state == StandbyState.STANDBY
 
         subscription_registry.unregister(insight)
 


### PR DESCRIPTION
## Description:

Insight property changes:

*  Add a `StandbyState` enum for holding the values from the `get_standby_state` property.
*  Add pytype annotations
*  Add `total_kwh`. `current_power_watts`, and `threshold_power_watts` for conversions to common power/energy units.
*  Add `total_on_time` property.
*  Deprecate `today_standby_time`. It's measuring the same thing as `today_on_time` and has a misleading name.


**Related issue (if applicable):** fixes #<pywemo issue number goes here>

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] There is no commented out code in this PR.
  - [x] I have read and agree to the [CONTRIBUTING document](
        https://github.com/pavoni/pywemo/blob/master/CONTRIBUTING.md).