### PR TITLE
Add parsers for SignalStrength/MetaInfo/ExtMetaInfo

### DIFF
--- a/pywemo/ouimeaux_device/__init__.py
+++ b/pywemo/ouimeaux_device/__init__.py
@@ -353,7 +353,7 @@ class Device(RequiredServicesMixin):
         return self.reset(data=True, wifi=True)
 
     @staticmethod
-    def encrypt_aes128(password: str, meta_info: MetaInfo, is_rtos: bool):
+    def encrypt_aes128(password, wemo_metadata, is_rtos):
         """
         Encrypt a password using OpenSSL.
 
@@ -364,6 +364,7 @@ class Device(RequiredServicesMixin):
             raise SetupException('password required for AES')
 
         # Wemo uses some meta information for salt and iv
+        meta_info = MetaInfo.from_meta_info(wemo_metadata)
         keydata = (
             meta_info.mac[:6] + meta_info.serial_number + meta_info.mac[6:12]
         )
@@ -564,9 +565,7 @@ class Device(RequiredServicesMixin):
             encrypted_password = ''
         else:
             # get the meta information of the device and encrypt the password
-            meta_info = MetaInfo.from_meta_info(
-                self.get_service('metainfo').GetMetaInfo()
-            )
+            meta_info = self.get_service('metainfo').GetMetaInfo()['MetaInfo']
             is_rtos = self._config_any.get('rtos', '0') == '1'
             encrypted_password = self.encrypt_aes128(
                 password, meta_info, is_rtos

--- a/pywemo/util.py
+++ b/pywemo/util.py
@@ -1,6 +1,10 @@
 """Miscellaneous utility functions."""
+from __future__ import annotations
+
 import socket
 from collections import defaultdict
+from dataclasses import dataclass
+from datetime import datetime, timedelta
 
 import ifaddr
 
@@ -67,3 +71,92 @@ def get_ip_address(host='1.2.3.4'):
         return None
     finally:
         del sock
+
+
+def signal_strength_to_dbm(value: dict[str, str] | str) -> int:
+    """Convert signal strength percentage into a RSSI dBm value.
+
+    WeMo devices use the algorithm described here to convert a RSSI dBm value
+    into a signal strength percentage:
+    https://community.cambiumnetworks.com/t/cnmaestro-wifi-analyzer-tool/63471
+
+    signal_strength_to_dbm is meant to be used with the
+    basicevent.GetSignalStrength UPnP Action.
+
+    signal_strength = device.basicevent.GetSignalStrength()
+    signal_strength_to_dbm(signal_strength)
+      or
+    signal_strength_to_dbm(signal_strength["SignalStrength"])
+    """
+    if isinstance(value, dict):
+        percent_str = value["SignalStrength"]
+    else:
+        percent_str = value
+
+    percent = round(float(percent_str))
+    if percent >= 100:
+        return -50
+    if percent >= 24:
+        return round((percent - 24) * 10 / 26 - 80)
+    if percent > 0:
+        return round(percent * 10 / 26 - 90)
+    return -90
+
+
+@dataclass
+class MetaInfo:
+    """Parsed output of the metainfo.GetMetaInfo() Action."""
+
+    mac: str
+    serial_number: str
+    device_sku: str
+    firmware_version: str
+    access_point_ssid: str
+    model_name: str
+
+    @classmethod
+    def from_meta_info(cls, value: dict[str, str] | str) -> MetaInfo:
+        """Initialize from metainfo.GetMetaInfo() output."""
+        info_str = value["MetaInfo"] if isinstance(value, dict) else value
+        values = info_str.split("|")
+        if len(values) < 6:
+            raise ValueError(f"Could not unpack MetaInfo: {info_str}")
+        return cls(*values[:6])
+
+
+@dataclass
+class ExtMetaInfo:
+    """Parsed output of the metainfo.GetExtMetaInfo() Action."""
+
+    current_client_state: int
+    ice_running: int
+    nat_initialized: int
+    last_auth_value: int
+    uptime: timedelta
+    firmware_update_state: int
+    utc_time: datetime
+    home_id: str
+    remote_access_enabled: bool
+    model_name: str
+
+    @classmethod
+    def from_ext_meta_info(cls, value: dict[str, str] | str) -> ExtMetaInfo:
+        """Initialize from metainfo.GetExtMetaInfo() output."""
+        info_str = value["ExtMetaInfo"] if isinstance(value, dict) else value
+        values = info_str.split("|")
+        if not len(values) > 9:
+            raise ValueError(f"Could not unpack ExtMetaInfo: {info_str}")
+
+        hours, minutes, seconds = (int(v) for v in values[4].split(":"))
+        return cls(
+            current_client_state=int(values[0]),
+            ice_running=int(values[1]),
+            nat_initialized=int(values[2]),
+            last_auth_value=int(values[3]),
+            uptime=timedelta(hours=hours, minutes=minutes, seconds=seconds),
+            firmware_update_state=int(values[5]),
+            utc_time=datetime.utcfromtimestamp(int(values[6])),
+            home_id=values[7],
+            remote_access_enabled=bool(int(values[8])),
+            model_name=values[9],
+        )

--- a/tests/ouimeaux_device/test_device.py
+++ b/tests/ouimeaux_device/test_device.py
@@ -19,6 +19,7 @@ from pywemo.ouimeaux_device import (
     UnknownService,
     parse_device_xml,
 )
+from pywemo.util import MetaInfo
 
 RESPONSE_SETUP = '''<?xml version="1.0"?>
 <root xmlns="urn:Belkin:device-1-0">
@@ -217,7 +218,14 @@ def lightspeed():
 class TestDevice:
     """Test the Device object."""
 
-    METAINFO = 'XXXXXXXXXXXX|123456A1234567|dummy'
+    META_INFO = MetaInfo(
+        mac="XXXXXXXXXXXXXX",
+        serial_number="XXXXXXXXXXXXXX",
+        device_sku="",
+        firmware_version="",
+        access_point_ssid="",
+        model_name="",
+    )
 
     def test_initialization(self, device):
         """Test device initialization."""
@@ -283,14 +291,14 @@ class TestDevice:
     def test_encryption_no_openssl(self, mock_run, device):
         """Test device encryption (openssl not found/not installed)."""
         with pytest.raises(SetupException):
-            assert device.encrypt_aes128('password', self.METAINFO, False)
+            assert device.encrypt_aes128('password', self.META_INFO, False)
         assert mock_run.call_count == 1
 
     @mock.patch('subprocess.run', side_effect=CalledProcessError(-1, 'error'))
     def test_encryption_openssl_error(self, mock_run, device):
         """Test device encryption (error in openssl)."""
         with pytest.raises(SetupException):
-            assert device.encrypt_aes128('password', self.METAINFO, False)
+            assert device.encrypt_aes128('password', self.META_INFO, False)
         assert mock_run.call_count == 1
 
     @mock.patch('subprocess.run', return_value=mock.Mock(stdout=ENC_PASSWORD))
@@ -298,7 +306,7 @@ class TestDevice:
         """Test device encryption (good result)."""
         correct = 'wNTUdjT+cA1pa0Vta/jgEg==1808'
         assert (
-            device.encrypt_aes128('password', self.METAINFO, False) == correct
+            device.encrypt_aes128('password', self.META_INFO, False) == correct
         )
         assert mock_run.call_count == 1
 
@@ -307,7 +315,7 @@ class TestDevice:
         """Test device encryption (good result)."""
         correct = 'wNTUdjT+cA1pa0Vta/jgEg=='
         assert (
-            device.encrypt_aes128('password', self.METAINFO, True) == correct
+            device.encrypt_aes128('password', self.META_INFO, True) == correct
         )
         assert mock_run.call_count == 1
 

--- a/tests/ouimeaux_device/test_device.py
+++ b/tests/ouimeaux_device/test_device.py
@@ -19,7 +19,6 @@ from pywemo.ouimeaux_device import (
     UnknownService,
     parse_device_xml,
 )
-from pywemo.util import MetaInfo
 
 RESPONSE_SETUP = '''<?xml version="1.0"?>
 <root xmlns="urn:Belkin:device-1-0">
@@ -218,14 +217,7 @@ def lightspeed():
 class TestDevice:
     """Test the Device object."""
 
-    META_INFO = MetaInfo(
-        mac="XXXXXXXXXXXXXX",
-        serial_number="XXXXXXXXXXXXXX",
-        device_sku="",
-        firmware_version="",
-        access_point_ssid="",
-        model_name="",
-    )
+    METAINFO = 'XXXXXXXXXXXX|123456A1234567|dummy|||'
 
     def test_initialization(self, device):
         """Test device initialization."""
@@ -291,14 +283,14 @@ class TestDevice:
     def test_encryption_no_openssl(self, mock_run, device):
         """Test device encryption (openssl not found/not installed)."""
         with pytest.raises(SetupException):
-            assert device.encrypt_aes128('password', self.META_INFO, False)
+            assert device.encrypt_aes128('password', self.METAINFO, False)
         assert mock_run.call_count == 1
 
     @mock.patch('subprocess.run', side_effect=CalledProcessError(-1, 'error'))
     def test_encryption_openssl_error(self, mock_run, device):
         """Test device encryption (error in openssl)."""
         with pytest.raises(SetupException):
-            assert device.encrypt_aes128('password', self.META_INFO, False)
+            assert device.encrypt_aes128('password', self.METAINFO, False)
         assert mock_run.call_count == 1
 
     @mock.patch('subprocess.run', return_value=mock.Mock(stdout=ENC_PASSWORD))
@@ -306,7 +298,7 @@ class TestDevice:
         """Test device encryption (good result)."""
         correct = 'wNTUdjT+cA1pa0Vta/jgEg==1808'
         assert (
-            device.encrypt_aes128('password', self.META_INFO, False) == correct
+            device.encrypt_aes128('password', self.METAINFO, False) == correct
         )
         assert mock_run.call_count == 1
 
@@ -315,7 +307,7 @@ class TestDevice:
         """Test device encryption (good result)."""
         correct = 'wNTUdjT+cA1pa0Vta/jgEg=='
         assert (
-            device.encrypt_aes128('password', self.META_INFO, True) == correct
+            device.encrypt_aes128('password', self.METAINFO, True) == correct
         )
         assert mock_run.call_count == 1
 

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1,0 +1,99 @@
+"""Tests for pywemo.util."""
+
+from datetime import datetime, timedelta
+
+import pytest
+
+from pywemo import util
+
+
+@pytest.mark.parametrize(
+    "test_input,expected",
+    [
+        (100, -50),
+        (24, -80),
+        (0, -90),
+        (5000, -50),
+        (-4.2, -90),
+        (50, -70),
+        (10, -86),
+    ],
+)
+def test_signal_strength_to_dbm(test_input, expected):
+    signal_strength = {"SignalStrength": f"{test_input}"}
+
+    assert util.signal_strength_to_dbm(signal_strength) == expected
+    assert (
+        util.signal_strength_to_dbm(signal_strength["SignalStrength"])
+        == expected
+    )
+
+
+def test_meta_info():
+    meta_info = {
+        "MetaInfo": "|".join(
+            [
+                "MAC_ADDRESS",
+                "SERIAL_NUMBER",
+                "Plugin Device",
+                "WeMo_WW_2.00.11532.PVT-OWRT-Insight",
+                "WeMo.Insight.684",
+                "Insight",
+            ]
+        )
+    }
+    expected = util.MetaInfo(
+        mac="MAC_ADDRESS",
+        serial_number="SERIAL_NUMBER",
+        device_sku="Plugin Device",
+        firmware_version="WeMo_WW_2.00.11532.PVT-OWRT-Insight",
+        access_point_ssid="WeMo.Insight.684",
+        model_name="Insight",
+    )
+
+    assert util.MetaInfo.from_meta_info(meta_info) == expected
+    assert util.MetaInfo.from_meta_info(meta_info["MetaInfo"]) == expected
+
+    assert (
+        util.MetaInfo.from_meta_info(meta_info["MetaInfo"] + "|extra")
+        == expected
+    )
+
+    with pytest.raises(ValueError):
+        util.MetaInfo.from_meta_info("")
+
+
+def test_ext_meta_info():
+    ext_meta_info = {
+        "ExtMetaInfo": "1|0|1|0|1579:8:42|4|1640081818|123456|1|Insight"
+    }
+    expected = util.ExtMetaInfo(
+        current_client_state=1,
+        ice_running=0,
+        nat_initialized=1,
+        last_auth_value=0,
+        uptime=timedelta(hours=1579, minutes=8, seconds=42),
+        firmware_update_state=4,
+        utc_time=datetime(
+            year=2021, month=12, day=21, hour=10, minute=16, second=58
+        ),
+        home_id="123456",
+        remote_access_enabled=True,
+        model_name="Insight",
+    )
+
+    assert util.ExtMetaInfo.from_ext_meta_info(ext_meta_info) == expected
+    assert (
+        util.ExtMetaInfo.from_ext_meta_info(ext_meta_info["ExtMetaInfo"])
+        == expected
+    )
+
+    assert (
+        util.ExtMetaInfo.from_ext_meta_info(
+            ext_meta_info["ExtMetaInfo"] + "|extra"
+        )
+        == expected
+    )
+
+    with pytest.raises(ValueError):
+        util.ExtMetaInfo.from_ext_meta_info("")


### PR DESCRIPTION
## Description:

Adding a few helper methods to decode the output of:

- basicevent.GetSignalStrength (`signal_strength_to_dbm`)
- metainfo.GetMetaInfo (`MetaInfo.from_ext_meta_info`)
- metainfo.GetExtMetaInfo (`ExtMetaInfo.from_ext_meta_info`)

Related discussion: https://github.com/pywemo/pywemo/issues/171#issuecomment-770467753

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] There is no commented out code in this PR.
  - [x] I have read and agree to the [CONTRIBUTING document](
        https://github.com/pavoni/pywemo/blob/master/CONTRIBUTING.md).