### PR TITLE
Provide a default value for some enums

### DIFF
--- a/pywemo/ouimeaux_device/coffeemaker.py
+++ b/pywemo/ouimeaux_device/coffeemaker.py
@@ -1,5 +1,8 @@
 """Representation of a WeMo CoffeeMaker device."""
+from __future__ import annotations
+
 from enum import IntEnum
+from typing import Any
 
 from lxml import etree as et
 
@@ -15,6 +18,7 @@ from .switch import Switch
 class CoffeeMakerMode(IntEnum):
     """Enum to map WeMo modes to human-readable strings."""
 
+    _UNKNOWN = -1
     # pylint: disable=invalid-name
     Refill = 0  # reservoir empty and carafe not in place
     PlaceCarafe = 1  # reservoir has water but carafe not present
@@ -25,6 +29,10 @@ class CoffeeMakerMode(IntEnum):
     CleaningBrewing = 6
     CleaningSoaking = 7
     BrewFailCarafeRemoved = 8
+
+    @classmethod
+    def _missing_(cls, value: Any) -> CoffeeMakerMode:
+        return cls._UNKNOWN
 
 
 MODE_NAMES = {

--- a/pywemo/ouimeaux_device/crockpot.py
+++ b/pywemo/ouimeaux_device/crockpot.py
@@ -1,5 +1,8 @@
 """Representation of a WeMo CrockPot device."""
+from __future__ import annotations
+
 from enum import IntEnum
+from typing import Any
 
 from .api.service import RequiredService
 from .switch import Switch
@@ -11,11 +14,16 @@ from .switch import Switch
 class CrockPotMode(IntEnum):
     """Modes for the CrockPot."""
 
+    _UNKNOWN = -1
     # pylint: disable=invalid-name
     Off = 0
     Warm = 50
     Low = 51
     High = 52
+
+    @classmethod
+    def _missing_(cls, value: Any) -> CrockPotMode:
+        return cls._UNKNOWN
 
 
 MODE_NAMES = {

--- a/pywemo/ouimeaux_device/humidifier.py
+++ b/pywemo/ouimeaux_device/humidifier.py
@@ -1,5 +1,8 @@
 """Representation of a WeMo Humidifier device."""
+from __future__ import annotations
+
 from enum import IntEnum
+from typing import Any
 
 from lxml import etree as et
 
@@ -13,6 +16,7 @@ from .switch import Switch
 class FanMode(IntEnum):
     """Enum to map WeMo FanModes to human-readable strings."""
 
+    _UNKNOWN = -1
     # pylint: disable=invalid-name
     Off = 0  # Fan and device turned off
     Minimum = 1
@@ -20,6 +24,10 @@ class FanMode(IntEnum):
     Medium = 3
     High = 4
     Maximum = 5
+
+    @classmethod
+    def _missing_(cls, value: Any) -> FanMode:
+        return cls._UNKNOWN
 
 
 FAN_MODE_NAMES = {
@@ -35,12 +43,17 @@ FAN_MODE_NAMES = {
 class DesiredHumidity(IntEnum):
     """Enum to map WeMo DesiredHumidity to human-readable strings."""
 
+    _UNKNOWN = -1
     # pylint: disable=invalid-name
     FortyFivePercent = 0
     FiftyPercent = 1
     FiftyFivePercent = 2
     SixtyPercent = 3
     OneHundredPercent = 4  # "Always On" Mode
+
+    @classmethod
+    def _missing_(cls, value: Any) -> DesiredHumidity:
+        return cls._UNKNOWN
 
 
 DESIRED_HUMIDITY_NAMES = {


### PR DESCRIPTION
## Description:

I'd like to have methods return the enum values directly rather than returning an `int`. One downside of doing this is if any unexpected values are received from the device, this will cause an exception. To avoid this, I'm mapping unexpected values to an _UNKNOWN enum in each class.

**Related issue (if applicable):** #315

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] There is no commented out code in this PR.
  - [x] I have read and agree to the [CONTRIBUTING document](
        https://github.com/pavoni/pywemo/blob/master/CONTRIBUTING.md).