### PR TITLE
Update insight_params when the state is changed

### DIFF
--- a/pywemo/ouimeaux_device/insight.py
+++ b/pywemo/ouimeaux_device/insight.py
@@ -126,6 +126,11 @@ class Insight(Switch):
 
         return super().get_state(force_update)
 
+    def set_state(self, state: int) -> None:
+        """Set the state of this device to on or off."""
+        super().set_state(state)
+        self.get_state(force_update=True)  # Refresh the insight params.
+
     @property
     def today_kwh(self) -> float:
         """Return the number of kWh consumed today."""

--- a/tests/ouimeaux_device/test_insight.py
+++ b/tests/ouimeaux_device/test_insight.py
@@ -21,13 +21,15 @@ class Test_Insight:
     def test_turn_on(self, insight):
         """Turn on the insight switch."""
         insight.on()
-        assert insight.get_state(force_update=True) == 8
+        assert insight.get_state() == 8
+        assert insight.standby_state == StandbyState.STANDBY
 
     @pytest.mark.vcr()
     def test_turn_off(self, insight):
         """Turn off the insight switch."""
         insight.off()
-        assert insight.get_state(force_update=True) == 0
+        assert insight.get_state() == 0
+        assert insight.standby_state == StandbyState.OFF
 
     @pytest.mark.vcr()
     def test_insight_params(self, insight):


### PR DESCRIPTION
## Description:

Ensure the Insight device parameters are kept in sync with the device state. Turning the device on/off should also update the current sensors, for example.

Thanks for the suggestion @u8915055.

**Related issue (if applicable):** https://github.com/home-assistant/core/issues/63704

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] There is no commented out code in this PR.
  - [x] I have read and agree to the [CONTRIBUTING document](
        https://github.com/pavoni/pywemo/blob/master/CONTRIBUTING.md).