### PR TITLE
Report only the Python 3.10 build to coveralls

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,6 +5,10 @@ on:
     branches:
     - main
   workflow_call:
+
+permissions:
+  contents: read
+
 jobs:
   build:
     name: Build and test
@@ -26,26 +30,28 @@ jobs:
         run: |
           . .venv/bin/activate
           coverage lcov
-      - name: Report Coveralls
+      - name: Archive build files
+        if: ${{ matrix.python-version == '3.10' }}  # Just for 3.10.
+        uses: actions/upload-artifact@v3
+        with:
+          if-no-files-found: error
+          name: build-artifacts
+          path: |
+            coverage.lcov
+            dist/
+
+  coverage:
+    name: Report coverage to coveralls.io
+    runs-on: ubuntu-latest
+    needs: [build]
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+      - name: Download build artifacts
+        uses: actions/download-artifact@v3
+        with:
+          name: build-artifacts
+      - name: Report to Coveralls
         uses: coverallsapp/github-action@v2
         with:
           path-to-lcov: coverage.lcov
-          flag-name: run-${{ join(matrix.*, '-') }}
-          parallel: true
-      - name: Archive build files
-        uses: actions/upload-artifact@v3
-        with:
-          name: dist-files-${{ matrix.python-version }}
-          path: dist
-          retention-days: 3
-  coveralls:
-    name: Indicate completion to coveralls.io
-    needs: build
-    if: ${{ always() }}
-    runs-on: ubuntu-latest
-    steps:
-    - name: Coveralls Finished
-      uses: coverallsapp/github-action@v2
-      with:
-        parallel-finished: true
-        carryforward: "run-3.11"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,8 +6,7 @@ on:
     - main
   workflow_call:
 
-permissions:
-  contents: read
+permissions: {}  # No permissions needed for this workflow.
 
 jobs:
   build:
@@ -30,8 +29,8 @@ jobs:
         run: |
           . .venv/bin/activate
           coverage lcov
-      - name: Archive build files
-        if: ${{ matrix.python-version == '3.10' }}  # Just for 3.10.
+      - name: Archive build files (Python 3.10 only)
+        if: ${{ success() && matrix.python-version == '3.10' }}
         uses: actions/upload-artifact@v3
         with:
           if-no-files-found: error

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,8 +10,7 @@ jobs:
   check:
     name: Check version and tag match
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
+    permissions: {}
     needs: build
     steps:
       - name: Download build artifacts

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,21 +10,14 @@ jobs:
   check:
     name: Check version and tag match
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     needs: build
-    outputs:
-      version: ${{ steps.outputs.outputs.version }}
-      artifact: ${{ steps.outputs.outputs.artifact }}
     steps:
-      - name: Set Outputs
-        id: outputs
-        run: |
-          echo "artifact=dist-files-3.10" | tee -a "$GITHUB_OUTPUT"
-          echo "version=$GITHUB_REF_NAME" | tee -a "$GITHUB_OUTPUT"
       - name: Download build artifacts
         uses: actions/download-artifact@v3
         with:
-          name: ${{ steps.outputs.outputs.artifact }}
-          path: dist
+          name: build-artifacts
       - name: Check if tag version matches project version
         working-directory: dist
         run: |
@@ -47,8 +40,7 @@ jobs:
       - name: Download build artifacts
         uses: actions/download-artifact@v3
         with:
-          name: ${{ needs.check.outputs.artifact }}
-          path: dist
+          name: build-artifacts
       - name: Publish package distributions to PyPI
         uses: pypa/gh-action-pypi-publish@a56da0b891b3dc519c7ee3284aff1fad93cc8598 # v1.8.6
       - name: Generate Checksums


### PR DESCRIPTION
## Description:

Report only the Python 3.10 build to coveralls. This also removes unnecessary permissions from the workflows/jobs.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] There is no commented out code in this PR.
  - [x] I have read and agree to the [CONTRIBUTING document](
        https://github.com/pavoni/pywemo/blob/master/CONTRIBUTING.md).