### PR TITLE
Type annotations for commonly overridden Device methods

### DIFF
--- a/pywemo/ouimeaux_device/__init__.py
+++ b/pywemo/ouimeaux_device/__init__.py
@@ -212,7 +212,7 @@ class Device(DeviceDescription, RequiredServicesMixin, WeMoServiceTypesMixin):
             return True
         return False
 
-    def get_state(self, force_update=False):
+    def get_state(self, force_update: bool = False) -> int:
         """Return 0 if off and 1 if on."""
         if force_update or self._state is None:
             self.update_binary_state()

--- a/pywemo/ouimeaux_device/__init__.py
+++ b/pywemo/ouimeaux_device/__init__.py
@@ -197,7 +197,7 @@ class Device(DeviceDescription, RequiredServicesMixin, WeMoServiceTypesMixin):
         """Update the cached copy of the basic state response."""
         self.basic_state_params = self.basicevent.GetBinaryState() or {}
 
-    def subscription_update(self, _type, _params):
+    def subscription_update(self, _type: str, _params: str) -> bool:
         """Update device state based on subscription event."""
         LOG.debug("subscription_update %s %s", _type, _params)
         if _type == "BinaryState":

--- a/pywemo/ouimeaux_device/bridge.py
+++ b/pywemo/ouimeaux_device/bridge.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import io
 import time
 from html import escape
+from typing import Any
 
 from lxml import etree as et
 
@@ -43,7 +44,7 @@ class Bridge(Device):
     Lights = {}
     Groups = {}
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         """Create a WeMo Bridge (Link) device."""
         super().__init__(*args, **kwargs)
         self.bridge_update()

--- a/pywemo/ouimeaux_device/bridge.py
+++ b/pywemo/ouimeaux_device/bridge.py
@@ -107,7 +107,7 @@ class Bridge(Device):
         self.bridge_update(force_update)
         return state
 
-    def subscription_update(self, _type, _param):
+    def subscription_update(self, _type: str, _param: str) -> bool:
         """Update the bridge attributes due to a subscription update event."""
         if _type == "StatusChange" and _param:
             state_event = et.fromstring(_param.encode('utf8'))

--- a/pywemo/ouimeaux_device/bridge.py
+++ b/pywemo/ouimeaux_device/bridge.py
@@ -101,7 +101,7 @@ class Bridge(Device):
 
         return self.Lights, self.Groups
 
-    def get_state(self, force_update=False):
+    def get_state(self, force_update: bool = False) -> int:
         """Update the state of the Bridge device."""
         state = super().get_state(force_update)
         self.bridge_update(force_update)

--- a/pywemo/ouimeaux_device/coffeemaker.py
+++ b/pywemo/ouimeaux_device/coffeemaker.py
@@ -114,7 +114,7 @@ class CoffeeMaker(Switch):
         # Consider the Coffee Maker to be "on" if it's currently brewing.
         return int(self._state == CoffeeMakerMode.Brewing)
 
-    def set_state(self, state):
+    def set_state(self, state: int) -> None:
         """Set the state of this device to on or off."""
         # CoffeeMaker cannot be turned off remotely, so ignore the request if
         # state is "falsey"

--- a/pywemo/ouimeaux_device/coffeemaker.py
+++ b/pywemo/ouimeaux_device/coffeemaker.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 from enum import IntEnum
+from typing import Any
 
 from lxml import etree as et
 
@@ -65,7 +66,7 @@ def attribute_xml_to_dict(xml_blob):
 class CoffeeMaker(Switch):
     """Representation of a WeMo CoffeeMaker device."""
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         """Create a WeMo CoffeeMaker device."""
         Switch.__init__(self, *args, **kwargs)
         self._attributes = {}

--- a/pywemo/ouimeaux_device/coffeemaker.py
+++ b/pywemo/ouimeaux_device/coffeemaker.py
@@ -85,7 +85,7 @@ class CoffeeMaker(Switch):
         self._attributes = attribute_xml_to_dict(resp)
         self._state = self.mode
 
-    def subscription_update(self, _type, _params):
+    def subscription_update(self, _type: str, _params: str) -> bool:
         """Handle reports from device."""
         if _type == "attributeList":
             self._attributes.update(attribute_xml_to_dict(_params))

--- a/pywemo/ouimeaux_device/coffeemaker.py
+++ b/pywemo/ouimeaux_device/coffeemaker.py
@@ -104,7 +104,7 @@ class CoffeeMaker(Switch):
         """Return the mode of the device as a string."""
         return MODE_NAMES.get(self.mode, "Unknown")
 
-    def get_state(self, force_update=False):
+    def get_state(self, force_update: bool = False) -> int:
         """Return 0 if off and 1 if on."""
         # The base implementation using GetBinaryState doesn't work for
         # CoffeeMaker (always returns 0), so use mode instead.

--- a/pywemo/ouimeaux_device/crockpot.py
+++ b/pywemo/ouimeaux_device/crockpot.py
@@ -60,7 +60,7 @@ class CrockPot(Switch):
             self._attributes = state_attributes
             self._state = self.mode
 
-    def subscription_update(self, _type, _params):
+    def subscription_update(self, _type: str, _params: str) -> bool:
         """Handle reports from device."""
         if _params is None:
             return False

--- a/pywemo/ouimeaux_device/crockpot.py
+++ b/pywemo/ouimeaux_device/crockpot.py
@@ -98,7 +98,7 @@ class CrockPot(Switch):
         """Return the cooked time in minutes."""
         return int(self._attributes.get('cookedTime'))
 
-    def get_state(self, force_update=False):
+    def get_state(self, force_update: bool = False) -> int:
         """Return 0 if off and 1 if on."""
         # The base implementation using GetBinaryState doesn't work for
         # CrockPot (always returns 0) so use mode instead.

--- a/pywemo/ouimeaux_device/crockpot.py
+++ b/pywemo/ouimeaux_device/crockpot.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 from enum import IntEnum
+from typing import Any
 
 from .api.service import RequiredService
 from .switch import Switch
@@ -31,7 +32,7 @@ MODE_NAMES = {
 class CrockPot(Switch):
     """WeMo Crockpot."""
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         """Create a WeMo CrockPot device."""
         Switch.__init__(self, *args, **kwargs)
         self._attributes = {}

--- a/pywemo/ouimeaux_device/crockpot.py
+++ b/pywemo/ouimeaux_device/crockpot.py
@@ -107,7 +107,7 @@ class CrockPot(Switch):
 
         return int(self.mode != CrockPotMode.Off)
 
-    def set_state(self, state):
+    def set_state(self, state: int) -> None:
         """Set the state of this device to on or off."""
         if state:
             self.update_settings(

--- a/pywemo/ouimeaux_device/dimmer.py
+++ b/pywemo/ouimeaux_device/dimmer.py
@@ -1,6 +1,8 @@
 """Representation of a WeMo Dimmer device."""
 from __future__ import annotations
 
+from typing import Any
+
 from .api.long_press import LongPressMixin
 from .api.service import RequiredService
 from .switch import Switch
@@ -9,7 +11,7 @@ from .switch import Switch
 class Dimmer(Switch):
     """Representation of a WeMo Dimmer device."""
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         """Create a WeMo Dimmer device."""
         Switch.__init__(self, *args, **kwargs)
         self._brightness = None

--- a/pywemo/ouimeaux_device/dimmer.py
+++ b/pywemo/ouimeaux_device/dimmer.py
@@ -39,7 +39,7 @@ class Dimmer(Switch):
         else:
             self.off()
 
-    def get_state(self, force_update=False):
+    def get_state(self, force_update: bool = False) -> int:
         """Update the state & brightness for the Dimmer."""
         state = super().get_state(force_update)
         if force_update or self._brightness is None:

--- a/pywemo/ouimeaux_device/dimmer.py
+++ b/pywemo/ouimeaux_device/dimmer.py
@@ -50,7 +50,7 @@ class Dimmer(Switch):
             self._brightness = brightness
         return state
 
-    def subscription_update(self, _type, _param):
+    def subscription_update(self, _type: str, _param: str) -> bool:
         """Update the dimmer attributes due to a subscription update event."""
         if _type == "Brightness":
             try:

--- a/pywemo/ouimeaux_device/humidifier.py
+++ b/pywemo/ouimeaux_device/humidifier.py
@@ -223,7 +223,7 @@ class Humidifier(Switch):
         # Consider the Humidifier to be "on" if it's not off.
         return int(self._state != FanMode.Off)
 
-    def set_state(self, state):
+    def set_state(self, state: int) -> None:
         """
         Set the fan mode of this device (as int index of the FanMode IntEnum).
 

--- a/pywemo/ouimeaux_device/humidifier.py
+++ b/pywemo/ouimeaux_device/humidifier.py
@@ -153,7 +153,7 @@ class Humidifier(Switch):
         self._attributes = attribute_xml_to_dict(resp)
         self._state = self.fan_mode
 
-    def subscription_update(self, _type, _params):
+    def subscription_update(self, _type: str, _params: str) -> bool:
         """Handle reports from device."""
         if _type == "attributeList":
             self._attributes.update(attribute_xml_to_dict(_params))

--- a/pywemo/ouimeaux_device/humidifier.py
+++ b/pywemo/ouimeaux_device/humidifier.py
@@ -212,7 +212,7 @@ class Humidifier(Switch):
         """Return 0 if filter is OK, and 1 if it needs to be changed."""
         return self._attributes.get('filter_expired')
 
-    def get_state(self, force_update=False):
+    def get_state(self, force_update: bool = False) -> int:
         """Return 0 if off and 1 if on."""
         # The base implementation using GetBinaryState
         # doesn't work for Humidifier (always returns 0)

--- a/pywemo/ouimeaux_device/humidifier.py
+++ b/pywemo/ouimeaux_device/humidifier.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 from enum import IntEnum
+from typing import Any
 
 from lxml import etree as et
 
@@ -132,7 +133,7 @@ def attribute_xml_to_dict(xml_blob):  # noqa: 901
 class Humidifier(Switch):
     """Representation of a WeMo Humidifier device."""
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         """Create a WeMo Humidifier device."""
         Switch.__init__(self, *args, **kwargs)
         self._attributes = {}

--- a/pywemo/ouimeaux_device/insight.py
+++ b/pywemo/ouimeaux_device/insight.py
@@ -5,6 +5,7 @@ import logging
 import warnings
 from datetime import datetime
 from enum import Enum
+from typing import Any
 
 from .api.service import RequiredService
 from .switch import Switch
@@ -23,7 +24,7 @@ class StandbyState(str, Enum):
 class Insight(Switch):
     """Representation of a WeMo Insight device."""
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         """Create a WeMo Switch device."""
         Switch.__init__(self, *args, **kwargs)
         self.insight_params = {}

--- a/pywemo/ouimeaux_device/insight.py
+++ b/pywemo/ouimeaux_device/insight.py
@@ -86,7 +86,7 @@ class Insight(Switch):
             'powerthreshold': int(float(powerthreshold)),
         }
 
-    def get_state(self, force_update=False):
+    def get_state(self, force_update: bool = False) -> int:
         """Return the device state."""
         if force_update or self._state is None:
             self.update_insight_params()

--- a/pywemo/ouimeaux_device/insight.py
+++ b/pywemo/ouimeaux_device/insight.py
@@ -42,7 +42,7 @@ class Insight(Switch):
         params = self.insight.GetInsightParams().get('InsightParams')
         self.insight_params = self.parse_insight_params(params)
 
-    def subscription_update(self, _type, _params):
+    def subscription_update(self, _type: str, _params: str) -> bool:
         """Update the device attributes due to a subscription update event."""
         LOG.debug("subscription_update %s %s", _type, _params)
         if _type == "InsightParams":

--- a/pywemo/ouimeaux_device/maker.py
+++ b/pywemo/ouimeaux_device/maker.py
@@ -62,7 +62,7 @@ class Maker(Switch):
         self.maker_params = attribute_xml_to_dict(maker_resp)
         self._state = self.switch_state
 
-    def subscription_update(self, _type, _params):
+    def subscription_update(self, _type: str, _params: str) -> bool:
         """Handle reports from device."""
         if _type == "attributeList":
             self.maker_params.update(attribute_xml_to_dict(_params))

--- a/pywemo/ouimeaux_device/maker.py
+++ b/pywemo/ouimeaux_device/maker.py
@@ -81,7 +81,7 @@ class Maker(Switch):
 
         return self.switch_state
 
-    def set_state(self, state):
+    def set_state(self, state: int) -> None:
         """Set the state of this device to on or off."""
         # The Maker has a momentary mode - so it's not safe to assume
         # the state is what you just set, so re-read it from the device

--- a/pywemo/ouimeaux_device/maker.py
+++ b/pywemo/ouimeaux_device/maker.py
@@ -1,6 +1,8 @@
 """Representation of a WeMo Maker device."""
 from __future__ import annotations
 
+from typing import Any
+
 from lxml import etree as et
 
 from .api.service import RequiredService
@@ -39,7 +41,7 @@ def attribute_xml_to_dict(xml_blob) -> dict[str, int]:
 class Maker(Switch):
     """Representation of a WeMo Maker device."""
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         """Create a WeMo Switch device."""
         super().__init__(*args, **kwargs)
         self.maker_params = {}

--- a/pywemo/ouimeaux_device/maker.py
+++ b/pywemo/ouimeaux_device/maker.py
@@ -71,7 +71,7 @@ class Maker(Switch):
 
         return super().subscription_update(_type, _params)
 
-    def get_state(self, force_update=False):
+    def get_state(self, force_update: bool = False) -> int:
         """Return 0 if off and 1 if on."""
         # The base implementation using GetBinaryState doesn't work for the
         # Maker (always returns 0), so pull the switch state from the

--- a/pywemo/ouimeaux_device/switch.py
+++ b/pywemo/ouimeaux_device/switch.py
@@ -12,19 +12,19 @@ class Switch(Device):
             RequiredService(name="basicevent", actions=["SetBinaryState"]),
         ]
 
-    def set_state(self, state):
+    def set_state(self, state: int) -> None:
         """Set the state of this device to on or off."""
         self.basicevent.SetBinaryState(BinaryState=int(state))
         self._state = int(state)
 
     def off(self):
         """Turn this device off. If already off, will return "Error"."""
-        return self.set_state(0)
+        self.set_state(0)
 
     def on(self):
         """Turn this device on. If already on, will return "Error"."""
-        return self.set_state(1)
+        self.set_state(1)
 
     def toggle(self):
         """Toggle the switch's state."""
-        return self.set_state(not self.get_state())
+        self.set_state(not self.get_state())


### PR DESCRIPTION
## Description:

Adding type annotations on the following Device methods:

- \_\_init__
- get_state
- set_state
- subscription_update

**Related issue (if applicable):**  #315

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] There is no commented out code in this PR.
  - [x] I have read and agree to the [CONTRIBUTING document](
        https://github.com/pavoni/pywemo/blob/master/CONTRIBUTING.md).