### PR TITLE
Disable entity expansion in lxml

### DIFF
--- a/pywemo/ouimeaux_device/api/attributes.py
+++ b/pywemo/ouimeaux_device/api/attributes.py
@@ -55,7 +55,9 @@ class AttributeDevice(Switch):
         self._attributes.update(
             {
                 attribute[0].text: attribute[1].text
-                for attribute in et.fromstring(xml_blob)
+                for attribute in et.fromstring(
+                    xml_blob, parser=et.XMLParser(resolve_entities=False)
+                )
                 if len(attribute) >= 2 and _is_int_or_float(attribute[1].text)
             }
         )

--- a/pywemo/ouimeaux_device/api/service.py
+++ b/pywemo/ouimeaux_device/api/service.py
@@ -243,7 +243,9 @@ class Action:
                 )
                 last_exception = err
             else:
-                envelope = et.fromstring(response.data)
+                envelope = et.fromstring(
+                    response.data, parser=et.XMLParser(resolve_entities=False)
+                )
                 body_element = list(envelope)[0]
                 response_element = list(body_element)[0]
                 if (

--- a/pywemo/ouimeaux_device/api/xsd_types.py
+++ b/pywemo/ouimeaux_device/api/xsd_types.py
@@ -157,7 +157,12 @@ class DeviceDescription:
             )
 
         if device.anytypeobjs_:
-            xs_any = (et.fromstring(extra) for extra in device.anytypeobjs_)
+            xs_any = (
+                et.fromstring(
+                    extra, parser=et.XMLParser(resolve_entities=False)
+                )
+                for extra in device.anytypeobjs_
+            )
             config_any = {
                 et.QName(tag).localname: tag.text.strip()
                 for tag in xs_any

--- a/pywemo/ouimeaux_device/bridge.py
+++ b/pywemo/ouimeaux_device/bridge.py
@@ -88,7 +88,10 @@ class Bridge(Device):
             if not (end_devices_xml := end_devices.get('DeviceLists')):
                 return self.Lights, self.Groups
 
-            end_device_list = et.fromstring(end_devices_xml.encode('utf-8'))
+            end_device_list = et.fromstring(
+                end_devices_xml.encode('utf-8'),
+                parser=et.XMLParser(resolve_entities=False),
+            )
 
             for light in end_device_list.iter('DeviceInfo'):
                 if (uniqueID := light.find('DeviceID').text) in self.Lights:
@@ -113,7 +116,10 @@ class Bridge(Device):
     def subscription_update(self, _type: str, _param: str) -> bool:
         """Update the bridge attributes due to a subscription update event."""
         if _type == self.EVENT_TYPE_STATUS_CHANGE and _param:
-            state_event = et.fromstring(_param.encode('utf8'))
+            state_event = et.fromstring(
+                _param.encode('utf8'),
+                parser=et.XMLParser(resolve_entities=False),
+            )
             if not (key := state_event.findtext('DeviceID')):
                 return False
             if key in self.Lights:
@@ -132,7 +138,8 @@ class Bridge(Device):
         if not device_status_list_xml:
             return None
         device_status_list = et.fromstring(
-            device_status_list_xml.encode('utf-8')
+            device_status_list_xml.encode('utf-8'),
+            parser=et.XMLParser(resolve_entities=False),
         )
 
         return device_status_list.find('DeviceStatus')

--- a/pywemo/subscribe.py
+++ b/pywemo/subscribe.py
@@ -408,7 +408,7 @@ class RequestHandler(BaseHTTPRequestHandler):
         data = self.rfile.read(content_len)
         # trim garbage from end, if any
         data = data.strip()
-        return et.fromstring(data)
+        return et.fromstring(data, parser=et.XMLParser(resolve_entities=False))
 
     # pylint: disable=redefined-builtin
     def log_message(self, format: str, *args: Any) -> None:


### PR DESCRIPTION
## Description:

Disable entity expansion in lxml. This can lead to [XXE issues](https://owasp.org/www-community/vulnerabilities/XML_External_Entity_(XXE)_Processing), but is not currently used in pyWeMo in a way that is dangerous. Mainly doing this as a good practice and to guard against any future cases where the data may be returned.

https://lxml.de/FAQ.html#how-do-i-use-lxml-safely-as-a-web-service-endpoint

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] There is no commented out code in this PR.
  - [x] I have read and agree to the [CONTRIBUTING document](
        https://github.com/pywemo/pywemo/blob/master/CONTRIBUTING.md).