### PR TITLE
Define EVENT_TYPEs for each class that supports subscriptions

### DIFF
--- a/pywemo/__init__.py
+++ b/pywemo/__init__.py
@@ -4,6 +4,7 @@
 from .discovery import discover_devices, setup_url_for_address
 from .exceptions import PyWeMoException
 from .ouimeaux_device import Device as WeMoDevice
+from .ouimeaux_device.api.long_press import LongPressMixin
 from .ouimeaux_device.bridge import Bridge
 from .ouimeaux_device.coffeemaker import CoffeeMaker
 from .ouimeaux_device.crockpot import CrockPot

--- a/pywemo/ouimeaux_device/__init__.py
+++ b/pywemo/ouimeaux_device/__init__.py
@@ -134,6 +134,8 @@ def probe_device(device):
 class Device(RequiredServicesMixin):
     """Base object for WeMo devices."""
 
+    EVENT_TYPE_BINARY_STATE = "BinaryState"
+
     def __init__(self, url: str, mac: str = 'deprecated') -> None:
         """Create a WeMo device."""
         if mac != 'deprecated':
@@ -234,7 +236,7 @@ class Device(RequiredServicesMixin):
     def subscription_update(self, _type, _params):
         """Update device state based on subscription event."""
         LOG.debug("subscription_update %s %s", _type, _params)
-        if _type == "BinaryState":
+        if _type == self.EVENT_TYPE_BINARY_STATE:
             try:
                 self._state = int(self.parse_basic_state(_params).get("state"))
             except ValueError:

--- a/pywemo/ouimeaux_device/api/long_press.py
+++ b/pywemo/ouimeaux_device/api/long_press.py
@@ -89,6 +89,8 @@ def ensure_long_press_rule_exists(
 class LongPressMixin(RequiredServicesMixin):
     """Methods to make changes to the long press rules for a device."""
 
+    EVENT_TYPE_LONG_PRESS = "LongPress"
+
     @property
     def _required_services(self):
         return super()._required_services + [

--- a/pywemo/ouimeaux_device/bridge.py
+++ b/pywemo/ouimeaux_device/bridge.py
@@ -41,6 +41,8 @@ class Bridge(Device):
     Lights = {}
     Groups = {}
 
+    EVENT_TYPE_STATUS_CHANGE = "StatusChange"
+
     def __init__(self, *args, **kwargs):
         """Create a WeMo Bridge (Link) device."""
         super().__init__(*args, **kwargs)
@@ -106,7 +108,7 @@ class Bridge(Device):
 
     def subscription_update(self, _type, _param):
         """Update the bridge attributes due to a subscription update event."""
-        if _type == "StatusChange" and _param:
+        if _type == self.EVENT_TYPE_STATUS_CHANGE and _param:
             state_event = et.fromstring(_param.encode('utf8'))
             key = state_event.findtext('DeviceID')
             if not key:

--- a/pywemo/ouimeaux_device/coffeemaker.py
+++ b/pywemo/ouimeaux_device/coffeemaker.py
@@ -64,6 +64,8 @@ def attribute_xml_to_dict(xml_blob):
 class CoffeeMaker(Switch):
     """Representation of a WeMo CoffeeMaker device."""
 
+    EVENT_TYPE_ATTRIBUTE_LIST = "attributeList"
+
     def __init__(self, *args, **kwargs):
         """Create a WeMo CoffeeMaker device."""
         Switch.__init__(self, *args, **kwargs)
@@ -85,7 +87,7 @@ class CoffeeMaker(Switch):
 
     def subscription_update(self, _type, _params):
         """Handle reports from device."""
-        if _type == "attributeList":
+        if _type == self.EVENT_TYPE_ATTRIBUTE_LIST:
             self._attributes.update(attribute_xml_to_dict(_params))
             self._state = self.mode
             return True

--- a/pywemo/ouimeaux_device/crockpot.py
+++ b/pywemo/ouimeaux_device/crockpot.py
@@ -29,6 +29,10 @@ MODE_NAMES = {
 class CrockPot(Switch):
     """WeMo Crockpot."""
 
+    EVENT_TYPE_COOKED_TIME = "cookedTime"
+    EVENT_TYPE_MODE = "mode"
+    EVENT_TYPE_TIME = "time"
+
     def __init__(self, *args, **kwargs):
         """Create a WeMo CrockPot device."""
         Switch.__init__(self, *args, **kwargs)
@@ -59,18 +63,15 @@ class CrockPot(Switch):
 
     def subscription_update(self, _type, _params):
         """Handle reports from device."""
-        if _params is None:
-            return False
-
-        if _type == "mode":
-            self._attributes['mode'] = str(_params)
+        if _type == self.EVENT_TYPE_MODE:
+            self._attributes['mode'] = _params
             self._state = self.mode
             return True
-        if _type == "time":
-            self._attributes['time'] = str(_params)
+        if _type == self.EVENT_TYPE_TIME:
+            self._attributes['time'] = _params
             return True
-        if _type == "cookedTime":
-            self._attributes['cookedTime'] = str(_params)
+        if _type == self.EVENT_TYPE_COOKED_TIME:
+            self._attributes['cookedTime'] = _params
             return True
 
         return Switch.subscription_update(self, _type, _params)

--- a/pywemo/ouimeaux_device/dimmer.py
+++ b/pywemo/ouimeaux_device/dimmer.py
@@ -7,6 +7,8 @@ from .switch import Switch
 class Dimmer(Switch):
     """Representation of a WeMo Dimmer device."""
 
+    EVENT_TYPE_BRIGHTNESS = "Brightness"
+
     def __init__(self, *args, **kwargs):
         """Create a WeMo Dimmer device."""
         Switch.__init__(self, *args, **kwargs)
@@ -48,7 +50,7 @@ class Dimmer(Switch):
 
     def subscription_update(self, _type, _param):
         """Update the dimmer attributes due to a subscription update event."""
-        if _type == "Brightness":
+        if _type == self.EVENT_TYPE_BRIGHTNESS:
             try:
                 self._brightness = int(_param)
             except ValueError:

--- a/pywemo/ouimeaux_device/humidifier.py
+++ b/pywemo/ouimeaux_device/humidifier.py
@@ -130,6 +130,8 @@ def attribute_xml_to_dict(xml_blob):  # noqa: 901
 class Humidifier(Switch):
     """Representation of a WeMo Humidifier device."""
 
+    EVENT_TYPE_ATTRIBUTE_LIST = "attributeList"
+
     def __init__(self, *args, **kwargs):
         """Create a WeMo Humidifier device."""
         Switch.__init__(self, *args, **kwargs)
@@ -152,7 +154,7 @@ class Humidifier(Switch):
 
     def subscription_update(self, _type, _params):
         """Handle reports from device."""
-        if _type == "attributeList":
+        if _type == self.EVENT_TYPE_ATTRIBUTE_LIST:
             self._attributes.update(attribute_xml_to_dict(_params))
             self._state = self.fan_mode
 

--- a/pywemo/ouimeaux_device/insight.py
+++ b/pywemo/ouimeaux_device/insight.py
@@ -21,6 +21,8 @@ class StandbyState(str, Enum):
 class Insight(Switch):
     """Representation of a WeMo Insight device."""
 
+    EVENT_TYPE_INSIGHT_PARAMS = "InsightParams"
+
     def __init__(self, *args, **kwargs):
         """Create a WeMo Switch device."""
         Switch.__init__(self, *args, **kwargs)
@@ -42,11 +44,11 @@ class Insight(Switch):
     def subscription_update(self, _type, _params):
         """Update the device attributes due to a subscription update event."""
         LOG.debug("subscription_update %s %s", _type, _params)
-        if _type == "InsightParams":
+        if _type == self.EVENT_TYPE_INSIGHT_PARAMS:
             self.insight_params = self.parse_insight_params(_params)
             return True
         updated = super().subscription_update(_type, _params)
-        if _type == "BinaryState" and updated:
+        if _type == self.EVENT_TYPE_BINARY_STATE and updated:
             # Special case: When an Insight device turns off, it also stops
             # sending InsightParams updates. Return False in this case to
             # indicate that the current state of the device hasn't been fully

--- a/pywemo/ouimeaux_device/maker.py
+++ b/pywemo/ouimeaux_device/maker.py
@@ -39,6 +39,8 @@ def attribute_xml_to_dict(xml_blob) -> dict[str, int]:
 class Maker(Switch):
     """Representation of a WeMo Maker device."""
 
+    EVENT_TYPE_ATTRIBUTE_LIST = "attributeList"
+
     def __init__(self, *args, **kwargs):
         """Create a WeMo Switch device."""
         super().__init__(*args, **kwargs)
@@ -62,7 +64,7 @@ class Maker(Switch):
 
     def subscription_update(self, _type, _params):
         """Handle reports from device."""
-        if _type == "attributeList":
+        if _type == self.EVENT_TYPE_ATTRIBUTE_LIST:
             self.maker_params.update(attribute_xml_to_dict(_params))
             self._state = self.switch_state
             return True

--- a/pywemo/subscribe.py
+++ b/pywemo/subscribe.py
@@ -14,14 +14,9 @@ from lxml import etree as et
 
 from .exceptions import SubscriptionRegistryFailed
 from .ouimeaux_device import Device
-from .ouimeaux_device.api.long_press import VIRTUAL_DEVICE_UDN
+from .ouimeaux_device.api.long_press import VIRTUAL_DEVICE_UDN, LongPressMixin
 from .ouimeaux_device.api.service import REQUESTS_TIMEOUT
 from .util import get_ip_address
-
-# Subscription event types.
-EVENT_TYPE_BINARY_STATE = "BinaryState"
-EVENT_TYPE_INSIGHT_PARAMS = "InsightParams"
-EVENT_TYPE_LONG_PRESS = "LongPress"
 
 LOG = logging.getLogger(__name__)
 NS = "{urn:schemas-upnp-org:event-1-0}"
@@ -350,7 +345,9 @@ class RequestHandler(BaseHTTPRequestHandler):
                 binary_state = doc.find('.//BinaryState')
                 if binary_state is not None:
                     text = binary_state.text
-                    outer.event(device, EVENT_TYPE_LONG_PRESS, text)
+                    outer.event(
+                        device, LongPressMixin.EVENT_TYPE_LONG_PRESS, text
+                    )
             self._send_response(200, RESPONSE_SUCCESS)
         else:
             self._send_response(404, RESPONSE_NOT_FOUND)

--- a/tests/ouimeaux_device/test_insight.py
+++ b/tests/ouimeaux_device/test_insight.py
@@ -6,7 +6,6 @@ import threading
 import pytest
 
 from pywemo import Insight, StandbyState
-from pywemo.subscribe import EVENT_TYPE_BINARY_STATE, EVENT_TYPE_INSIGHT_PARAMS
 
 
 class Test_Insight:
@@ -67,14 +66,14 @@ class Test_Insight:
 
         subscription_registry.event(
             insight,
-            EVENT_TYPE_BINARY_STATE,
+            Insight.EVENT_TYPE_BINARY_STATE,
             '1',
         )
         assert insight.get_state() == 1
 
         subscription_registry.event(
             insight,
-            EVENT_TYPE_INSIGHT_PARAMS,
+            Insight.EVENT_TYPE_INSIGHT_PARAMS,
             '8|1611105078|2607|0|12416|1209600|328|500|457600|69632638|9500',
         )
         assert insight.today_kwh == pytest.approx(0.0076266668)

--- a/tests/test_subscribe.py
+++ b/tests/test_subscribe.py
@@ -8,7 +8,14 @@ from http.server import HTTPServer
 import pytest
 import requests
 
-from pywemo import Bridge, Insight, LightSwitch, subscribe
+from pywemo import (
+    Bridge,
+    Insight,
+    LightSwitch,
+    LongPressMixin,
+    WeMoDevice,
+    subscribe,
+)
 
 
 @pytest.fixture
@@ -104,7 +111,7 @@ class Test_RequestHandler:
         assert response.content == subscribe.RESPONSE_SUCCESS.encode("UTF-8")
         outer.event.assert_called_once_with(
             mock_light_switch,
-            subscribe.EVENT_TYPE_BINARY_STATE,
+            WeMoDevice.EVENT_TYPE_BINARY_STATE,
             '0',
             path='/path',
         )
@@ -145,7 +152,7 @@ class Test_RequestHandler:
         assert response.status_code == 200
         assert response.content == subscribe.RESPONSE_SUCCESS.encode("UTF-8")
         outer.event.assert_called_once_with(
-            mock_light_switch, subscribe.EVENT_TYPE_LONG_PRESS, '0'
+            mock_light_switch, LongPressMixin.EVENT_TYPE_LONG_PRESS, '0'
         )
 
     def test_POST_default_404(self, server_url):


### PR DESCRIPTION
## Description:

Add the following EVENT_TYPE_ constants so clients can use the constant values instead of strings. These values correspond to the `type_` argument in the subscription event callbacks (`callback(device, type_, value)`).

- `pywemo.WeMoDevice.EVENT_TYPE_BINARY_STATE` the on/off state of a device was changed.
- `pywemo.Bridge.EVENT_TYPE_STATUS_CHANGE` the state of one of the linked devices was updated.
- `pywemo.CoffeeMaker.EVENT_TYPE_ATTRIBUTE_LIST` the state of the coffee maker was updated.
- `pywemo.CrockPot.EVENT_TYPE_COOKED_TIME` the cooked_time property of the crock pot was updated.
- `pywemo.CrockPot.EVENT_TYPE_MODE` the mode & mode_string properties of the crock pot were updated.
- `pywemo.CrockPot.EVENT_TYPE_TIME` the remaining_time property of the crock pot was updated.
- `pywemo.Dimmer.EVENT_TYPE_BRIGHTNESS` the brightness setting on the dimmer was updated.
- `pywemo.Humidifier.EVENT_TYPE_ATTRIBUTE_LIST` the state of the humidifier was updated.
- `pywemo.Insight.EVENT_TYPE_INSIGHT_PARAMS` energy statistics were updated.
- `pywemo.LongPressMixin.EVENT_TYPE_LONG_PRESS` the button was held down for 2 seconds.
- `pywemo.Maker.EVENT_TYPE_ATTRIBUTE_LIST` the state of the Maker was updated.


Breaking change:

The EVENT_TYPE_* constants are no longer defined in subscribe.py. They are instead static properties of the devices that use the event. This makes the constants more self contained. Adding a new device only requires adding properties in the device file and does not require modifying subscribe.py.

Use the following instead:
- `from pywemo.WeMoDevice import EVENT_TYPE_BINARY_STATE`- EVENT_TYPE_BINARY_STATE is also defined on all other device classes (Bridge, Dimmer, Switch, ...etc)
- `from pywemo.Insight import EVENT_TYPE_INSIGHT_PARAMS`
- `from pywemo.LongPressMixin import EVENT_TYPE_LONG_PRESS` - EVENT_TYPE_LONG_PRESS is also defined on all device classes that support long-press (SwitchLongPress & LightSwitchLongPress)


## Checklist:
  - [x] The code change is tested and works locally.
  - [x] There is no commented out code in this PR.
  - [x] I have read and agree to the [CONTRIBUTING document](
        https://github.com/pavoni/pywemo/blob/master/CONTRIBUTING.md).