### PR TITLE
Generate coverage.lcov in build.sh

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,6 +24,7 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - name: Build
+        id: build
         run: ./scripts/build.sh
         env:
           OUTPUT_ENV_VAR: ${{ (matrix.python-version == '3.10' && 'GITHUB_OUTPUT') || '' }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,10 +25,6 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Build
         run: ./scripts/build.sh
-      - name: Generate coverage
-        run: |
-          . .venv/bin/activate
-          coverage lcov
       - name: Archive build files (Python 3.10 only)
         if: ${{ success() && matrix.python-version == '3.10' }}
         uses: actions/upload-artifact@v3
@@ -36,7 +32,7 @@ jobs:
           if-no-files-found: error
           name: build-artifacts
           path: |
-            coverage.lcov
+            .cache/coverage.lcov
             dist/
 
   coverage:
@@ -53,4 +49,4 @@ jobs:
       - name: Report to Coveralls
         uses: coverallsapp/github-action@v2
         with:
-          path-to-lcov: coverage.lcov
+          path-to-lcov: .cache/coverage.lcov

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,28 +25,18 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Build
         run: ./scripts/build.sh
-      - name: Archive build files (Python 3.10 only)
-        if: ${{ success() && matrix.python-version == '3.10' }}
+        env:
+          OUTPUT_ENV_VAR: ${{ (matrix.python-version == '3.10' && 'GITHUB_OUTPUT') || '' }}
+      # The next two steps only run if OUTPUT_ENV_VAR (above) has a value.
+      - name: Archive build artifacts
+        if: ${{ success() && steps.build.outputs.version }}
         uses: actions/upload-artifact@v3
         with:
           if-no-files-found: error
-          name: build-artifacts
-          path: |
-            .cache/coverage.lcov
-            dist/
-
-  coverage:
-    name: Report coverage to coveralls.io
-    runs-on: ubuntu-latest
-    needs: [build]
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v3
-      - name: Download build artifacts
-        uses: actions/download-artifact@v3
-        with:
-          name: build-artifacts
+          name: dist
+          path: dist/
       - name: Report to Coveralls
+        if: ${{ success() && steps.build.outputs.coverage-lcov }}
         uses: coverallsapp/github-action@v2
         with:
-          path-to-lcov: .cache/coverage.lcov
+          path-to-lcov: ${{ steps.build.outputs.coverage-lcov }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,9 +16,8 @@ jobs:
       - name: Download build artifacts
         uses: actions/download-artifact@v3
         with:
-          name: build-artifacts
+          name: dist
       - name: Check if tag version matches project version
-        working-directory: dist
         run: |
           # Get the version from the PKG-INFO in the source package.
           tar -xzf *.tar.gz
@@ -39,7 +38,8 @@ jobs:
       - name: Download build artifacts
         uses: actions/download-artifact@v3
         with:
-          name: build-artifacts
+          name: dist
+          path: dist
       - name: Publish package distributions to PyPI
         uses: pypa/gh-action-pypi-publish@a56da0b891b3dc519c7ee3284aff1fad93cc8598 # v1.8.6
       - name: Generate Checksums

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,6 +56,8 @@ pre-commit = "^2.10"
     "*/xsd/device.py",
     "*/xsd/service.py",
   ]
+  [tool.coverage.lcov]
+  output = ".cache/coverage.lcov"
 
 [tool.pytest]
   [tool.pytest.ini_options]

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -60,6 +60,7 @@ echo
 echo "===Test with pytest and coverage==="
 coverage run -m pytest --vcr-record=none
 coverage report --skip-covered
+coverage lcov
 
 echo
 echo "===Building package==="

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -31,7 +31,7 @@ rstcheck README.rst
 echo
 echo "===Sort imports with isort==="
 ISORT_ARGS=""
-if [[ "${CI:-}" = "1" ]]; then
+if [[ ! -z "${CI:-}" ]]; then
   ISORT_ARGS="--check-only"
 fi
 isort $ISORT_ARGS .
@@ -39,7 +39,7 @@ isort $ISORT_ARGS .
 echo
 echo "===Format with black==="
 BLACK_ARGS=""
-if [[ "${CI:-}" = "1" ]]; then
+if [[ ! -z "${CI:-}" ]]; then
   BLACK_ARGS="--check"
 fi
 black $BLACK_ARGS .

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -66,5 +66,12 @@ echo
 echo "===Building package==="
 poetry build
 
+if [[ ! -z "${OUTPUT_ENV_VAR:-}" ]]; then
+  echo
+  echo "===Generating output variables for CI==="
+  echo "version=$(poetry version -s)" | tee -a "${!OUTPUT_ENV_VAR}"
+  echo "coverage-lcov=$(coverage debug config | sed -ne 's/^.*lcov_output: \(.*\)$/\1/p')" | tee -a "${!OUTPUT_ENV_VAR}"
+fi
+
 echo
 echo "Build complete"


### PR DESCRIPTION
## Description:

Coverage is generated in `.cache/coverage.lcov` as part of running `scripts/build.sh`.

I've also modified the `${CI:-}` variable check to test whether or not it is empty. Github uses `CI=true` by default.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] There is no commented out code in this PR.
  - [x] I have read and agree to the [CONTRIBUTING document](
        https://github.com/pywemo/pywemo/blob/master/CONTRIBUTING.md).