### PR TITLE
Close the SubscriptionRegistry http server port when stopping

### DIFF
--- a/pywemo/subscribe.py
+++ b/pywemo/subscribe.py
@@ -639,6 +639,7 @@ class SubscriptionRegistry:
         self._httpd.outer = self
         LOG.info("Listening on port %d", self.port)
         self._httpd.serve_forever()
+        self._httpd.server_close()
 
     def _run_event_loop(self) -> None:
         """Run the event thread loop."""

--- a/tests/test_subscribe.py
+++ b/tests/test_subscribe.py
@@ -411,3 +411,16 @@ class Test_SubscriptionRegistry:
             headers=mock.ANY,
             timeout=10,
         )
+
+    def test_start_stop(self):
+        registry = subscribe.SubscriptionRegistry(requested_port=0)
+        registry.start()
+        port = registry.port
+        try:
+            response = requests.request("NOTIFY", f"http://127.0.0.1:{port}/")
+            assert response.status_code == 200
+        finally:
+            registry.stop()
+
+        with pytest.raises(requests.ConnectionError):
+            requests.request("NOTIFY", f"http://127.0.0.1:{port}/", timeout=5)


### PR DESCRIPTION
## Description:

Close the SubscriptionRegistry http server port when stopping

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] There is no commented out code in this PR.
  - [x] I have read and agree to the [CONTRIBUTING document](
        https://github.com/pywemo/pywemo/blob/master/CONTRIBUTING.md).