### PR TITLE
Always run pre-commit inside the venv

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -33,7 +33,7 @@ repos:
       - id: generateDS
         name: generateDS
         language: system
-        entry: poetry run python scripts/generate_ds.py
+        entry: python scripts/generate_ds.py
         args:
           - pywemo/ouimeaux_device/api/xsd/device.xsd
           - pywemo/ouimeaux_device/api/xsd/service.xsd
@@ -44,7 +44,7 @@ repos:
       - id: isort
         name: isort
         language: system
-        entry: poetry run isort
+        entry: isort
         args: ['--filter-files']
         require_serial: true
         types_or: [cython, pyi, python]
@@ -52,21 +52,21 @@ repos:
       - id: black
         name: black
         language: system
-        entry: poetry run black
+        entry: black
         require_serial: true
         types_or: [python, pyi]
 
       - id: flake8
         name: flake8
         language: system
-        entry: poetry run flake8
+        entry: flake8
         require_serial: true
         types: [python]
 
       - id: pylint
         name: pylint
         language: system
-        entry: poetry run pylint
+        entry: pylint
         args: ['--disable=fixme']
         require_serial: true
         types: [python]
@@ -74,7 +74,7 @@ repos:
       - id: mypy
         name: mypy
         language: system
-        entry: poetry run mypy
+        entry: mypy
         require_serial: true
         types_or: [python, pyi]
         # By default mypy will prefer .pyi files to py files if both are found
@@ -90,12 +90,12 @@ repos:
       - id: rstcheck
         name: rstcheck
         language: system
-        entry: poetry run rstcheck
+        entry: rstcheck
         types: [rst]
 
       - id: deptry
         name: deptry
         language: system
-        entry: poetry run deptry .
+        entry: deptry .
         pass_filenames: false
         types: [python]

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -14,7 +14,7 @@ echo
 echo "===Installing pre-commit hooks==="
 pre-commit install
 # Always run pre-commit inside the venv.
-REPLACE="VIRTUAL_ENV=$VIRTUAL_ENV\nPATH=$VIRTUAL_ENV/bin:\$PATH"
+REPLACE="VIRTUAL_ENV=\"$VIRTUAL_ENV\"\nPATH=\"$VIRTUAL_ENV/bin:\$PATH\""
 sed -ie "s^# start templated.*^$REPLACE^" .git/hooks/pre-commit
 
 echo

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -13,6 +13,9 @@ poetryInstall
 echo
 echo "===Installing pre-commit hooks==="
 pre-commit install
+# Always run pre-commit inside the venv.
+REPLACE="VIRTUAL_ENV=$VIRTUAL_ENV\nPATH=$VIRTUAL_ENV/bin:\$PATH"
+sed -ie "s^# start templated.*^$REPLACE^" .git/hooks/pre-commit
 
 echo
 echo "===Running pre-commit checks==="

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -14,7 +14,8 @@ echo
 echo "===Installing pre-commit hooks==="
 pre-commit install
 # Always run pre-commit inside the venv.
-REPLACE="VIRTUAL_ENV=\"$VIRTUAL_ENV\"\nPATH=\"$VIRTUAL_ENV/bin:\$PATH\""
+ORIG_PATH="$(python -c "import os;print(f'{os.pathsep}\$PATH')")"
+REPLACE="VIRTUAL_ENV=\"$VIRTUAL_ENV\"\nPATH=\"$VIRTUAL_ENV/bin$ORIG_PATH\""
 sed -ie "s^# start templated.*^$REPLACE^" .git/hooks/pre-commit
 
 echo


### PR DESCRIPTION
## Description:

The pre-commit git hook (.git/hooks/pre-commit) currently runs [pre-commit](https://github.com/pre-commit/pre-commit) outside of a venv. This PR modifies pre-commit's git hook run pre-commit inside the venv.

This is based on https://github.com/cjolowicz/nox-poetry/blob/5772b66ebff8d5a3351a08ed402d3d31e48be5f8/noxfile.py#L70

**Related issue (if applicable):** fixes #413

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] There is no commented out code in this PR.
  - [x] I have read and agree to the [CONTRIBUTING document](
        https://github.com/pywemo/pywemo/blob/master/CONTRIBUTING.md).