### PR TITLE
Run pre-commit via a script to activate the venv

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -13,6 +13,9 @@ poetryInstall
 echo
 echo "===Installing pre-commit hooks==="
 pre-commit install
+sed -ie \
+    "s#INSTALL_PYTHON=.*#INSTALL_PYTHON=$(pwd)/scripts/pre-commit.sh#" \
+    .git/hooks/pre-commit
 
 echo
 echo "===Running pre-commit checks==="

--- a/scripts/pre-commit.sh
+++ b/scripts/pre-commit.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -euf -o pipefail
+
+SELF_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+cd "$SELF_DIR/.."
+
+source "$SELF_DIR/common.sh"
+
+assertPython
+enterVenv
+
+if [ "${1:-}" == "-mpre_commit" ]; then
+    shift
+fi
+
+exec python -mpre_commit "$@"


### PR DESCRIPTION
## Description:

The pre-commit git hook (`.git/hooks/pre-commit`) currently runs [pre-commit](https://github.com/pre-commit/pre-commit) outside of a venv. This PR modifies pre-commit's git hook to indirectly launch Python via a script. The script enters the venv and then runs pre-commit.

Before:

```bash
#!/usr/bin/env bash
# File generated by pre-commit: https://pre-commit.com
# ID: 138fd403232d2ddd5efb44317e38bf03

# start templated
INSTALL_PYTHON=/home/eric/github/pywemo/.venv/bin/python
ARGS=(hook-impl --config=.pre-commit-config.yaml --hook-type=pre-commit)
# end templated

HERE="$(cd "$(dirname "$0")" && pwd)"
ARGS+=(--hook-dir "$HERE" -- "$@")

if [ -x "$INSTALL_PYTHON" ]; then
    exec "$INSTALL_PYTHON" -mpre_commit "${ARGS[@]}"
elif command -v pre-commit > /dev/null; then
    exec pre-commit "${ARGS[@]}"
else
    echo '`pre-commit` not found.  Did you forget to activate your virtualenv?' 1>&2
    exit 1
fi
```

Diff

```patch
--- .git/hooks/pre-commit.orig  2023-05-22 21:34:57.384905849 -0700
+++ .git/hooks/pre-commit       2023-05-22 21:35:09.080786793 -0700
@@ -3,7 +3,7 @@
 # ID: 138fd403232d2ddd5efb44317e38bf03
 
 # start templated
-INSTALL_PYTHON=/home/eric/github/pywemo/.venv/bin/python
+INSTALL_PYTHON=/home/eric/github/pywemo/scripts/pre-commit.sh
 ARGS=(hook-impl --config=.pre-commit-config.yaml --hook-type=pre-commit)
 # end templated
 ```



**Related issue (if applicable):** fixes #413

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] There is no commented out code in this PR.
  - [x] I have read and agree to the [CONTRIBUTING document](
        https://github.com/pywemo/pywemo/blob/master/CONTRIBUTING.md).