### PR TITLE
CoffeeMaker/Humidifier/Maker have common base class

### DIFF
--- a/pywemo/ouimeaux_device/api/attributes.py
+++ b/pywemo/ouimeaux_device/api/attributes.py
@@ -1,0 +1,103 @@
+"""Attribute device helpers."""
+from __future__ import annotations
+
+from typing import Any
+
+from lxml import etree as et
+
+from ..switch import Switch
+from .service import RequiredService
+from .xsd_types import quote_xml
+
+
+def _is_int_or_float(value: str) -> bool:
+    if value.isdecimal():
+        return True
+    values = value.split(".")
+    return len(values) == 2 and values[0].isdecimal() and values[1].isdecimal()
+
+
+class AttributeDevice(Switch):
+    """Handles all parsing/getting/setting of attribute lists.
+
+    This is intended to be used as the base class for all devices that support
+    the deviceevent.GetAttributes() method.
+
+    Subclasses can use the _attributes property to fetch the string values of
+    all attributes. Subclasses must provide the name of the property to use
+    for self._state in a property named _state_property.
+    """
+
+    EVENT_TYPE_ATTRIBUTE_LIST = "attributeList"
+
+    _attributes: dict[str, str] = {}
+    _state_property: str
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        """Create a Attributes device."""
+        assert isinstance(self._state_property, str)
+        super().__init__(*args, **kwargs)
+        self.update_attributes()
+
+    @property
+    def _required_services(self) -> list[RequiredService]:
+        return super()._required_services + [
+            RequiredService(
+                name="deviceevent", actions=["GetAttributes", "SetAttributes"]
+            ),
+        ]
+
+    def _get_state(self) -> int | None:
+        state: int | None = getattr(self, self._state_property)
+        return state
+
+    def _update_attributes_dict(self, xml_blob: str) -> None:
+        xml_blob = "<attributes>" + xml_blob + "</attributes>"
+        xml_blob = xml_blob.replace("&gt;", ">")
+        xml_blob = xml_blob.replace("&lt;", "<")
+
+        self._attributes.update(
+            {
+                attribute[0].text: attribute[1].text
+                for attribute in et.fromstring(xml_blob)
+                if len(attribute) >= 2 and _is_int_or_float(attribute[1].text)
+            }
+        )
+
+        self._state = self._get_state()
+
+    def update_attributes(self) -> None:
+        """Request state from device."""
+        resp = self.deviceevent.GetAttributes().get(
+            self.EVENT_TYPE_ATTRIBUTE_LIST
+        )
+        assert resp is not None
+        self._update_attributes_dict(resp)
+
+    def subscription_update(self, _type: str, _params: str) -> bool:
+        """Handle subscription push-events from device."""
+        if _type == self.EVENT_TYPE_ATTRIBUTE_LIST:
+            self._update_attributes_dict(_params)
+            return True
+
+        return super().subscription_update(_type, _params)
+
+    def get_state(self, force_update: bool = False) -> int:
+        """Return 0 if off and 1 if on."""
+        if force_update or self._state is None:
+            self.update_attributes()
+
+        assert self._state is not None
+        return self._state
+
+    def _set_attributes(self, *args: tuple[str, str | int | float]) -> None:
+        """Set the specified attributes on the device."""
+        attribute_xml = "</attribute><attribute>".join(
+            f"<name>{name}</name><value>{value}</value>"
+            for name, value in args
+        )
+        attribute_xml = f"<attribute>{attribute_xml}</attribute>"
+        self.deviceevent.SetAttributes(attributeList=quote_xml(attribute_xml))
+
+        # Refresh the device state
+        self.get_state(True)

--- a/pywemo/ouimeaux_device/api/attributes.py
+++ b/pywemo/ouimeaux_device/api/attributes.py
@@ -47,10 +47,6 @@ class AttributeDevice(Switch):
             ),
         ]
 
-    def _get_state(self) -> int | None:
-        state: int | None = getattr(self, self._state_property)
-        return state
-
     def _update_attributes_dict(self, xml_blob: str) -> None:
         xml_blob = "<attributes>" + xml_blob + "</attributes>"
         xml_blob = xml_blob.replace("&gt;", ">")
@@ -64,7 +60,8 @@ class AttributeDevice(Switch):
             }
         )
 
-        self._state = self._get_state()
+        state: int | None = getattr(self, self._state_property)
+        self._state = state
 
     def update_attributes(self) -> None:
         """Request state from device."""

--- a/pywemo/ouimeaux_device/coffeemaker.py
+++ b/pywemo/ouimeaux_device/coffeemaker.py
@@ -52,14 +52,14 @@ class CoffeeMaker(AttributeDevice):
     _state_property = "mode"  # Required by AttributeDevice.
 
     @property
-    def mode_string(self) -> str:
-        """Return the mode of the device as a string."""
-        return MODE_NAMES.get(self.mode, "Unknown")
-
-    @property
     def mode(self) -> CoffeeMakerMode:
         """Return the mode of the device."""
         return CoffeeMakerMode(int(self._attributes.get("Mode", _UNKNOWN)))
+
+    @property
+    def mode_string(self) -> str:
+        """Return the mode of the device as a string."""
+        return MODE_NAMES.get(self.mode, "Unknown")
 
     def get_state(self, force_update: bool = False) -> int:
         """Return 0 if off and 1 if on."""

--- a/pywemo/ouimeaux_device/coffeemaker.py
+++ b/pywemo/ouimeaux_device/coffeemaker.py
@@ -2,11 +2,11 @@
 from __future__ import annotations
 
 from enum import IntEnum
-from typing import Any, Final
+from typing import Any
 
 from .api.attributes import AttributeDevice
 
-_UNKNOWN: Final = -1
+_UNKNOWN = -1
 
 
 # These enums were derived from the

--- a/pywemo/ouimeaux_device/coffeemaker.py
+++ b/pywemo/ouimeaux_device/coffeemaker.py
@@ -2,13 +2,11 @@
 from __future__ import annotations
 
 from enum import IntEnum
-from typing import Any
+from typing import Any, Final
 
-from lxml import etree as et
+from .api.attributes import AttributeDevice
 
-from .api.service import RequiredService
-from .api.xsd_types import quote_xml
-from .switch import Switch
+_UNKNOWN: Final = -1
 
 
 # These enums were derived from the
@@ -18,7 +16,7 @@ from .switch import Switch
 class CoffeeMakerMode(IntEnum):
     """Enum to map WeMo modes to human-readable strings."""
 
-    _UNKNOWN = -1
+    _UNKNOWN = _UNKNOWN
     # pylint: disable=invalid-name
     Refill = 0  # reservoir empty and carafe not in place
     PlaceCarafe = 1  # reservoir has water but carafe not present
@@ -48,76 +46,27 @@ MODE_NAMES = {
 }
 
 
-def attribute_xml_to_dict(xml_blob):
-    """Return integer value of Mode from an attributesList blob, if present."""
-    xml_blob = "<attributes>" + xml_blob + "</attributes>"
-    xml_blob = xml_blob.replace("&gt;", ">")
-    xml_blob = xml_blob.replace("&lt;", "<")
-    result = {}
-    attributes = et.fromstring(xml_blob)
-    for attribute in attributes:
-        # The coffee maker might also send unrelated xml blobs, e.g.:
-        # <ruleID>coffee-brewed</ruleID>
-        # <ruleMsg><![CDATA[Coffee's ready!]]></ruleMsg>
-        # so be sure to check the length of attribute
-        if len(attribute) >= 2:
-            try:
-                result[attribute[0].text] = int(attribute[1].text)
-            except ValueError:
-                pass
-    return result
-
-
-class CoffeeMaker(Switch):
+class CoffeeMaker(AttributeDevice):
     """Representation of a WeMo CoffeeMaker device."""
 
-    def __init__(self, *args: Any, **kwargs: Any) -> None:
-        """Create a WeMo CoffeeMaker device."""
-        Switch.__init__(self, *args, **kwargs)
-        self._attributes = {}
+    _state_property = "mode"  # Required by AttributeDevice.
 
     @property
-    def _required_services(self) -> list[RequiredService]:
-        return super()._required_services + [
-            RequiredService(
-                name="deviceevent", actions=["GetAttributes", "SetAttributes"]
-            ),
-        ]
-
-    def update_attributes(self):
-        """Request state from device."""
-        resp = self.deviceevent.GetAttributes().get('attributeList')
-        self._attributes = attribute_xml_to_dict(resp)
-        self._state = self.mode
-
-    def subscription_update(self, _type: str, _params: str) -> bool:
-        """Handle reports from device."""
-        if _type == "attributeList":
-            self._attributes.update(attribute_xml_to_dict(_params))
-            self._state = self.mode
-            return True
-
-        return Switch.subscription_update(self, _type, _params)
-
-    @property
-    def mode(self):
-        """Return the mode of the device."""
-        return self._attributes.get('Mode')
-
-    @property
-    def mode_string(self):
+    def mode_string(self) -> str:
         """Return the mode of the device as a string."""
         return MODE_NAMES.get(self.mode, "Unknown")
+
+    @property
+    def mode(self) -> CoffeeMakerMode:
+        """Return the mode of the device."""
+        return CoffeeMakerMode(int(self._attributes.get("Mode", _UNKNOWN)))
 
     def get_state(self, force_update: bool = False) -> int:
         """Return 0 if off and 1 if on."""
         # The base implementation using GetBinaryState doesn't work for
         # CoffeeMaker (always returns 0), so use mode instead.
-        if force_update or self._state is None:
-            self.update_attributes()
-
         # Consider the Coffee Maker to be "on" if it's currently brewing.
-        return int(self._state == CoffeeMakerMode.Brewing)
+        return int(super().get_state(force_update) == CoffeeMakerMode.Brewing)
 
     def set_state(self, state: int) -> None:
         """Set the state of this device to on or off."""
@@ -126,12 +75,4 @@ class CoffeeMaker(Switch):
         if state:
             # Coffee Maker always responds with an error if SetBinaryState is
             # called. Use SetAttributes to change the Mode to "Brewing"
-            self.deviceevent.SetAttributes(
-                attributeList=quote_xml(
-                    "<attribute><name>Mode</name><value>4</value></attribute>"
-                )
-            )
-
-        # The Coffee Maker might not be ready - so it's not safe to assume the
-        # state is what you just set, so re-read it from the device
-        self.get_state(True)
+            self._set_attributes(("Mode", CoffeeMakerMode.Brewing))

--- a/pywemo/ouimeaux_device/humidifier.py
+++ b/pywemo/ouimeaux_device/humidifier.py
@@ -2,13 +2,11 @@
 from __future__ import annotations
 
 from enum import IntEnum
-from typing import Any
+from typing import Any, Final
 
-from lxml import etree as et
+from .api.attributes import AttributeDevice
 
-from .api.service import RequiredService
-from .api.xsd_types import quote_xml
-from .switch import Switch
+_UNKNOWN: Final = -1
 
 
 # These enums were derived from Humidifier.deviceevent.GetAttributeList() and
@@ -16,7 +14,7 @@ from .switch import Switch
 class FanMode(IntEnum):
     """Enum to map WeMo FanModes to human-readable strings."""
 
-    _UNKNOWN = -1
+    _UNKNOWN = _UNKNOWN
     # pylint: disable=invalid-name
     Off = 0  # Fan and device turned off
     Minimum = 1
@@ -43,7 +41,7 @@ FAN_MODE_NAMES = {
 class DesiredHumidity(IntEnum):
     """Enum to map WeMo DesiredHumidity to human-readable strings."""
 
-    _UNKNOWN = -1
+    _UNKNOWN = _UNKNOWN
     # pylint: disable=invalid-name
     FortyFivePercent = 0
     FiftyPercent = 1
@@ -83,227 +81,118 @@ WATER_LEVEL_NAMES = {
 FILTER_LIFE_MAX = 60480
 
 
-def attribute_xml_to_dict(xml_blob):  # noqa: 901
-    """Return attribute values as a dict of key value pairs."""
-    xml_blob = "<attributes>" + xml_blob + "</attributes>"
-    xml_blob = xml_blob.replace("&gt;", ">")
-    xml_blob = xml_blob.replace("&lt;", "<")
-
-    result = {}
-
-    attributes = et.fromstring(xml_blob)
-
-    result["water_level"] = int(2)
-
-    for attribute in attributes:
-        if attribute[0].text == "FanMode":
-            try:
-                result["fan_mode"] = int(attribute[1].text)
-            except ValueError:
-                pass
-        elif attribute[0].text == "DesiredHumidity":
-            try:
-                result["desired_humidity"] = int(attribute[1].text)
-            except ValueError:
-                pass
-        elif attribute[0].text == "CurrentHumidity":
-            try:
-                result["current_humidity"] = float(attribute[1].text)
-            except ValueError:
-                pass
-        elif attribute[0].text == "NoWater" and attribute[1].text == "1":
-            try:
-                result["water_level"] = int(0)
-            except ValueError:
-                pass
-        elif attribute[0].text == "WaterAdvise" and attribute[1].text == "1":
-            try:
-                result["water_level"] = int(1)
-            except ValueError:
-                pass
-        elif attribute[0].text == "FilterLife":
-            try:
-                result["filter_life"] = float(
-                    round(
-                        (float(attribute[1].text) / float(60480)) * float(100),
-                        2,
-                    )
-                )
-            except ValueError:
-                pass
-        elif attribute[0].text == "ExpiredFilterTime":
-            try:
-                result["filter_expired"] = bool(int(attribute[1].text))
-            except ValueError:
-                pass
-
-    return result
-
-
-class Humidifier(Switch):
+class Humidifier(AttributeDevice):
     """Representation of a WeMo Humidifier device."""
 
-    def __init__(self, *args: Any, **kwargs: Any) -> None:
-        """Create a WeMo Humidifier device."""
-        Switch.__init__(self, *args, **kwargs)
-        self._attributes = {}
-        self.update_attributes()
+    _state_property = "fan_mode"  # Required by AttributeDevice.
 
     @property
-    def _required_services(self) -> list[RequiredService]:
-        return super()._required_services + [
-            RequiredService(
-                name="deviceevent", actions=["GetAttributes", "SetAttributes"]
-            ),
-        ]
-
-    def update_attributes(self):
-        """Request state from device."""
-        resp = self.deviceevent.GetAttributes().get('attributeList')
-        self._attributes = attribute_xml_to_dict(resp)
-        self._state = self.fan_mode
-
-    def subscription_update(self, _type: str, _params: str) -> bool:
-        """Handle reports from device."""
-        if _type == "attributeList":
-            self._attributes.update(attribute_xml_to_dict(_params))
-            self._state = self.fan_mode
-
-            return True
-
-        return Switch.subscription_update(self, _type, _params)
-
-    @property
-    def fan_mode(self):
+    def fan_mode(self) -> FanMode:
         """Return the FanMode setting (as an int index of the IntEnum)."""
-        return self._attributes.get('fan_mode')
+        return FanMode(int(self._attributes.get("FanMode", _UNKNOWN)))
 
     @property
-    def fan_mode_string(self):
-        """
-        Return the FanMode setting as a string.
+    def fan_mode_string(self) -> str:
+        """Return the FanMode setting as a string.
 
         (Off, Low, Medium, High, Maximum).
         """
         return FAN_MODE_NAMES.get(self.fan_mode, "Unknown")
 
     @property
-    def desired_humidity(self):
+    def desired_humidity(self) -> DesiredHumidity:
         """Return the desired humidity (as an int index of the IntEnum)."""
-        return self._attributes.get('desired_humidity')
+        return DesiredHumidity(
+            int(self._attributes.get("DesiredHumidity", _UNKNOWN))
+        )
 
     @property
-    def desired_humidity_percent(self):
+    def desired_humidity_percent(self) -> str:
         """Return the desired humidity in percent (string)."""
         return DESIRED_HUMIDITY_NAMES.get(self.desired_humidity, "Unknown")
 
     @property
-    def current_humidity_percent(self):
+    def current_humidity_percent(self) -> float:
         """Return the observed relative humidity in percent (float)."""
-        return self._attributes.get('current_humidity')
+        return float(self._attributes.get("CurrentHumidity", 0.0))
 
     @property
-    def water_level(self):
+    def water_level(self) -> WaterLevel:
         """Return 0 if water level is Empty, 1 if Low, and 2 if Good."""
-        return self._attributes.get('water_level')
+        if self._attributes.get("NoWater") == "1":
+            return WaterLevel.Empty
+        if self._attributes.get("WaterAdvise") == "1":
+            return WaterLevel.Low
+        return WaterLevel.Good
 
     @property
-    def water_level_string(self):
+    def water_level_string(self) -> str:
         """Return Empty, Low, or Good depending on the water level."""
         return WATER_LEVEL_NAMES.get(self.water_level, "Unknown")
 
     @property
-    def filter_life_percent(self):
+    def filter_life_percent(self) -> float:
         """Return the percentage (float) of filter life remaining."""
-        return self._attributes.get('filter_life')
+        filter_life = float(self._attributes.get("FilterLife", 0.0))
+        return round(filter_life / float(FILTER_LIFE_MAX) * 100.0, 2)
 
     @property
-    def filter_expired(self):
-        """Return 0 if filter is OK, and 1 if it needs to be changed."""
-        return self._attributes.get('filter_expired')
+    def filter_expired(self) -> bool:
+        """Return False if filter is OK, or True if it needs to be changed."""
+        return bool(int(self._attributes.get("ExpiredFilterTime", 0)))
 
     def get_state(self, force_update: bool = False) -> int:
         """Return 0 if off and 1 if on."""
         # The base implementation using GetBinaryState
         # doesn't work for Humidifier (always returns 0)
         # so use fan mode instead.
-        if force_update or self._state is None:
-            self.update_attributes()
-
         # Consider the Humidifier to be "on" if it's not off.
-        return int(self._state != FanMode.Off)
+        return int(super().get_state(force_update) != FanMode.Off)
 
     def set_state(self, state: int) -> None:
+        """Set the fan mode of this device.
+
+        Provided for compatibility with the Switch base class.
+
+        Args:
+          state: An int index of the FanMode IntEnum.
         """
-        Set the fan mode of this device (as int index of the FanMode IntEnum).
+        self.set_fan_mode(FanMode(state))
+
+    def set_fan_mode(self, fan_mode: FanMode) -> None:
+        """Set the fan mode of this device.
 
         Provided for compatibility with the Switch base class.
         """
-        self.set_fan_mode(state)
+        self.set_fan_mode_and_humidity(fan_mode=fan_mode)
 
-    def set_fan_mode(self, fan_mode):
-        """
-        Set the fan mode of this device (as int index of the FanMode IntEnum).
-
-        Provided for compatibility with the Switch base class.
-        """
-        # Send the attribute list to the device
-        self.deviceevent.SetAttributes(
-            attributeList=quote_xml(
-                "<attribute><name>FanMode</name><value>"
-                + str(int(fan_mode))
-                + "</value></attribute>"
-            )
-        )
-
-        # Refresh the device state
-        self.get_state(True)
-
-    def set_humidity(self, desired_humidity):
+    def set_humidity(self, desired_humidity: DesiredHumidity) -> None:
         """Set the desired humidity (as int index of the IntEnum)."""
-        # Send the attribute list to the device
-        self.deviceevent.SetAttributes(
-            attributeList=quote_xml(
-                "<attribute><name>DesiredHumidity</name><value>"
-                + str(int(desired_humidity))
-                + "</value></attribute>"
-            )
-        )
+        self.set_fan_mode_and_humidity(desired_humidity=desired_humidity)
 
-        # Refresh the device state
-        self.get_state(True)
+    def set_fan_mode_and_humidity(
+        self,
+        fan_mode: FanMode | None = None,
+        desired_humidity: DesiredHumidity | None = None,
+    ) -> None:
+        """Set the desired humidity and fan mode."""
+        args: list[tuple[str, int]] = []
 
-    def set_fan_mode_and_humidity(self, fan_mode, desired_humidity):
-        """
-        Set the desired humidity and fan mode.
+        if fan_mode is not None:
+            if FanMode(fan_mode) == _UNKNOWN:
+                raise ValueError(f"Unexpected value for fan_mode: {fan_mode}")
+            args.append(("FanMode", fan_mode))
 
-        (as int index of their respective IntEnums)
-        """
-        # Send the attribute list to the device
-        self.deviceevent.SetAttributes(
-            attributeList=quote_xml(
-                "<attribute><name>FanMode</name><value>"
-                + str(int(fan_mode))
-                + "</value></attribute>"
-                + "<attribute><name>DesiredHumidity</name><value>"
-                + str(int(desired_humidity))
-                + "</value></attribute>"
-            )
-        )
+        if desired_humidity is not None:
+            if DesiredHumidity(desired_humidity) == _UNKNOWN:
+                raise ValueError(
+                    "Unexpected value for desired_humidity: "
+                    f"{desired_humidity}"
+                )
+            args.append(("DesiredHumidity", desired_humidity))
 
-        # Refresh the device state
-        self.get_state(True)
+        self._set_attributes(*args)
 
-    def reset_filter_life(self):
+    def reset_filter_life(self) -> None:
         """Reset the filter life (call this when you install a new filter)."""
-        # Send the attribute list to the device
-        self.deviceevent.SetAttributes(
-            attributeList=quote_xml(
-                "<attribute><name>FilterLife</name><value>"
-                + str(FILTER_LIFE_MAX)
-                + "</value></attribute>"
-            )
-        )
-
-        # Refresh the device state
-        self.get_state(True)
+        self._set_attributes(("FilterLife", FILTER_LIFE_MAX))

--- a/pywemo/ouimeaux_device/humidifier.py
+++ b/pywemo/ouimeaux_device/humidifier.py
@@ -2,11 +2,11 @@
 from __future__ import annotations
 
 from enum import IntEnum
-from typing import Any, Final
+from typing import Any
 
 from .api.attributes import AttributeDevice
 
-_UNKNOWN: Final = -1
+_UNKNOWN = -1
 
 
 # These enums were derived from Humidifier.deviceevent.GetAttributeList() and

--- a/pywemo/ouimeaux_device/maker.py
+++ b/pywemo/ouimeaux_device/maker.py
@@ -1,85 +1,46 @@
 """Representation of a WeMo Maker device."""
 from __future__ import annotations
 
-from typing import Any
+import warnings
 
-from lxml import etree as et
-
+from .api.attributes import AttributeDevice
 from .api.service import RequiredService
-from .switch import Switch
 
 
-def attribute_xml_to_dict(xml_blob) -> dict[str, int]:
-    """Return attribute values as a dict of key value pairs."""
-    xml_blob = "<attributes>" + xml_blob + "</attributes>"
-    xml_blob = xml_blob.replace("&gt;", ">")
-    xml_blob = xml_blob.replace("&lt;", "<")
-
-    values = {}
-
-    attributes = et.fromstring(xml_blob)
-
-    def set_int_value(name, value):
-        try:
-            values[name] = int(value)
-        except ValueError:
-            pass
-
-    for attribute in attributes:
-        if attribute[0].text == "Switch":
-            set_int_value('switchstate', attribute[1].text)
-        elif attribute[0].text == "Sensor":
-            set_int_value('sensorstate', attribute[1].text)
-        elif attribute[0].text == "SwitchMode":
-            set_int_value('switchmode', attribute[1].text)
-        elif attribute[0].text == "SensorPresent":
-            set_int_value('hassensor', attribute[1].text)
-
-    return values
-
-
-class Maker(Switch):
+class Maker(AttributeDevice):
     """Representation of a WeMo Maker device."""
 
-    def __init__(self, *args: Any, **kwargs: Any) -> None:
-        """Create a WeMo Switch device."""
-        super().__init__(*args, **kwargs)
-        self.maker_params = {}
-        self.get_state(force_update=True)
+    _state_property = "switch_state"  # Required by AttributeDevice.
+
+    @property
+    def maker_params(self) -> dict[str, int]:
+        """Legacy maker_params value."""
+        warnings.warn(
+            "maker_params is deprecated and will be removed in a future "
+            "release. Use the properties on the Maker instance instead.",
+            DeprecationWarning,
+        )
+        return {
+            "switchstate": self.switch_state,
+            "sensorstate": self.sensor_state,
+            "switchmode": self.switch_mode,
+            "hassensor": self.has_sensor,
+        }
 
     @property
     def _required_services(self) -> list[RequiredService]:
         return super()._required_services + [
             RequiredService(name="basicevent", actions=["SetBinaryState"]),
-            RequiredService(
-                name="deviceevent", actions=["GetAttributes", "SetAttributes"]
-            ),
         ]
 
-    def update_maker_params(self):
+    def update_maker_params(self) -> None:
         """Get and parse the device attributes."""
-        maker_resp = self.deviceevent.GetAttributes().get('attributeList')
-        self.maker_params = attribute_xml_to_dict(maker_resp)
-        self._state = self.switch_state
-
-    def subscription_update(self, _type: str, _params: str) -> bool:
-        """Handle reports from device."""
-        if _type == "attributeList":
-            self.maker_params.update(attribute_xml_to_dict(_params))
-            self._state = self.switch_state
-            return True
-
-        return super().subscription_update(_type, _params)
-
-    def get_state(self, force_update: bool = False) -> int:
-        """Return 0 if off and 1 if on."""
-        # The base implementation using GetBinaryState doesn't work for the
-        # Maker (always returns 0), so pull the switch state from the
-        # attributes instead
-        if force_update or self._state is None:
-            self.update_maker_params()
-
-        return self.switch_state
+        warnings.warn(
+            "update_maker_params is deprecated and will be removed in a "
+            "future release. Use update_attributes instead.",
+            DeprecationWarning,
+        )
+        self.update_attributes()
 
     def set_state(self, state: int) -> None:
         """Set the state of this device to on or off."""
@@ -91,19 +52,19 @@ class Maker(Switch):
     @property
     def switch_state(self) -> int:
         """Return the state of the switch."""
-        return self.maker_params['switchstate']
+        return int(self._attributes["Switch"])
 
     @property
     def sensor_state(self) -> int:
         """Return the state of the sensor."""
-        return self.maker_params['sensorstate']
+        return int(self._attributes["Sensor"])
 
     @property
     def switch_mode(self) -> int:
         """Return the switch mode of the sensor."""
-        return self.maker_params['switchmode']
+        return int(self._attributes["SwitchMode"])
 
     @property
     def has_sensor(self) -> int:
         """Return whether the device has a sensor."""
-        return self.maker_params['hassensor']
+        return int(self._attributes["SensorPresent"])

--- a/tests/ouimeaux_device/test_humidifier.py
+++ b/tests/ouimeaux_device/test_humidifier.py
@@ -57,6 +57,12 @@ def test_set_fan_mode_and_humidity(humidifier):
 
     assert humidifier.get_state() == 1
 
+    with pytest.raises(ValueError):
+        humidifier.set_fan_mode_and_humidity(fan_mode=99)
+
+    with pytest.raises(ValueError):
+        humidifier.set_fan_mode_and_humidity(desired_humidity=99)
+
 
 @pytest.mark.vcr()
 def test_reset_filter_life(humidifier):

--- a/tests/ouimeaux_device/test_maker.py
+++ b/tests/ouimeaux_device/test_maker.py
@@ -1,7 +1,5 @@
 """Integration tests for WeMo Switch devices."""
 
-import unittest
-
 import pytest
 
 from pywemo import Maker
@@ -21,15 +19,6 @@ class Test_Maker:
         assert maker.get_state(force_update=True) == 0
 
     def test_maker_params(self, maker):
-        expected_params = {
-            'hassensor': 1,
-            'sensorstate': 1,
-            'switchmode': 1,
-            'switchstate': 0,
-        }
-        unittest.TestCase().assertDictEqual(
-            maker.maker_params, expected_params
-        )
         assert maker.switch_state == 0
         assert maker.sensor_state == 1
         assert maker.switch_mode == 1
@@ -44,7 +33,7 @@ class Test_Maker:
         assert maker.subscription_update("", "") is False
 
     @pytest.mark.parametrize(
-        "update,expected_params",
+        "update,has_sensor,sensor_state,switch_mode,switch_state",
         [
             # Sensor/sensorstate
             (
@@ -52,12 +41,10 @@ class Test_Maker:
                     '<attribute><name>Sensor</name><value>0</value>'
                     '<prevalue>1</prevalue><ts>1627869840</ts></attribute>'
                 ),
-                {
-                    'hassensor': 1,
-                    'sensorstate': 0,
-                    'switchmode': 1,
-                    'switchstate': 0,
-                },
+                1,
+                0,
+                1,
+                0,
             ),
             # Switch/switchstate
             (
@@ -65,12 +52,10 @@ class Test_Maker:
                     '<attribute><name>Switch</name><value>1</value>'
                     '<prevalue>1</prevalue><ts>1627869840</ts></attribute>'
                 ),
-                {
-                    'hassensor': 1,
-                    'sensorstate': 1,
-                    'switchmode': 1,
-                    'switchstate': 1,
-                },
+                1,
+                1,
+                1,
+                1,
             ),
             # SwitchMode/switchmode
             (
@@ -78,12 +63,10 @@ class Test_Maker:
                     '<attribute><name>SwitchMode</name><value>0</value>'
                     '<prevalue>1</prevalue><ts>1627869840</ts></attribute>'
                 ),
-                {
-                    'hassensor': 1,
-                    'sensorstate': 1,
-                    'switchmode': 0,
-                    'switchstate': 0,
-                },
+                1,
+                1,
+                0,
+                0,
             ),
             # SensorPresent/hassensor
             (
@@ -91,12 +74,10 @@ class Test_Maker:
                     '<attribute><name>SensorPresent</name><value>0</value>'
                     '<prevalue>1</prevalue><ts>1627869840</ts></attribute>'
                 ),
-                {
-                    'hassensor': 0,
-                    'sensorstate': 1,
-                    'switchmode': 1,
-                    'switchstate': 0,
-                },
+                0,
+                1,
+                1,
+                0,
             ),
             # Invalid state value.
             (
@@ -104,12 +85,10 @@ class Test_Maker:
                     '<attribute><name>SensorPresent</name><value>ABC</value>'
                     '<prevalue>1</prevalue><ts>1627869840</ts></attribute>'
                 ),
-                {
-                    'hassensor': 1,
-                    'sensorstate': 1,
-                    'switchmode': 1,
-                    'switchstate': 0,
-                },
+                1,
+                1,
+                1,
+                0,
             ),
             # Unexpected State name
             (
@@ -117,22 +96,29 @@ class Test_Maker:
                     '<attribute><name>Unexpected</name><value>ABC</value>'
                     '<prevalue>1</prevalue><ts>1627869840</ts></attribute>'
                 ),
-                {
-                    'hassensor': 1,
-                    'sensorstate': 1,
-                    'switchmode': 1,
-                    'switchstate': 0,
-                },
+                1,
+                1,
+                1,
+                0,
             ),
         ],
     )
-    def test_subscription_update(self, update, expected_params, maker):
+    def test_subscription_update(
+        self,
+        update,
+        has_sensor,
+        sensor_state,
+        switch_mode,
+        switch_state,
+        maker,
+    ):
         """Test that subscription updates happen as expected."""
         updated = maker.subscription_update('attributeList', update)
         assert updated is True
-        unittest.TestCase().assertDictEqual(
-            maker.maker_params, expected_params
-        )
+        assert maker.has_sensor == has_sensor
+        assert maker.sensor_state == sensor_state
+        assert maker.switch_mode == switch_mode
+        assert maker.switch_state == switch_state
 
     @pytest.fixture
     def maker(self, vcr):


### PR DESCRIPTION
## Description:

The CoffeeMaker, Humidifier, and Maker devices all operate similarly. They use they use deviceevent.GetAttributes/SetAttributes to exchange XML-based attributes with the device. The subscription events also work similarly between all three devices.

This PR creates a common base class and moves shared logic from the device classes to the base.

**Related issue (if applicable):** #315 

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] There is no commented out code in this PR.
  - [x] I have read and agree to the [CONTRIBUTING document](
        https://github.com/pavoni/pywemo/blob/master/CONTRIBUTING.md).