### PR TITLE
Move coveralls reporting to a separate workflow step

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,19 +25,36 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Build
         id: build
-        run: ./scripts/build.sh
         env:
-          OUTPUT_ENV_VAR: ${{ (matrix.python-version == '3.10' && 'GITHUB_OUTPUT') || '' }}
-      # The next two steps only run if OUTPUT_ENV_VAR (above) has a value.
+          OUTPUT_ENV_VAR: GITHUB_OUTPUT
+        run: ./scripts/build.sh
       - name: Archive build artifacts
-        if: ${{ success() && steps.build.outputs.version }}
         uses: actions/upload-artifact@v3
         with:
           if-no-files-found: error
-          name: dist
+          name: dist-${{ matrix.python-version }}
           path: dist/
-      - name: Report to Coveralls
-        if: ${{ success() && steps.build.outputs.coverage-lcov }}
-        uses: coverallsapp/github-action@v2
+      - name: Archive coverage results
+        uses: actions/upload-artifact@v3
         with:
-          path-to-lcov: ${{ steps.build.outputs.coverage-lcov }}
+          if-no-files-found: error
+          name: coverage-${{ matrix.python-version }}
+          path: ${{ steps.build.outputs.coverage-lcov }}
+
+  # Coverage reporting is its own step so it can optionally fail if coveralls
+  # is experiencing issues. pyWeMo doesn't currently have any logic that is
+  # different between Python versions, so the coverage output from only one
+  # version needs to be reported. Change the artifact name to use the coverage
+  # from a different matrix build version.
+  coverage:
+    name: Report coverage to coveralls.io
+    needs: [build]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/download-artifact@v3
+        with:
+          name: coverage-3.10
+      - uses: coverallsapp/github-action@v2
+        with:
+          path-to-lcov: coverage.lcov

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,6 +2,15 @@ name: Publish
 on:
   release:
     types: [published]
+
+permissions: {}  # No permissions by default. Permissions are added per-job.
+
+env:
+  # Artifact name to use for the release. The build matrix builds and tests
+  # multiple Python versions. But the release only comes from this single
+  # version.
+  DIST_ARTIFACT: dist-3.10
+
 jobs:
   build:
     name: Build
@@ -10,13 +19,12 @@ jobs:
   check:
     name: Check version and tag match
     runs-on: ubuntu-latest
-    permissions: {}
     needs: build
     steps:
       - name: Download build artifacts
         uses: actions/download-artifact@v3
         with:
-          name: dist
+          name: ${{ env.DIST_ARTIFACT }}
       - name: Check if tag version matches project version
         run: |
           # Get the version from the PKG-INFO in the source package.
@@ -38,7 +46,7 @@ jobs:
       - name: Download build artifacts
         uses: actions/download-artifact@v3
         with:
-          name: dist
+          name: ${{ env.DIST_ARTIFACT }}
           path: dist
       - name: Publish package distributions to PyPI
         uses: pypa/gh-action-pypi-publish@a56da0b891b3dc519c7ee3284aff1fad93cc8598 # v1.8.6


### PR DESCRIPTION
## Description:

Separate coverage reporting into its own build step. The Python build/test steps are marked as required for merging to the main branch. It is undesirable for these to fail due to a transient issue with coverage reporting

## Checklist:
  - [ ] The code change is tested and works locally.
  - [x] There is no commented out code in this PR.
  - [x] I have read and agree to the [CONTRIBUTING document](
        https://github.com/pywemo/pywemo/blob/master/CONTRIBUTING.md).