### PR TITLE
Insight is not subscribed when off

### DIFF
--- a/pywemo/subscribe.py
+++ b/pywemo/subscribe.py
@@ -80,7 +80,7 @@ class Subscription:
     # Has a notification event been received for this subscription?
     event_received: bool = False
 
-    # Subscription Identifer (SID) used to maintain/refresh the subscription.
+    # Subscription Identifier (SID) used to maintain/refresh the subscription.
     # `None` when the subscription is not active.
     subscription_id: str | None = None
 

--- a/tests/test_subscribe.py
+++ b/tests/test_subscribe.py
@@ -346,11 +346,14 @@ class Test_SubscriptionRegistry:
         assert insight.time == pytest.approx(time.time() + 225, abs=2)
         assert insight.action == subscription_registry._resubscribe
 
+        device._state = 1
         assert subscription_registry.is_subscribed(device) is False
         subscription_registry.event(device, '', '', path='/sub/insight')
         assert subscription_registry.is_subscribed(device) is False
         subscription_registry.event(device, '', '', path='/sub/basicevent')
         assert subscription_registry.is_subscribed(device) is True
+        device._state = 0
+        assert subscription_registry.is_subscribed(device) is False
         subscription_registry.event(device, '', '', path='invalid_path')
 
         assert subscription_registry.devices['192.168.1.100'] == device


### PR DESCRIPTION
## Description:

When the Insight device is off, it stops reporting subscription updates for the Insight subscription. This makes the power reading, standby_state, and "today" energy readings maintain their state until the device is turned on again. If the device is off:

1. current_power_watts should be 0
2. standby_state should be OFF
3. today_kwh should reset at midnight.

But none of this happens because no updates are received on the Insight subscription.

I fixed this downstream in Home Assistant, but am now thinking it would have been more appropriate to fix here instead.

**Related issues:** 
- https://github.com/home-assistant/core/issues/54113
- https://github.com/home-assistant/core/pull/55348

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] There is no commented out code in this PR.
  - [x] I have read and agree to the [CONTRIBUTING document](
        https://github.com/pavoni/pywemo/blob/master/CONTRIBUTING.md).