### PR TITLE
Handle openssl output without Salted__ prefix

### DIFF
--- a/pywemo/ouimeaux_device/__init__.py
+++ b/pywemo/ouimeaux_device/__init__.py
@@ -387,9 +387,12 @@ class Device(DeviceDescription, RequiredServicesMixin, WeMoServiceTypesMixin):
             LOG.error('stderr:\n%s', stderr)
             raise SetupException('openssl command failed') from exc
 
-        # remove 16byte magic and salt prefix inserted by OpenSSL, which is of
-        # the form "Salted__XXXXXXXX" before the actual password
-        encrypted_password = base64.b64encode(openssl.stdout[16:]).decode()
+        output = openssl.stdout
+        if output.startswith(b'Salted__'):
+            # remove 16byte magic and salt prefix inserted by OpenSSL, which
+            # is of the form "Salted__XXXXXXXX" before the actual password
+            output = output[16:]
+        encrypted_password = base64.b64encode(output).decode()
 
         # the last 4 digits that wemo expects is xxyy, where:
         #     xx: length of the encrypted password as hexadecimal

--- a/tests/ouimeaux_device/test_device.py
+++ b/tests/ouimeaux_device/test_device.py
@@ -2,6 +2,7 @@
 
 import itertools
 import logging
+import shutil
 import unittest.mock as mock
 from subprocess import CalledProcessError
 
@@ -150,8 +151,6 @@ EMPTY_SERVICE = '''<?xml version="1.0"?>
   </actionList>
 </scpd>'''
 
-ENC_PASSWORD = b'Salted__XXXXXX12\xc0\xd4\xd4v4\xfep\rikEmk\xf8\xe0\x12'
-
 APLIST = (
     'Page:1/1/2$\n'
     'ap_aes|6|100|WPA2PSK/AES,\n'
@@ -293,25 +292,56 @@ class TestDevice:
         assert mock_run.call_count == 1
 
     @pytest.mark.parametrize(
-        'is_rtos, openssl_stdout, expected',
-        [
-            (False, ENC_PASSWORD, 'wNTUdjT+cA1pa0Vta/jgEg==1808'),
-            (False, ENC_PASSWORD[16:], 'wNTUdjT+cA1pa0Vta/jgEg==1808'),
-            (True, ENC_PASSWORD, 'wNTUdjT+cA1pa0Vta/jgEg=='),
-            (True, ENC_PASSWORD[16:], 'wNTUdjT+cA1pa0Vta/jgEg=='),
-        ],
+        'is_rtos, is_salted_prefix',
+        [(False, True), (False, False), (True, True), (True, False)],
     )
     @mock.patch('subprocess.run')
     def test_encryption_successful(
-        self, mock_run, is_rtos, openssl_stdout, expected, device
+        self, mock_run, is_rtos, is_salted_prefix, device
     ):
         """Test device encryption (good result)."""
-        mock_run.return_value = mock.Mock(stdout=openssl_stdout)
+        salt = '5858585858583132'
+        iv = '58585858585831323334353641313233'
+        password = 'pass:XXXXXX123456A1234567XXXXXX' + (
+            'b3{8t;80dIN{ra83eC1s?M70?683@2Yf' if is_rtos else ''
+        )
+        stdout = {
+            False: b'I\x08\xfb\x9fh\x80\t\xd1\x99\x9cskl\xb3;\xdb',
+            True: b'\xc7\xf7\x9f\xd7 \x8dL\xe3nS\xe6S\xdd\xce$\x02',
+        }
+        expected = {
+            False: 'SQj7n2iACdGZnHNrbLM72w==1808',
+            True: 'x/ef1yCNTONuU+ZT3c4kAg==',
+        }
+
+        def check_args(args, **kwargs):
+            assert args[args.index('-S') + 1] == salt
+            assert args[args.index('-iv') + 1] == iv
+            assert args[args.index('-pass') + 1] == password
+            prefix = b'Salted__XXXXXX12' if is_salted_prefix else b''
+            return mock.Mock(stdout=prefix + stdout[is_rtos])
+
+        mock_run.side_effect = check_args
         assert (
             device.encrypt_aes128('password', self.METAINFO, is_rtos)
-            == expected
+            == expected[is_rtos]
         )
         assert mock_run.call_count == 1
+
+    @pytest.mark.parametrize(
+        'is_rtos, expected',
+        [
+            (False, 'SQj7n2iACdGZnHNrbLM72w==1808'),
+            (True, 'x/ef1yCNTONuU+ZT3c4kAg=='),
+        ],
+    )
+    @pytest.mark.skipif(
+        not shutil.which('openssl'), reason='The openssl binary was not found'
+    )
+    def test_encryption_with_openssl(self, is_rtos, expected, device):
+        """Test encryption using the OpenSSL binary (if it exists)."""
+        actual = device.encrypt_aes128('password', self.METAINFO, is_rtos)
+        assert expected == actual
 
     def test_setup_unknown_service(self, device):
         """Test device setup (WiFiSetup service not available)."""


### PR DESCRIPTION
## Description:

The version of openssl shipped with Ubuntu 22.04 does not add the `Salted__XXXXXXXX` prefix.

**Related issue (if applicable):** 
- fixes #357 
- fixes #358

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] There is no commented out code in this PR.
  - [x] I have read and agree to the [CONTRIBUTING document](
        https://github.com/pavoni/pywemo/blob/master/CONTRIBUTING.md).