### PR TITLE
Only log discovery issues once per uuid/udn

### DIFF
--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -130,3 +130,28 @@ def test_device_from_uuid_and_location_returns_unsupported():
             )
             == unsupported
         )
+
+
+def test_call_once_per_uuid():
+    call_count = 0
+
+    def increment_call_count():
+        nonlocal call_count
+        call_count += 1
+
+    def decrement_call_count():
+        nonlocal call_count
+        call_count -= 1
+
+    for uuid in ("a_uuid", "b_uuid"):
+        discovery._call_once_per_uuid(uuid, increment_call_count)
+        assert call_count == 1
+
+        discovery._call_once_per_uuid(uuid, decrement_call_count)
+        assert call_count == 0
+
+        discovery._call_once_per_uuid(uuid, increment_call_count)
+        assert call_count == 0
+
+        discovery._call_once_per_uuid(uuid, decrement_call_count)
+        assert call_count == 0

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -104,6 +104,16 @@ def test_device_from_uuid_and_location_returns_none():
         )
 
     with mock.patch(
+        "pywemo.discovery.Switch", side_effect=exceptions.InvalidSchemaError
+    ):
+        assert (
+            discovery.device_from_uuid_and_location(
+                "uuid:Socket-1_0-SERIALNUMBER", "http://127.0.0.1/setup.xml"
+            )
+            is None
+        )
+
+    with mock.patch(
         "pywemo.discovery.UnsupportedDevice",
         side_effect=exceptions.HTTPException,
     ):


### PR DESCRIPTION
## Description:

The discovery process can be run periodically. It isn't helpful to see the same log messages each time it runs. Only log issues once per device.

Based on feedback from @LorenKeagle in https://github.com/home-assistant/core/issues/62259#issuecomment-997518775

**Related issue (if applicable):** https://github.com/home-assistant/core/issues/62259

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] There is no commented out code in this PR.
  - [x] I have read and agree to the [CONTRIBUTING document](
        https://github.com/pavoni/pywemo/blob/master/CONTRIBUTING.md).