### PR TITLE
Use PyPI publish action in publish workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
     - main
+  workflow_call:
 jobs:
   build:
     name: Build and test
@@ -31,6 +32,12 @@ jobs:
           path-to-lcov: coverage.lcov
           flag-name: run-${{ join(matrix.*, '-') }}
           parallel: true
+      - name: Archive build files
+        uses: actions/upload-artifact@v3
+        with:
+          name: dist-files-${{ matrix.python-version }}
+          path: dist
+          retention-days: 3
   coveralls:
     name: Indicate completion to coveralls.io
     needs: build

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,27 +3,68 @@ on:
   release:
     types: [created]
 jobs:
-  deploy:
-    name: Build, test, and deploy to PyPI
+  build:
+    name: Build
+    uses: ./.github/workflows/build.yml
+
+  check:
+    name: Check version and tag match
     runs-on: ubuntu-latest
+    needs: build
+    outputs:
+      version: ${{ steps.outputs.outputs.version }}
+      artifact: ${{ steps.outputs.outputs.artifact }}
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v3
-      - name: Set up Python 3.11
-        uses: actions/setup-python@v4
-        with:
-          python-version: '3.11'
-      - name: Build
-        run: ./scripts/build.sh
-      - name: Generate coverage
+      - name: Set Outputs
+        id: outputs
         run: |
-          . .venv/bin/activate
-          coverage lcov
-      - name: Report Coveralls
-        uses: coverallsapp/github-action@v2
+          echo "artifact=dist-files-3.10" | tee -a "$GITHUB_OUTPUT"
+          echo "version=$GITHUB_REF_NAME" | tee -a "$GITHUB_OUTPUT"
+      - name: Download build artifacts
+        uses: actions/download-artifact@v3
         with:
-          path-to-lcov: coverage.lcov
-      - name: Publish
+          name: ${{ steps.outputs.outputs.artifact }}
+          path: dist
+      - name: Check if tag version matches project version
+        working-directory: dist
         run: |
-          . .venv/bin/activate
-          poetry publish --username __token__ --password "${{ secrets.PYPI_PASSWORD }}"
+          # Get the version from the PKG-INFO in the source package.
+          tar -xzf *.tar.gz
+          DIST_VERSION=$(sed -ne 's/^Version: \([0-9]\..*\)$/\1/p' < */PKG-INFO | head -1)
+          echo "TAG: $GITHUB_REF_NAME"
+          echo "VERSION: $DIST_VERSION"
+          if [[ "$GITHUB_REF_NAME" != "$DIST_VERSION" ]]; then exit 1; fi
+
+  assets:
+    name: Add assets to Release
+    runs-on: ubuntu-latest
+    needs: check
+    steps:
+      - name: Download build artifacts
+        uses: actions/download-artifact@v3
+        with:
+          name: ${{ needs.check.outputs.artifact }}
+          path: dist
+      - name: Generate Checksums
+        working-directory: dist
+        run: sha256sum * | tee sha256sums.txt
+      - name: Add assets to release
+        uses: softprops/action-gh-release@v1
+        with:
+          files: dist/*
+
+  pypi:
+    name: Publish to PyPI
+    runs-on: ubuntu-latest
+    needs: check
+    permissions:
+      # IMPORTANT: this permission is mandatory for trusted publishing
+      id-token: write
+    steps:
+      - name: Download build artifacts
+        uses: actions/download-artifact@v3
+        with:
+          name: ${{ needs.check.outputs.artifact }}
+          path: dist
+      - name: Publish package distributions to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -57,6 +57,7 @@ jobs:
     name: Publish to PyPI
     runs-on: ubuntu-latest
     needs: check
+    environment: release
     permissions:
       # IMPORTANT: this permission is mandatory for trusted publishing
       id-token: write

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -51,7 +51,7 @@ jobs:
         working-directory: dist
         run: sha256sum * | tee sha256sums.txt
       - name: Add assets to release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@de2c0eb89ae2a093876385947365aca7b0e5f844 # v0.1.15
         with:
           files: dist/*
 
@@ -70,4 +70,4 @@ jobs:
           name: ${{ needs.check.outputs.artifact }}
           path: dist
       - name: Publish package distributions to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@a56da0b891b3dc519c7ee3284aff1fad93cc8598 # v1.8.6

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,7 +1,7 @@
 name: Publish
 on:
   release:
-    types: [created]
+    types: [published]
 jobs:
   build:
     name: Build
@@ -35,34 +35,14 @@ jobs:
           echo "VERSION: $DIST_VERSION"
           if [[ "$GITHUB_REF_NAME" != "$DIST_VERSION" ]]; then exit 1; fi
 
-  assets:
-    name: Add assets to Release
-    runs-on: ubuntu-latest
-    needs: check
-    permissions:
-      contents: write
-    steps:
-      - name: Download build artifacts
-        uses: actions/download-artifact@v3
-        with:
-          name: ${{ needs.check.outputs.artifact }}
-          path: dist
-      - name: Generate Checksums
-        working-directory: dist
-        run: sha256sum * | tee sha256sums.txt
-      - name: Add assets to release
-        uses: softprops/action-gh-release@de2c0eb89ae2a093876385947365aca7b0e5f844 # v0.1.15
-        with:
-          files: dist/*
-
-  pypi:
-    name: Publish to PyPI
+  publish:
+    name: Publish
     runs-on: ubuntu-latest
     needs: check
     environment: release
     permissions:
-      # IMPORTANT: this permission is mandatory for trusted publishing
-      id-token: write
+      id-token: write # For Sigstore & PyPI trusted publishing
+      contents: write # For adding assets to the github release
     steps:
       - name: Download build artifacts
         uses: actions/download-artifact@v3
@@ -71,3 +51,12 @@ jobs:
           path: dist
       - name: Publish package distributions to PyPI
         uses: pypa/gh-action-pypi-publish@a56da0b891b3dc519c7ee3284aff1fad93cc8598 # v1.8.6
+      - name: Generate Checksums
+        working-directory: dist
+        run: sha256sum * | tee sha256sums.txt
+      - name: Sign the release
+        uses: sigstore/gh-action-sigstore-python@e323e1b02e26cc6600843935562c862b94200b0c # v1.2.3
+        with:
+          inputs: ./dist/*
+          release-signing-artifacts: true
+          bundle-only: true

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -39,6 +39,8 @@ jobs:
     name: Add assets to Release
     runs-on: ubuntu-latest
     needs: check
+    permissions:
+      contents: write
     steps:
       - name: Download build artifacts
         uses: actions/download-artifact@v3


### PR DESCRIPTION
## Description:

Revise the publish workflow to use [PyPI trusted publishing](https://docs.pypi.org/trusted-publishers/) instead of a secret token for uploading. I'm also revising the workflows a bit.

1. [Reuse](https://docs.github.com/en/actions/using-workflows/reusing-workflows) the build workflow as part of the publish workflow. The build workflow uploads the `dist` artifacts for other workflows to use.
2. Added a check that the release version within [pyproject.toml](https://github.com/pywemo/pywemo/blob/main/pyproject.toml) matches the git tag for the release.
3. Add the `dist` artifacts and their SHA256 checksums as assets on the release. The assets appear at the bottom of the release beside the source code download links. ![image](https://user-images.githubusercontent.com/289218/235577092-9f6dce4a-b4c0-4dca-93a0-82aed292d159.png)


## Checklist:
  - [x] The code change is tested and works locally.
  - [x] There is no commented out code in this PR.
  - [x] I have read and agree to the [CONTRIBUTING document](
        https://github.com/pavoni/pywemo/blob/master/CONTRIBUTING.md).