### PR TITLE
Fetch current state in CrockPot.__init__

### DIFF
--- a/pywemo/ouimeaux_device/crockpot.py
+++ b/pywemo/ouimeaux_device/crockpot.py
@@ -41,6 +41,7 @@ class CrockPot(Switch):
         """Create a WeMo CrockPot device."""
         Switch.__init__(self, *args, **kwargs)
         self._attributes = {}
+        self.get_state(True)
 
     @property
     def _required_services(self) -> list[RequiredService]:


### PR DESCRIPTION
## Description:

Fetch the current state of the CrockPot when creating an instance of the class.

The `set_state` method requires that the `time` attribute already be set before it is called.

## Checklist:
  - [ ] The code change is tested and works locally.
  - [x] There is no commented out code in this PR.
  - [x] I have read and agree to the [CONTRIBUTING document](
        https://github.com/pavoni/pywemo/blob/master/CONTRIBUTING.md).