### PR TITLE
Fix UPNPEntry.expires return type

### DIFF
--- a/pywemo/ssdp.py
+++ b/pywemo/ssdp.py
@@ -169,7 +169,7 @@ class UPNPEntry:
         return self._created
 
     @property
-    def expires(self) -> datetime:
+    def expires(self) -> datetime | None:
         """Return timestamp for when this entry expires."""
         warnings.warn(
             "pywemo.ssdp.UPNPEntry.expires is unused within pywemo and "


### PR DESCRIPTION
## Description:

The `UPNPEntry.expires` datetime return value is optional. It will return `None` for entries that did not have an expires header.

**Related issue (if applicable):** #315

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] There is no commented out code in this PR.
  - [x] I have read and agree to the [CONTRIBUTING document](
        https://github.com/pavoni/pywemo/blob/master/CONTRIBUTING.md).