### PR TITLE
Remove LongPressMixin from LightSwitch

### DIFF
--- a/pywemo/ouimeaux_device/lightswitch.py
+++ b/pywemo/ouimeaux_device/lightswitch.py
@@ -3,7 +3,7 @@ from .api.long_press import LongPressMixin
 from .switch import Switch
 
 
-class LightSwitch(Switch, LongPressMixin):
+class LightSwitch(Switch):
     """Representation of a WeMo Light Switch device."""
 
 


### PR DESCRIPTION
## Description:

Remove LongPressMixin from LightSwitch

**Related issue (if applicable):** This change should have been included in #305

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] There is no commented out code in this PR.
  - [x] I have read and agree to the [CONTRIBUTING document](
        https://github.com/pavoni/pywemo/blob/master/CONTRIBUTING.md).