### PR TITLE
Deprecation: Device.serialnumber property

### DIFF
--- a/pywemo/ouimeaux_device/__init__.py
+++ b/pywemo/ouimeaux_device/__init__.py
@@ -674,16 +674,6 @@ class Device(DeviceDescription, RequiredServicesMixin, WeMoServiceTypesMixin):
         return self.session.port
 
     @property
-    def serialnumber(self) -> str:
-        """Return the serial number of the device."""
-        warnings.warn(
-            "serialnumber is deprecated and will be removed in a future "
-            "release. Use serial_number instead.",
-            DeprecationWarning,
-        )
-        return self.serial_number
-
-    @property
     def device_type(self) -> str:
         """Return what kind of WeMo this device is."""
         return type(self).__name__

--- a/pywemo/ouimeaux_device/bridge.py
+++ b/pywemo/ouimeaux_device/bridge.py
@@ -194,7 +194,7 @@ class LinkedDevice:
         self.update_state(info)
         self._last_err: dict[str, str] = {}
         self.mac = self.bridge.mac
-        self.serialnumber = self.bridge.serial_number
+        self.serial_number = self.bridge.serial_number
         self.uniqueID = ''
 
     def get_state(self, force_update: bool = False) -> DeviceState:


### PR DESCRIPTION
## Description:

The `Device.serialnumber` property will is being removed. Use `serial_number` instead.

This was announced in the version 0.8.0 release in February 2022. https://github.com/pywemo/pywemo/releases/tag/0.8.0

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] There is no commented out code in this PR.
  - [x] I have read and agree to the [CONTRIBUTING document](
        https://github.com/pywemo/pywemo/blob/master/CONTRIBUTING.md).