### PR TITLE
Rename DimmerV1 to DimmerLongPress

### DIFF
--- a/pywemo/__init__.py
+++ b/pywemo/__init__.py
@@ -7,7 +7,7 @@ from .ouimeaux_device import Device as WeMoDevice
 from .ouimeaux_device.bridge import Bridge
 from .ouimeaux_device.coffeemaker import CoffeeMaker
 from .ouimeaux_device.crockpot import CrockPot
-from .ouimeaux_device.dimmer import Dimmer, DimmerV1
+from .ouimeaux_device.dimmer import Dimmer, DimmerLongPress
 from .ouimeaux_device.humidifier import Humidifier
 from .ouimeaux_device.insight import Insight, StandbyState
 from .ouimeaux_device.lightswitch import LightSwitch, LightSwitchLongPress

--- a/pywemo/discovery.py
+++ b/pywemo/discovery.py
@@ -18,7 +18,7 @@ from .ouimeaux_device.api.service import REQUESTS_TIMEOUT
 from .ouimeaux_device.bridge import Bridge
 from .ouimeaux_device.coffeemaker import CoffeeMaker
 from .ouimeaux_device.crockpot import CrockPot
-from .ouimeaux_device.dimmer import Dimmer, DimmerV1
+from .ouimeaux_device.dimmer import Dimmer, DimmerLongPress
 from .ouimeaux_device.humidifier import Humidifier
 from .ouimeaux_device.insight import Insight
 from .ouimeaux_device.lightswitch import LightSwitch, LightSwitchLongPress
@@ -94,7 +94,7 @@ def device_from_uuid_and_location(uuid, location, debug=False):  # noqa: C901
         if uuid.startswith('uuid:Lightswitch'):
             return LightSwitch(location)
         if uuid.startswith('uuid:Dimmer-1_0'):
-            return DimmerV1(location)
+            return DimmerLongPress(location)
         if uuid.startswith('uuid:Dimmer'):
             return Dimmer(location)
         if uuid.startswith('uuid:Insight'):

--- a/pywemo/ouimeaux_device/dimmer.py
+++ b/pywemo/ouimeaux_device/dimmer.py
@@ -57,5 +57,5 @@ class Dimmer(Switch):
         return super().subscription_update(_type, _param)
 
 
-class DimmerV1(Dimmer, LongPressMixin):
+class DimmerLongPress(Dimmer, LongPressMixin):
     """WeMo Dimmer device that supports long press."""

--- a/tests/ouimeaux_device/test_dimmer.py
+++ b/tests/ouimeaux_device/test_dimmer.py
@@ -2,7 +2,7 @@
 
 import pytest
 
-from pywemo import Dimmer, DimmerV1
+from pywemo.discovery import device_from_uuid_and_location
 
 from .api.unit import long_press_helpers
 
@@ -49,7 +49,10 @@ class Test_PVT_OWRT_Dimmer_v1(Base, long_press_helpers.TestLongPress):
     @pytest.fixture
     def dimmer(self, vcr):
         with vcr.use_cassette('WeMo_WW_2.00.11453.PVT-OWRT-Dimmer'):
-            return DimmerV1('http://192.168.1.100:49153/setup.xml')
+            return device_from_uuid_and_location(
+                'uuid:Dimmer-1_0-SERIALNUMBER',
+                'http://192.168.1.100:49153/setup.xml',
+            )
 
     device = dimmer  # for TestLongPress
 
@@ -60,4 +63,7 @@ class Test_PVT_RTOS_Dimmer_v2(Base):
     @pytest.fixture
     def dimmer(self, vcr):
         with vcr.use_cassette('WEMO_WW_2.00.20110904.PVT-RTOS-DimmerV2'):
-            return Dimmer('http://192.168.1.100:49153/setup.xml')
+            return device_from_uuid_and_location(
+                'uuid:Dimmer-2_0-SERIALNUMBER',
+                'http://192.168.1.100:49153/setup.xml',
+            )

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -15,7 +15,7 @@ from pywemo import discovery, exceptions, ssdp
         ("uuid:Lightswitch-3_0-SERIALNUMBER", discovery.LightSwitchLongPress),
         ("uuid:Lightswitch-3_0-SERIALNUMBER", discovery.LightSwitchLongPress),
         ("uuid:Lightswitch-9_0-SERIALNUMBER", discovery.LightSwitch),
-        ("uuid:Dimmer-1_0-SERIALNUMBER", discovery.DimmerV1),
+        ("uuid:Dimmer-1_0-SERIALNUMBER", discovery.DimmerLongPress),
         ("uuid:Dimmer-2_0-SERIALNUMBER", discovery.Dimmer),
         ("uuid:Insight-1_0-SERIALNUMBER", discovery.Insight),
         ("uuid:Sensor-1_0-SERIALNUMBER", discovery.Motion),


### PR DESCRIPTION
## Description:

Rename DimmerV1 to DimmerLongPress for consistent naming with [LightSwitch](https://github.com/pywemo/pywemo/pull/305).

**Related issue (if applicable):**  #305 

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] There is no commented out code in this PR.
  - [x] I have read and agree to the [CONTRIBUTING document](
        https://github.com/pavoni/pywemo/blob/master/CONTRIBUTING.md).