### PR TITLE
Update mypy config

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -109,22 +109,17 @@ src_paths = ["pywemo", "tests"]
 skip_glob = "*/xsd/*"
 
 [tool.mypy]
-show_error_codes = true
-ignore_missing_imports = true
-strict_equality = true
+cache_dir = ".cache/mypy/"
+strict = true
 warn_incomplete_stub = true
-warn_redundant_casts = true
-warn_unused_configs = true
-warn_unused_ignores = true
-check_untyped_defs = true
-disallow_incomplete_defs = true
-disallow_subclassing_any = true
-disallow_untyped_calls = true
-disallow_untyped_decorators = true
-disallow_untyped_defs = true
-no_implicit_optional = true
-warn_return_any = true
 warn_unreachable = true
+
+[[tool.mypy.overrides]]
+module = [
+  "vcr",
+  "lxml",  # TODO: use either lxml-stubs or types-lxml (maybe more complete?)
+]
+ignore_missing_imports = true
 
 [[tool.mypy.overrides]]
 module = [

--- a/setup.cfg
+++ b/setup.cfg
@@ -34,13 +34,3 @@ extend-ignore = B028, E203
 per-file-ignores =
     # don't require function, method, or __init__ docstrings for tests
     tests/*: D102, D103, D107
-
-[mypy]
-pretty = True
-cache_dir = .cache/mypy/
-no_implicit_optional = true
-check_untyped_defs = true
-files = pywemo
-
-[mypy-*.api.xsd.*]
-ignore_errors = True


### PR DESCRIPTION
## Description:
There was still old/stale mypy configuration options in the setup.cfg file (mypy options in pyproject.toml take precedence).  I've removed those and merged a couple into pyproject.toml.  Most of the options enabled are part of the "strict = true" rule, so I switched to that (which then enables 3 extra rules that were not already enabled (disallow_any_generics, no_implicit_reexport, and strict_concatenate).  I remove a rule or two that I believe no longer exists.

I switched  to make the two cases of ignore_missing_imports explicit via an override section.  Note that lxml has two different types packages that could be added to the dev dependencies and then it could be removed from this override.  I can try them both out later to see what other changes that might require and which of the two are better.

@esev, note that the pre-commit process still isn't exactly "fool-proof", as you probably already suspect.  I recently updated to Poetry 1.5.0, which is new.  When I tried to commit my code, that caused poetry to update the lock file (added a catgeory="dev" section to those dependencies) and bootstrap file.  Even though the bootstrap file locks Poetry to 1.4.2, when you run pre-commit it just calls "poetry run ...." and thus uses your system-installed version of poetry.  This assumes, of course, that the virtual environment is not already active (mine generally isn't) - though I know @esev works with it active while developing and thus has probably not seen this issue.  So I committed with --no-verify to prevent that update to the lock file.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] There is no commented out code in this PR.
  - [x] I have read and agree to the [CONTRIBUTING document](
        https://github.com/pywemo/pywemo/blob/master/CONTRIBUTING.md).