### PR TITLE
V2 Dimmers do not send brightness events

### DIFF
--- a/pywemo/__init__.py
+++ b/pywemo/__init__.py
@@ -15,7 +15,7 @@ from .ouimeaux_device.bridge import Group as BridgeGroup
 from .ouimeaux_device.bridge import Light as BridgeLight
 from .ouimeaux_device.coffeemaker import CoffeeMaker, CoffeeMakerMode
 from .ouimeaux_device.crockpot import CrockPot, CrockPotMode
-from .ouimeaux_device.dimmer import Dimmer, DimmerLongPress
+from .ouimeaux_device.dimmer import Dimmer, DimmerLongPress, DimmerV2
 from .ouimeaux_device.humidifier import (
     DesiredHumidity,
     FanMode,

--- a/pywemo/discovery.py
+++ b/pywemo/discovery.py
@@ -21,7 +21,7 @@ from .ouimeaux_device.api.xsd_types import DeviceDescription
 from .ouimeaux_device.bridge import Bridge
 from .ouimeaux_device.coffeemaker import CoffeeMaker
 from .ouimeaux_device.crockpot import CrockPot
-from .ouimeaux_device.dimmer import Dimmer, DimmerLongPress
+from .ouimeaux_device.dimmer import Dimmer, DimmerLongPress, DimmerV2
 from .ouimeaux_device.humidifier import Humidifier
 from .ouimeaux_device.insight import Insight
 from .ouimeaux_device.lightswitch import LightSwitch, LightSwitchLongPress
@@ -97,6 +97,8 @@ def device_from_uuid_and_location(  # noqa: C901
             return LightSwitch(location)
         if uuid.startswith('uuid:Dimmer-1_0'):
             return DimmerLongPress(location)
+        if uuid.startswith('uuid:Dimmer-2_0'):
+            return DimmerV2(location)
         if uuid.startswith('uuid:Dimmer'):
             return Dimmer(location)
         if uuid.startswith('uuid:Insight'):

--- a/pywemo/ouimeaux_device/dimmer.py
+++ b/pywemo/ouimeaux_device/dimmer.py
@@ -71,3 +71,7 @@ class Dimmer(Switch):
 
 class DimmerLongPress(Dimmer, LongPressMixin):
     """WeMo Dimmer device that supports long press."""
+
+
+class DimmerV2(Dimmer):
+    """WeMo Dimmer version 2."""

--- a/pywemo/subscribe.py
+++ b/pywemo/subscribe.py
@@ -17,6 +17,7 @@ from .exceptions import SubscriptionRegistryFailed
 from .ouimeaux_device import Device
 from .ouimeaux_device.api.long_press import VIRTUAL_DEVICE_UDN
 from .ouimeaux_device.api.service import REQUESTS_TIMEOUT
+from .ouimeaux_device.dimmer import DimmerV2
 from .ouimeaux_device.insight import Insight
 from .util import get_ip_address
 
@@ -567,6 +568,11 @@ class SubscriptionRegistry:
             # Insight subscription updates. This causes problems for the
             # "today" energy properties on the device, which should reset at
             # midnight but don't because subscription updates have stopped.
+            return False
+        if isinstance(device, DimmerV2) and device.get_state() == 1:
+            # Special case: The V2 (RTOS) Dimmers do not send subscription
+            # updates for brightness changes. Return False so clients know
+            # polling is required to update the device brightness.
             return False
         subscriptions = self._subscriptions.get(device, [])
         return len(subscriptions) > 0 and all(

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -12,11 +12,12 @@ from pywemo import discovery, exceptions, ssdp
     [
         ("uuid:Socket-1_0-SERIALNUMBER", discovery.Switch),
         ("uuid:Lightswitch-1_0-SERIALNUMBER", discovery.LightSwitchLongPress),
-        ("uuid:Lightswitch-3_0-SERIALNUMBER", discovery.LightSwitchLongPress),
+        ("uuid:Lightswitch-2_0-SERIALNUMBER", discovery.LightSwitchLongPress),
         ("uuid:Lightswitch-3_0-SERIALNUMBER", discovery.LightSwitchLongPress),
         ("uuid:Lightswitch-9_0-SERIALNUMBER", discovery.LightSwitch),
         ("uuid:Dimmer-1_0-SERIALNUMBER", discovery.DimmerLongPress),
         ("uuid:Dimmer-2_0-SERIALNUMBER", discovery.DimmerV2),
+        ("uuid:Dimmer-9_0-SERIALNUMBER", discovery.Dimmer),
         ("uuid:Insight-1_0-SERIALNUMBER", discovery.Insight),
         ("uuid:Sensor-1_0-SERIALNUMBER", discovery.Motion),
         ("uuid:Maker-1_0-SERIALNUMBER", discovery.Maker),

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -16,7 +16,7 @@ from pywemo import discovery, exceptions, ssdp
         ("uuid:Lightswitch-3_0-SERIALNUMBER", discovery.LightSwitchLongPress),
         ("uuid:Lightswitch-9_0-SERIALNUMBER", discovery.LightSwitch),
         ("uuid:Dimmer-1_0-SERIALNUMBER", discovery.DimmerLongPress),
-        ("uuid:Dimmer-2_0-SERIALNUMBER", discovery.Dimmer),
+        ("uuid:Dimmer-2_0-SERIALNUMBER", discovery.DimmerV2),
         ("uuid:Insight-1_0-SERIALNUMBER", discovery.Insight),
         ("uuid:Sensor-1_0-SERIALNUMBER", discovery.Motion),
         ("uuid:Maker-1_0-SERIALNUMBER", discovery.Maker),

--- a/tests/vcr/tests.ouimeaux_device.test_dimmer/Test_PVT_RTOS_Dimmer_v2.test_is_subscribed.yaml
+++ b/tests/vcr/tests.ouimeaux_device.test_dimmer/Test_PVT_RTOS_Dimmer_v2.test_is_subscribed.yaml
@@ -1,0 +1,42 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CALLBACK:
+      - <http://192.168.1.1:8989/sub/basicevent>
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      NT:
+      - upnp:event
+      TIMEOUT:
+      - Second-300
+      User-Agent:
+      - python-requests/2.26.0
+    method: SUBSCRIBE
+    uri: http://192.168.1.100:49153/upnp/event/basicevent1
+  response:
+    body:
+      string: ''
+    headers:
+      CONTENT-LENGTH:
+      - '0'
+      DATE:
+      - Mon, 04 Apr 2022 03:32:29
+      SERVER:
+      - Unspecified, UPnP/1.0, Unspecified
+      SID:
+      - uuid:22950699-df04-49a3-a15d-b2517fc84183
+      TIMEOUT:
+      - Second-1801
+      X-User-Agent:
+      - redsonic
+    status:
+      code: 200
+      message: OK
+version: 1


### PR DESCRIPTION
## Description:

The version 2 (RTOS) dimmers do not send subscription events for changes in brightness. To get around this issue clients should poll the device. This PR adjusts the is_subscribed method to return False for these dimmers so that clients are aware of the need to poll.

I've modified is_subscribed to return False only when the device is turned On. That avoids needing the additional polling network traffic when the device is Off.

**Related issue (if applicable):** https://github.com/home-assistant/core/issues/68582

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] There is no commented out code in this PR.
  - [x] I have read and agree to the [CONTRIBUTING document](
        https://github.com/pavoni/pywemo/blob/master/CONTRIBUTING.md).