### PR TITLE
[Bug] _attributes needs to be created per-instance.

### DIFF
--- a/pywemo/ouimeaux_device/api/attributes.py
+++ b/pywemo/ouimeaux_device/api/attributes.py
@@ -30,12 +30,12 @@ class AttributeDevice(Switch):
 
     EVENT_TYPE_ATTRIBUTE_LIST = "attributeList"
 
-    _attributes: dict[str, str] = {}
     _state_property: str
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         """Create a Attributes device."""
         assert isinstance(self._state_property, str)
+        self._attributes: dict[str, str] = {}
         super().__init__(*args, **kwargs)
         self.update_attributes()
 

--- a/pywemo/ouimeaux_device/crockpot.py
+++ b/pywemo/ouimeaux_device/crockpot.py
@@ -43,11 +43,10 @@ class CrockPot(Switch):
     EVENT_TYPE_MODE = "mode"
     EVENT_TYPE_TIME = "time"
 
-    _attributes: dict[str, str] = {}
-
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         """Create a WeMo CrockPot device."""
         super().__init__(*args, **kwargs)
+        self._attributes: dict[str, str] = {}
         self.get_state(True)
 
     @property


### PR DESCRIPTION
## Description:

The `_attributes` field of AttributeDevice needs to be created per instance and not shared across instances.

**Related issue (if applicable):** https://github.com/home-assistant/core/issues/73066

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] There is no commented out code in this PR.
  - [x] I have read and agree to the [CONTRIBUTING document](
        https://github.com/pavoni/pywemo/blob/master/CONTRIBUTING.md).