### PR TITLE
Maintain subscription SID through request exceptions

### DIFF
--- a/pywemo/subscribe.py
+++ b/pywemo/subscribe.py
@@ -173,14 +173,13 @@ class Subscription:
         subscription. Does nothing if there is no subscription.
         """
         if self.subscription_id:
-            subscription_id = self.subscription_id
-            self.subscription_id = None
             requests.request(
                 method='UNSUBSCRIBE',
                 url=self.url,
-                headers={'SID': subscription_id},
+                headers={'SID': self.subscription_id},
                 timeout=REQUESTS_TIMEOUT,
             )
+            self.subscription_id = None
 
     def _update_subscription(self, headers: MutableMapping[str, str]) -> int:
         """Update UPnP subscription parameters from SUBSCRIBE response headers.
@@ -207,7 +206,6 @@ class Subscription:
         """
         self.event_received = False
         self.expiration_time = 0.0
-        self.subscription_id = None
 
     @property
     def url(self) -> str:


### PR DESCRIPTION
## Description:

A `requests` exception that occurs while maintaining a subscription should not cause the subscription id (SID) to be reset, as it is unknown if the device still has the subscription active. If the device has forgotten/lost the subscription, it will return a HTTP `412` error code (Precondition Failed). Only then should the SID be cleared, as only then is it known that the device is no longer keeping state for the old subscription.

This PR aims to resolve a potential issue whereby pyWeMo registers for multiple subscriptions with the device. Prior to this PR each requests exception would cause a new subscription to be created between pyWeMo and the device. For devices with poor WiFi signal strength it's possible that this could cause a new subscription to be generated each time the `maintain` method is called.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] There is no commented out code in this PR.
  - [x] I have read and agree to the [CONTRIBUTING document](
        https://github.com/pavoni/pywemo/blob/master/CONTRIBUTING.md).