### PR TITLE
Deprecation: Remove the mac address argument

### DIFF
--- a/pywemo/discovery.py
+++ b/pywemo/discovery.py
@@ -2,7 +2,6 @@
 from __future__ import annotations
 
 import logging
-import warnings
 from ipaddress import ip_address
 from socket import gaierror, gethostbyname
 from typing import Any, Callable
@@ -54,15 +53,9 @@ def discover_devices(debug: bool = False, **kwargs: Any) -> list[Device]:
 
 
 def device_from_description(
-    description_url: str, mac: str = 'deprecated', debug: bool = False
+    description_url: str, debug: bool = False
 ) -> Device | None:
     """Return object representing WeMo device running at host, else None."""
-    if mac != 'deprecated':
-        warnings.warn(
-            "The mac argument to device_from_description is deprecated and "
-            "will be removed in a future release.",
-            DeprecationWarning,
-        )
     try:
         xml = requests.get(description_url, timeout=REQUESTS_TIMEOUT)
     except requests.RequestException:

--- a/pywemo/ouimeaux_device/__init__.py
+++ b/pywemo/ouimeaux_device/__init__.py
@@ -107,14 +107,8 @@ class Device(DeviceDescription, RequiredServicesMixin, WeMoServiceTypesMixin):
 
     EVENT_TYPE_BINARY_STATE = "BinaryState"
 
-    def __init__(self, url: str, mac: str = 'deprecated') -> None:
+    def __init__(self, url: str) -> None:
         """Create a WeMo device."""
-        if mac != 'deprecated':
-            warnings.warn(
-                "The mac argument to Device is deprecated and will be removed "
-                "in a future release.",
-                DeprecationWarning,
-            )
         self._state: int | None = None
         self.basic_state_params: dict[str, str] = {}
         self._reconnect_lock = threading.Lock()


### PR DESCRIPTION
## Description:

The `mac` argument is being removed from `Device.__init__` and `device_from_description`.

This was announced in the version 0.8.0 release in February 2022. https://github.com/pywemo/pywemo/releases/tag/0.8.0

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] There is no commented out code in this PR.
  - [x] I have read and agree to the [CONTRIBUTING document](
        https://github.com/pywemo/pywemo/blob/master/CONTRIBUTING.md).