### PR TITLE
Add configuration to enable callbacks in containers.

### DIFF
--- a/pywemo/util.py
+++ b/pywemo/util.py
@@ -1,6 +1,7 @@
 """Miscellaneous utility functions."""
 from __future__ import annotations
 
+import os
 import socket
 import warnings
 from collections import defaultdict
@@ -69,12 +70,16 @@ def interface_addresses() -> list[str]:
     return addresses
 
 
-def get_ip_address(host: str = '1.2.3.4') -> str | None:
-    """Return IP from hostname or IP."""
+def get_callback_address(host: str, port: int) -> str | None:
+    """Return IP address & port used by devices to send event notifications."""
+    pywemo_callback_address = os.getenv('PYWEMO_CALLBACK_ADDRESS')
+    if pywemo_callback_address is not None:
+        return pywemo_callback_address
+
     sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
     try:
         sock.connect((host, 9))
-        return cast(str, sock.getsockname()[0])
+        return f'{cast(str, sock.getsockname()[0])}:{port}'
     except OSError:
         return None
     finally:

--- a/tests/test_subscribe.py
+++ b/tests/test_subscribe.py
@@ -179,9 +179,11 @@ class Test_Subscription:
     http_port = 8989
 
     @pytest.fixture(autouse=True)
-    def get_ip_address(self):
-        with mock.patch('pywemo.subscribe.get_ip_address') as mock_ip_address:
-            mock_ip_address.return_value = '192.168.1.1'
+    def get_callback_address(self):
+        with mock.patch(
+            'pywemo.subscribe.get_callback_address'
+        ) as mock_ip_address:
+            mock_ip_address.return_value = f'192.168.1.1:{self.http_port}'
             yield mock_ip_address
 
     @pytest.fixture(


### PR DESCRIPTION
## Description:

I run home assistant in a container without using host networking.  As a result, when pyWeMo subscribes for callbacks, it provides the IP address of the container.  Obviously the wemo device can't access this address, so push notifications are not received.

This PR reads two environment variables that can be used to allow callbacks to work in containers that do not use host networking:

 * `PYWEMO_HTTP_SERVER_PORT` is used to specify the port on which the HTTP server should be started.  If this variable has a value, only that port will be tried.  Although it's extremely likely that port 8989 will be available within a container, this provides a mechanism to ensure that you know which container port to bind to when starting the container.
 * `PYWEMO_CALLBACK_ADDRESS` is used to specify the IP and port that should be provided to the wemo device for callbacks.  This can be set to the host machine's IP address and the port on which its listening.

I did consider adding these values as optional constructor parameters to the `SubscriptionRegistry`.  If I had went down that path, it would have meant that any application that wants to allow pyWeMo to be used in a container would have to provide a way of configuring these values.  By using environment variables, application authors don't have to worry about any of this configuration, and the onus is put on the person starting the container.  Please let me know if you think the constructor approach is more appropriate and I'm happy to go down that path.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] There is no commented out code in this PR.
  - [x] I have read and agree to the [CONTRIBUTING document](
        https://github.com/pavoni/pywemo/blob/master/CONTRIBUTING.md).