### PR TITLE
Enable mypy checks in pyWeMo

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -42,6 +42,13 @@ repos:
         types: [python]
         exclude: tests/
 
+      - id: mypy
+        name: mypy
+        language: system
+        entry: poetry run mypy
+        require_serial: true
+        types: [python]
+
       - id: rstcheck
         name: rstcheck
         language: system

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -53,6 +53,10 @@ echo "===Lint with pylint==="
 pylint pywemo scripts
 
 echo
+echo "===Lint with mypy==="
+mypy .
+
+echo
 echo "===Test with pytest and coverage==="
 coverage run -m pytest --vcr-record=none
 coverage report --skip-covered


### PR DESCRIPTION
## Description:

Enable mypy type checking in pyWeMo.

- Checks will happen inside the 'Build and test' workflow actions that run when a PR is created.
- Checks will happen in the pre-commit git hook in local repositories.

**Related issue (if applicable):** #315

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] There is no commented out code in this PR.
  - [x] I have read and agree to the [CONTRIBUTING document](
        https://github.com/pavoni/pywemo/blob/master/CONTRIBUTING.md).