### PR TITLE
Always use a setup timeout of 20 seconds or greater

### DIFF
--- a/pywemo/ouimeaux_device/__init__.py
+++ b/pywemo/ouimeaux_device/__init__.py
@@ -489,7 +489,7 @@ class Device(DeviceDescription, RequiredServicesMixin, WeMoServiceTypesMixin):
         """
         # a timeout of less than 20 is too short for many devices, so require
         # at least 20 seconds.
-        timeout = min(timeout, 15.0)
+        timeout = max(timeout, 20.0)
         status_delay = min(status_delay, timeout / 2.0)
         connection_attempts = int(max(1, connection_attempts))
 

--- a/tests/ouimeaux_device/test_device.py
+++ b/tests/ouimeaux_device/test_device.py
@@ -208,7 +208,7 @@ def device(mock_get):
 def lightspeed():
     """Skip sleeps in the code and auto-increment time.time calls."""
     with mock.patch('time.sleep', return_value=None), mock.patch(
-        'time.time', side_effect=itertools.count(0, 15)
+        'time.time', side_effect=itertools.count(0, 20)
     ):
         yield
 


### PR DESCRIPTION
## Description:

Allows the setup for timeout to be greater than 15 seconds.

**Related issue (if applicable):** #357

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] There is no commented out code in this PR.
  - [x] I have read and agree to the [CONTRIBUTING document](
        https://github.com/pavoni/pywemo/blob/master/CONTRIBUTING.md).