### PR TITLE
Remove warnings import

### DIFF
--- a/pywemo/ouimeaux_device/__init__.py
+++ b/pywemo/ouimeaux_device/__init__.py
@@ -6,7 +6,6 @@ import logging
 import subprocess
 import threading
 import time
-import warnings
 from typing import Any, Sequence
 
 import requests


### PR DESCRIPTION
## Description:

The warnings import is no longer needed after #367 & #369. This ended up breaking the build: https://github.com/pywemo/pywemo/actions/runs/4973475555

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] There is no commented out code in this PR.
  - [x] I have read and agree to the [CONTRIBUTING document](
        https://github.com/pywemo/pywemo/blob/master/CONTRIBUTING.md).