### PR TITLE
Enable GitHub Action caching for pip/poetry downloads

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,10 +44,20 @@ jobs:
         uses: actions/setup-python@57ded4d7d5e986d7296eab16560982c6dd7c923b # v4.6.0
         with:
           python-version: ${{ matrix.python-version }}
+      - name: Enable build input caching
+        uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
+        with:
+          path: |
+            ./.cache/pip
+            ./.cache/pypoetry
+          key: ${{ runner.os }}-${{ hashFiles('**/poetry.lock') }}
+          restore-keys: ${{ runner.os }}-
       - name: Build
         id: build
         env:
           OUTPUT_ENV_VAR: GITHUB_OUTPUT
+          PIP_CACHE_DIR: ./.cache/pip
+          POETRY_CACHE_DIR: ./.cache/pypoetry
         run: bash -x ./scripts/build.sh
       - name: Check for code modifications
         if: always()

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,7 +51,12 @@ jobs:
             ./.cache/pip
             ./.cache/pypoetry
           key: ${{ runner.os }}-${{ hashFiles('**/poetry.lock') }}
-          restore-keys: ${{ runner.os }}-
+          # Don't restore for pushes to the main branch. Otherwise the cache
+          # will continue to grow over time.
+          restore-keys: >
+            ${{ github.event_name == 'push' &&
+                github.ref_name == 'main' &&
+                'no-restore' || format('{0}-', runner.os) }}
       - name: Build
         id: build
         env:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -56,7 +56,7 @@ jobs:
           restore-keys: >-
             ${{ github.event_name == 'push' &&
                 github.ref_name == 'main' &&
-                'no-restore' || format('{0}-', runner.os) }}
+                'no-restore' || runner.os }}-
       - name: Build
         id: build
         env:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,7 +53,7 @@ jobs:
           key: ${{ runner.os }}-${{ hashFiles('**/poetry.lock') }}
           # Don't restore for pushes to the main branch. Otherwise the cache
           # will continue to grow over time.
-          restore-keys: >
+          restore-keys: >-
             ${{ github.event_name == 'push' &&
                 github.ref_name == 'main' &&
                 'no-restore' || format('{0}-', runner.os) }}


### PR DESCRIPTION
## Description:

GitHub provides a way for Actions to cache downloaded files. Use this cache to avoid pip/poetry needing to download the wheels for each dependency every time the Action runs. The cache is invalidated whenever `poetry.lock` is changed. 

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] There is no commented out code in this PR.
  - [x] I have read and agree to the [CONTRIBUTING document](
        https://github.com/pywemo/pywemo/blob/master/CONTRIBUTING.md).