### PR TITLE
Avoid simultaneous write file handles

### DIFF
--- a/tests/ouimeaux_device/api/unit/long_press_helpers.py
+++ b/tests/ouimeaux_device/api/unit/long_press_helpers.py
@@ -1,6 +1,7 @@
 """Helper(s) for long press testing on supported devices."""
 
 import contextlib
+import os
 import sqlite3
 import tempfile
 from unittest.mock import patch
@@ -17,12 +18,11 @@ class TestLongPress:
 
     @pytest.fixture
     def rules_db_from_device(self, device):
-        with tempfile.NamedTemporaryFile(
-            prefix="wemorules", suffix=".db"
-        ) as temp_file:
-            rules_db._create_empty_db(temp_file.name)
+        with tempfile.TemporaryDirectory(prefix="wemorules_") as temp_dir:
+            rules_file_name = os.path.join(temp_dir, "rules.db")
+            rules_db._create_empty_db(rules_file_name)
             try:
-                conn = sqlite3.connect(temp_file.name)
+                conn = sqlite3.connect(rules_file_name)
                 conn.row_factory = sqlite3.Row
                 rdb = rules_db.RulesDb(conn, device.udn, device.name)
 

--- a/tests/ouimeaux_device/api/unit/test_long_press.py
+++ b/tests/ouimeaux_device/api/unit/test_long_press.py
@@ -1,5 +1,6 @@
 """Helper(s) for long press testing on supported devices."""
 
+import os
 import sqlite3
 import tempfile
 
@@ -208,12 +209,11 @@ MOCK_UDN = "WemoDeviceUDN"
     ],
 )
 def test_ensure_long_press_rule_exists(test_input, expected):
-    with tempfile.NamedTemporaryFile(
-        prefix="wemorules", suffix=".db"
-    ) as temp_file:
-        rules_db._create_empty_db(temp_file.name)
+    with tempfile.TemporaryDirectory(prefix="wemorules_") as temp_dir:
+        rules_file_name = os.path.join(temp_dir, "rules.db")
+        rules_db._create_empty_db(rules_file_name)
         try:
-            conn = sqlite3.connect(temp_file.name)
+            conn = sqlite3.connect(rules_file_name)
             conn.row_factory = sqlite3.Row
             cursor = conn.cursor()
             for row in test_input:


### PR DESCRIPTION
## Description:

The rules_db module was opening two write file handles on the same database file. One write file handle was opened by calling `tempfile.NamedTemporaryFile` and the other by calling `sqlite3.connect`. This wasn't causing any issues under Linux, but does not work at all on Windows. This PR ensures pyWeMo only has the database file opened for writing in one place at a time.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] There is no commented out code in this PR.
  - [x] I have read and agree to the [CONTRIBUTING document](
        https://github.com/pywemo/pywemo/blob/master/CONTRIBUTING.md).