### PR TITLE
Limit running workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,6 +4,10 @@ on:
   push:
     branches:
       - main
+    paths-ignore:  # These will run in publish.yml.
+      - .github/**
+      - pyproject.toml
+      - scripts/build.sh
   workflow_call:
     outputs:
       version:

--- a/.github/workflows/push-build-changes.yml
+++ b/.github/workflows/push-build-changes.yml
@@ -11,7 +11,7 @@ on:
     types:
       - completed
     branches:
-      - dependabot/**
+      - dependabot/pip/**
 
 permissions: {}  # No permissions needed for this workflow.
 

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -3,6 +3,7 @@
 # policy, and support documentation.
 
 name: Scorecard supply-chain security
+concurrency: scorecard-workflow
 on:
   # For Branch-Protection check. Only the default branch is supported. See
   # https://github.com/ossf/scorecard/blob/main/docs/checks.md#branch-protection


### PR DESCRIPTION
## Description:

More tightly scope when workflows will run. Avoids having too many running all at once.

## Checklist:
  - [ ] The code change is tested and works locally.
  - [x] There is no commented out code in this PR.
  - [x] I have read and agree to the [CONTRIBUTING document](
        https://github.com/pywemo/pywemo/blob/master/CONTRIBUTING.md).