### PR TITLE
Validate device returned xml documents in one place

### DIFF
--- a/pywemo/ouimeaux_device/api/xsd_types.py
+++ b/pywemo/ouimeaux_device/api/xsd_types.py
@@ -1,0 +1,217 @@
+"""Parsing and validation for Device/Service XML.
+
+Provides a light wrapper around the generated device & service parsers. The
+wrappers check for required fields and values. Default values are also
+provided for optional fields. Clients of this module can expect that all
+fields of the dataclass instances are fully populated and valid. Any parsing
+or validation issues will result in InvalidSchemaError being raised.
+"""
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Any
+
+from lxml import etree as et
+
+from pywemo.exceptions import InvalidSchemaError
+
+from .xsd import device as device_parser
+from .xsd import service as service_parser
+
+LOG = logging.getLogger(__name__)
+
+
+def quote_xml(xml: str) -> str:
+    """Escape markup chars, but do not modify CDATA sections."""
+    return device_parser.quote_xml(xml)  # type: ignore
+
+
+@dataclass(frozen=True)
+class ArgumentType:
+    """Parsed service_parser.ArgumentType."""
+
+    name: str
+    direction: str
+
+    @classmethod
+    def from_argument(
+        cls, argument: service_parser.ArgumentType
+    ) -> ArgumentType:
+        """Parse and validate the service_parser.ArgumentType."""
+        return cls(
+            name=_get_element_text(argument, "name", ""),
+            direction=_get_element_text(argument, "direction", ""),
+        )
+
+
+@dataclass(frozen=True)
+class ActionProperties:
+    """Parsed service_parser.ActionType."""
+
+    name: str
+    arguments: list[ArgumentType]
+
+    @classmethod
+    def from_action(
+        cls, action: service_parser.ActionType
+    ) -> ActionProperties:
+        """Parse and validate the service_parser.ActionType."""
+        arguments: list[service_parser.ArgumentType] = []
+        if action.argumentList and action.argumentList.argument:
+            arguments = action.argumentList.argument
+
+        return cls(
+            name=_get_element_text(action, "name"),
+            arguments=[
+                ArgumentType.from_argument(argument) for argument in arguments
+            ],
+        )
+
+
+@dataclass(frozen=True)
+class ServiceDescription:
+    """Parsed service_parser.scpd."""
+
+    actions: list[ActionProperties]
+
+    @classmethod
+    def from_xml(cls, service_xml_content: bytes) -> ServiceDescription:
+        """Parse and validate the service_parser.scpd."""
+        try:
+            scpd = service_parser.parseString(  # type: ignore
+                service_xml_content, silence=True, print_warnings=False
+            )
+        except Exception as err:
+            raise InvalidSchemaError("Could not parse schema") from err
+
+        if scpd.actionList and scpd.actionList.action:
+            actions = scpd.actionList.action
+        else:
+            actions = []
+
+        return cls(
+            actions=[
+                ActionProperties.from_action(action) for action in actions
+            ]
+        )
+
+
+@dataclass(frozen=True)
+class ServiceProperties:
+    """Parsed device_parser.serviceType."""
+
+    service_type: str
+    service_id: str
+    description_url: str
+    control_url: str
+    event_subscription_url: str
+
+    @classmethod
+    def from_service(
+        cls, service: device_parser.serviceType
+    ) -> ServiceProperties:
+        """Parse and validate the device_parser.serviceType."""
+        return cls(
+            service_type=_get_element_text(service, "serviceType"),
+            service_id=_get_element_text(service, "serviceId"),
+            description_url=_get_element_text(service, "SCPDURL"),
+            control_url=_get_element_text(service, "controlURL"),
+            event_subscription_url=_get_element_text(service, "eventSubURL"),
+        )
+
+
+@dataclass(frozen=True)
+class DeviceDescription:
+    """Device properties from the DeviceType xsd type."""
+
+    firmware_version: str
+    name: str
+    mac: str
+    manufacturer: str
+    model: str
+    model_name: str
+    serial_number: str
+    udn: str
+    _config_any: dict[str, str]
+    _device_type: str
+    _services: list[ServiceProperties]
+
+    @staticmethod
+    def dict_from_xml(setup_xml_content: bytes) -> dict[str, Any]:
+        """Parse and validate the DeviceType xsd type."""
+        try:
+            root = device_parser.parseString(  # type: ignore
+                setup_xml_content, silence=True, print_warnings=False
+            )
+        except Exception as err:
+            raise InvalidSchemaError("Could not parse schema") from err
+
+        device = root.get_device()
+        if device is None:
+            raise InvalidSchemaError("Missing root.device element")
+        manufacturer = _get_element_text(device, "manufacturer")
+        if manufacturer != "Belkin International Inc.":
+            raise InvalidSchemaError(
+                f"Unexpected manufacturer: {manufacturer}"
+            )
+
+        if device.anytypeobjs_:
+            xs_any = (et.fromstring(extra) for extra in device.anytypeobjs_)
+            config_any = {
+                et.QName(tag).localname: tag.text.strip()
+                for tag in xs_any
+                if tag.text and tag.text.strip()
+            }
+        else:
+            config_any = {}
+
+        if device.serviceList and device.serviceList.service:
+            service_list = device.serviceList.service
+        else:
+            service_list = []
+
+        return {
+            "firmware_version": config_any.get("firmwareVersion", ""),
+            "name": _get_element_text(device, "friendlyName"),
+            "mac": _get_element_text(device, "macAddress", ""),
+            "manufacturer": manufacturer,
+            "model": _get_element_text(device, "modelDescription", ""),
+            "model_name": _get_element_text(device, "modelName"),
+            "serial_number": _get_element_text(device, "serialNumber", ""),
+            "udn": _get_element_text(device, "UDN"),
+            "_config_any": config_any,
+            "_device_type": _get_element_text(device, "deviceType"),
+            "_services": [
+                ServiceProperties.from_service(service)
+                for service in service_list
+            ],
+        }
+
+    @classmethod
+    def from_xml(cls, setup_xml_content: bytes) -> DeviceDescription:
+        """Parse and validate the DeviceType xsd type."""
+        return cls(**cls.dict_from_xml(setup_xml_content))
+
+    def __hash__(self) -> int:
+        """Hash only the required elements from the xsd."""
+        return hash((self.name, self.manufacturer, self.model_name, self.udn))
+
+
+def _get_element_text(
+    parent_element: Any, element_name: str, default_value: str | None = None
+) -> str:
+    """Extract text from a sub-element.
+
+    If the sub-element is not found:
+      1. If a `default_value` is provided, that will be returned.
+      2. If no `default_value` is provided, raises InvalidSchemaError.
+
+    Use #1 for optional elements and use #2 for required elements.
+    """
+    text: str | None = getattr(parent_element, f"get_{element_name}")()
+    if text is None or not text:
+        if default_value is not None:
+            return default_value
+        raise InvalidSchemaError(f"Missing element: {element_name}")
+    return text.strip()

--- a/pywemo/ouimeaux_device/bridge.py
+++ b/pywemo/ouimeaux_device/bridge.py
@@ -147,7 +147,7 @@ class Bridge(Device):
 class LinkedDevice:
     """Representation of a device connected to the bridge."""
 
-    def __init__(self, bridge, info):
+    def __init__(self, bridge: Bridge, info: et.Element) -> None:
         """Create a Linked Device."""
         self.bridge = bridge
         self.host = self.bridge.host
@@ -159,7 +159,7 @@ class LinkedDevice:
         self.update_state(info)
         self._last_err = None
         self.mac = self.bridge.mac
-        self.serialnumber = self.bridge.serialnumber
+        self.serialnumber = self.bridge.serial_number
         self.uniqueID = None
 
     def get_state(self, force_update=False):

--- a/pywemo/ouimeaux_device/coffeemaker.py
+++ b/pywemo/ouimeaux_device/coffeemaker.py
@@ -3,9 +3,8 @@ from enum import IntEnum
 
 from lxml import etree as et
 
-from pywemo.ouimeaux_device.api.xsd.device import quote_xml
-
 from .api.service import RequiredService
+from .api.xsd_types import quote_xml
 from .switch import Switch
 
 

--- a/pywemo/ouimeaux_device/humidifier.py
+++ b/pywemo/ouimeaux_device/humidifier.py
@@ -4,7 +4,7 @@ from enum import IntEnum
 from lxml import etree as et
 
 from .api.service import RequiredService
-from .api.xsd.device import quote_xml
+from .api.xsd_types import quote_xml
 from .switch import Switch
 
 

--- a/tests/ouimeaux_device/api/unit/test_xsd_types.py
+++ b/tests/ouimeaux_device/api/unit/test_xsd_types.py
@@ -1,0 +1,232 @@
+"""Tests for interfacing with the generated XSD classes."""
+
+import unittest.mock as mock
+
+import pytest
+
+from pywemo.exceptions import InvalidSchemaError
+from pywemo.ouimeaux_device.api import xsd_types
+from pywemo.ouimeaux_device.api.xsd import device as device_parser
+from pywemo.ouimeaux_device.api.xsd import service as service_parser
+
+DEVICE_PARSER = "pywemo.ouimeaux_device.api.xsd_types.device_parser"
+SERVICE_PARSER = "pywemo.ouimeaux_device.api.xsd_types.service_parser"
+
+
+def test_argument_default_values():
+    xsd_argument = service_parser.ArgumentType()
+
+    argument = xsd_types.ArgumentType.from_argument(xsd_argument)
+
+    assert argument.name == ""
+    assert argument.direction == ""
+
+
+def test_action():
+    argument = service_parser.ArgumentType(name="arg_name", direction="out")
+    argument_list = service_parser.ArgumentListType(argument=[argument])
+    xsd_action = service_parser.ActionType(
+        name="action_name", argumentList=argument_list
+    )
+
+    action = xsd_types.ActionProperties.from_action(xsd_action)
+
+    assert action.name == "action_name"
+    assert action.arguments[0].name == "arg_name"
+    assert action.arguments[0].direction == "out"
+
+
+def test_action_missing_name():
+    action = service_parser.ActionType()
+
+    with pytest.raises(InvalidSchemaError):
+        xsd_types.ActionProperties.from_action(action)
+
+
+def test_action_missing_arguments():
+    action = service_parser.ActionType(name="abc")
+
+    assert isinstance(
+        xsd_types.ActionProperties.from_action(action).arguments, list
+    )
+
+
+def test_service():
+    action = service_parser.ActionType(name="action_name")
+    action_list = service_parser.ActionListType(action=[action])
+    xsd_scpd = service_parser.scpd(actionList=action_list)
+
+    with mock.patch(SERVICE_PARSER) as mock_parser:
+        mock_parser.parseString.return_value = xsd_scpd
+        scpd = xsd_types.ServiceDescription.from_xml(b'')
+
+    assert scpd.actions[0].name == "action_name"
+
+
+def test_services_parse_string_raises():
+    with mock.patch(SERVICE_PARSER) as mock_parser, pytest.raises(
+        InvalidSchemaError
+    ):
+        mock_parser.parseString.side_effect = Exception
+        xsd_types.ServiceDescription.from_xml(b'')
+
+
+def test_service_no_action():
+    xsd_scpd = service_parser.scpd()
+
+    with mock.patch(SERVICE_PARSER) as mock_parser:
+        mock_parser.parseString.return_value = xsd_scpd
+        scpd = xsd_types.ServiceDescription.from_xml(b'')
+
+    assert isinstance(scpd.actions, list)
+
+
+SERVICE_PROPERTIES = {
+    "serviceType_member": "ServiceTypeValue",
+    "serviceId": "ServiceIdValue",
+    "SCPDURL": "SCPDURLValue",
+    "controlURL": "ControlURLValue",
+    "eventSubURL": "EventSubURLValue",
+}
+
+
+def test_service_properties():
+    xsd_service = device_parser.serviceType(**SERVICE_PROPERTIES)
+
+    service = xsd_types.ServiceProperties.from_service(xsd_service)
+
+    assert service.service_type == "ServiceTypeValue"
+    assert service.service_id == "ServiceIdValue"
+    assert service.description_url == "SCPDURLValue"
+    assert service.control_url == "ControlURLValue"
+    assert service.event_subscription_url == "EventSubURLValue"
+
+
+@pytest.mark.parametrize("exclude", SERVICE_PROPERTIES.keys())
+def test_service_properties_missing(exclude):
+    args = {**SERVICE_PROPERTIES}
+    del args[exclude]
+    xsd_service = device_parser.serviceType(**args)
+
+    with pytest.raises(InvalidSchemaError):
+        xsd_types.ServiceProperties.from_service(xsd_service)
+
+
+@pytest.mark.parametrize("exclude", SERVICE_PROPERTIES.keys())
+def test_service_properties_empty(exclude):
+    args = {**SERVICE_PROPERTIES, exclude: ""}
+    xsd_service = device_parser.serviceType(**args)
+
+    with pytest.raises(InvalidSchemaError):
+        xsd_types.ServiceProperties.from_service(xsd_service)
+
+
+DEVICE_PROPERTIES = {
+    "friendlyName": "FriendlyNameValue",
+    "macAddress": "MACAddressValue",
+    "manufacturer": "Belkin International Inc.",
+    "modelDescription": "ModelDescriptionValue",
+    "modelName": "ModelNameValue",
+    "serialNumber": "SerialNumberValue",
+    "UDN": "UniqueDeviceName",
+    "deviceType": "DeviceTypeValue",
+    "anytypeobjs_": [
+        "<firmwareVersion>FirmwareVersionValue</firmwareVersion>"
+    ],
+    "serviceList": device_parser.ServiceListType(
+        service=[device_parser.serviceType(**SERVICE_PROPERTIES)]
+    ),
+}
+
+REQUIRED_KEYS = (
+    "friendlyName",
+    "manufacturer",
+    "modelName",
+    "UDN",
+    "deviceType",
+)
+
+
+def test_device():
+    xsd_device = device_parser.DeviceType(**DEVICE_PROPERTIES)
+    root = device_parser.root(device=xsd_device)
+
+    with mock.patch(DEVICE_PARSER) as mock_parser:
+        mock_parser.parseString.return_value = root
+        device = xsd_types.DeviceDescription.from_xml(b'')
+
+    assert device.firmware_version == "FirmwareVersionValue"
+    assert device.name == "FriendlyNameValue"
+    assert device.mac == "MACAddressValue"
+    assert device.manufacturer == "Belkin International Inc."
+    assert device.model == "ModelDescriptionValue"
+    assert device.model_name == "ModelNameValue"
+    assert device.serial_number == "SerialNumberValue"
+    assert device.udn == "UniqueDeviceName"
+    assert device._config_any["firmwareVersion"] == "FirmwareVersionValue"
+    assert device._device_type == "DeviceTypeValue"
+    assert device._services[0].service_type == "ServiceTypeValue"
+
+
+@pytest.mark.parametrize("exclude", REQUIRED_KEYS)
+def test_device_missing_required_fields(exclude):
+    args = {**DEVICE_PROPERTIES}
+    del args[exclude]
+    xsd_device = device_parser.DeviceType(**args)
+    root = device_parser.root(device=xsd_device)
+
+    with mock.patch(DEVICE_PARSER) as mock_parser, pytest.raises(
+        InvalidSchemaError
+    ):
+        mock_parser.parseString.return_value = root
+        xsd_types.DeviceDescription.from_xml(b'')
+
+
+def test_device_missing_optional_fields():
+    optional_keys = set(DEVICE_PROPERTIES.keys()).difference(REQUIRED_KEYS)
+    args = {**DEVICE_PROPERTIES}
+    for optional_key in optional_keys:
+        del args[optional_key]
+
+    xsd_device = device_parser.DeviceType(**args)
+    root = device_parser.root(device=xsd_device)
+    with mock.patch(DEVICE_PARSER) as mock_parser:
+        mock_parser.parseString.return_value = root
+        device = xsd_types.DeviceDescription.from_xml(b'')
+
+    assert device.firmware_version == ""
+    assert device.mac == ""
+    assert device.model == ""
+    assert device.serial_number == ""
+    assert device._config_any == {}
+    assert device._services == []
+
+
+def test_device_missing_device():
+    root = device_parser.root()
+
+    with mock.patch(DEVICE_PARSER) as mock_parser, pytest.raises(
+        InvalidSchemaError
+    ):
+        mock_parser.parseString.return_value = root
+        xsd_types.DeviceDescription.from_xml(b'')
+
+
+def test_device_wrong_manufacturer():
+    args = {**DEVICE_PROPERTIES, "manufacturer": "pywemo"}
+    xsd_device = device_parser.DeviceType(**args)
+    root = device_parser.root(device=xsd_device)
+
+    with mock.patch(DEVICE_PARSER) as mock_parser, pytest.raises(
+        InvalidSchemaError
+    ):
+        mock_parser.parseString.return_value = root
+        xsd_types.DeviceDescription.from_xml(b'')
+
+
+def test_device_parser_raises():
+    with mock.patch(DEVICE_PARSER) as mock_parser, pytest.raises(
+        InvalidSchemaError
+    ):
+        mock_parser.parseString.side_effect = Exception
+        xsd_types.DeviceDescription.from_xml(b'')

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -69,9 +69,9 @@ def test_device_from_description_returns_none():
         )
 
     with mock.patch("requests.get"), mock.patch(
-        "pywemo.discovery.parse_device_xml"
-    ) as mock_parse:
-        mock_parse.side_effect = exceptions.InvalidSchemaError
+        "pywemo.discovery.DeviceDescription"
+    ) as mock_description:
+        mock_description.from_xml.side_effect = exceptions.InvalidSchemaError
         assert (
             discovery.device_from_description("http://127.0.0.1/setup.xml")
             is None


### PR DESCRIPTION
## Description:

The xsd_types module provides a light wrapper around the generated device & service parsers. The wrappers check for required fields and values. Default values are also provided for optional fields. Clients of this module can expect that all fields of the dataclass instances are fully populated and valid. Any parsing or validation issues will result in InvalidSchemaError being raised.

Related to #315: All other pyWeMo modules use `xsd_types` and `xsd_types` has type annotations. This provides a buffer between the un-typed GenerateDS files and the rest of pyWeMo.


## Checklist:
  - [x] The code change is tested and works locally.
  - [x] There is no commented out code in this PR.
  - [x] I have read and agree to the [CONTRIBUTING document](
        https://github.com/pavoni/pywemo/blob/master/CONTRIBUTING.md).