### PR TITLE
Replace the get_standby_state property with standby_state

### DIFF
--- a/pywemo/ouimeaux_device/insight.py
+++ b/pywemo/ouimeaux_device/insight.py
@@ -160,7 +160,7 @@ class Insight(Switch):
         return self.insight_params['lastchange']
 
     @property
-    def get_standby_state(self) -> StandbyState:
+    def standby_state(self) -> StandbyState:
         """Return the standby state of the device."""
         state = self.insight_params['state']
 
@@ -171,3 +171,14 @@ class Insight(Switch):
             return StandbyState.ON
 
         return StandbyState.STANDBY
+
+    @property
+    def get_standby_state(self) -> StandbyState:
+        """Return the standby state of the device."""
+        warnings.warn(
+            "The Insight.get_standby_state property should not be used and "
+            "will be removed in a future version of pyWeMo. Switch to using "
+            "the Insight.standby_state property instead.",
+            DeprecationWarning,
+        )
+        return self.standby_state

--- a/tests/ouimeaux_device/test_insight.py
+++ b/tests/ouimeaux_device/test_insight.py
@@ -48,7 +48,7 @@ class Test_Insight:
             )
         )
         assert insight.today_on_time == 300
-        assert insight.get_standby_state == StandbyState.OFF
+        assert insight.standby_state == StandbyState.OFF
 
     @pytest.mark.vcr()
     def test_subscribe(self, insight, subscription_registry):
@@ -93,7 +93,7 @@ class Test_Insight:
             )
         )
         assert insight.today_on_time == 0
-        assert insight.get_standby_state == StandbyState.STANDBY
+        assert insight.standby_state == StandbyState.STANDBY
 
         subscription_registry.unregister(insight)
 


### PR DESCRIPTION
## Description:

`get_standby_state` can easily be confused for a callable method. Drop the `get` and use `standby_state`.

I'm keeping `get_standby_state` for backward compatibility and marking it as deprecated.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] There is no commented out code in this PR.
  - [x] I have read and agree to the [CONTRIBUTING document](
        https://github.com/pavoni/pywemo/blob/master/CONTRIBUTING.md).