### PR TITLE
Prevent invalid values for CrockPot attributes

### DIFF
--- a/pywemo/ouimeaux_device/crockpot.py
+++ b/pywemo/ouimeaux_device/crockpot.py
@@ -40,7 +40,7 @@ MODE_NAMES = {
 
 
 class _Attributes(TypedDict, total=False):
-    """LinkedDevice state dictionary type."""
+    """CrockPot state dictionary type."""
 
     cookedTime: int
     mode: int

--- a/tests/ouimeaux_device/test_crockpot.py
+++ b/tests/ouimeaux_device/test_crockpot.py
@@ -1,6 +1,10 @@
 """Integration tests for the WeMo CrockPot."""
 
+from unittest.mock import patch
+
 import pytest
+from hypothesis import HealthCheck, example, given, settings
+from hypothesis import strategies as st
 
 from pywemo.ouimeaux_device.crockpot import CrockPot, CrockPotMode
 
@@ -16,6 +20,7 @@ def test_on(crockpot):
     crockpot.on()
 
     assert crockpot.mode == CrockPotMode.High
+    assert crockpot.mode_string == "High"
 
 
 @pytest.mark.vcr()
@@ -23,3 +28,71 @@ def test_off(crockpot):
     crockpot.off()
 
     assert crockpot.mode == CrockPotMode.Off
+    assert crockpot.mode_string == "Turned Off"
+
+
+@st.composite
+def state_dict(draw):
+    keys = st.one_of(
+        st.sampled_from(["cookedTime", "mode", "time"]), st.text()
+    )
+    values = st.one_of(st.integers(), st.text())
+    return {
+        key: str(value)
+        for key, value in draw(st.dictionaries(keys, values)).items()
+    }
+
+
+@given(state=state_dict())
+@settings(suppress_health_check=[HealthCheck.function_scoped_fixture])
+# Positive examples.
+@example(state={"cookedTime": "0", "mode": "0", "time": "0"})
+@example(state={"cookedTime": "1", "mode": "50", "time": "1"})
+@example(state={"cookedTime": "2", "mode": "51", "time": "2"})
+@example(state={"cookedTime": "3", "mode": "52", "time": "3"})
+# Negative examples.
+@example(state={"cookedTime": "'", "mode": "50", "time": "1"})
+@example(state={"cookedTime": "1", "mode": "'", "time": "1"})
+@example(state={"cookedTime": "1", "mode": "50", "time": "'"})
+@example(state={"mode": "50", "time": "1"})
+@example(state={"cookedTime": "1", "time": "1"})
+@example(state={"cookedTime": "1", "mode": "50"})
+def test_update_attributes(state, crockpot):
+    crockpot._attributes = {}
+    try:
+        expected = (
+            CrockPotMode(int(state["mode"])),
+            int(state["time"]),
+            int(state["cookedTime"]),
+        )
+    except (KeyError, ValueError):
+        # State should only change if all values are well formed.
+        expected = (
+            crockpot.mode,
+            crockpot.remaining_time,
+            crockpot.cooked_time,
+        )
+
+    with patch.object(
+        crockpot.basicevent, "GetCrockpotState", return_value=state
+    ):
+        crockpot.get_state(True)
+        assert expected == (
+            crockpot.mode,
+            crockpot.remaining_time,
+            crockpot.cooked_time,
+        )
+
+    # Test the subscription_update method with the same data.
+    for key, value in state.items():
+        if key == "BinaryState":
+            continue  # Handled by CrockPot superclass. Not tested here.
+        result = crockpot.subscription_update(key, value)
+
+        subscription_update_valid = key in ("mode", "time", "cookedTime")
+        try:
+            _ = int(value)
+        except ValueError:
+            subscription_update_valid = False
+
+        assert result is subscription_update_valid

--- a/tests/test_registry_notify_fuzz.py
+++ b/tests/test_registry_notify_fuzz.py
@@ -24,7 +24,9 @@ MOCK_SERVICE_RETURN_VALUES = {
             )
         }
     },
-    "basicevent": {"GetCrockpotState": {}},
+    "basicevent": {
+        "GetCrockpotState": {"cookedTime": "0", "mode": "0", "time": "0"}
+    },
     "insight": {
         "GetInsightParams": {
             "InsightParams": (
@@ -68,6 +70,9 @@ PROPERTY_NAMES = st.one_of(
     st.sampled_from(
         [
             "attributeList",
+            "cookedTime",
+            "mode",
+            "time",
             "BinaryState",
             "CurrentHumidity",
             "DesiredHumidity",
@@ -156,6 +161,9 @@ def registry(request):
 @example(name="Bridge", properties={"StatusChange": "1"})
 @example(name="CoffeeMaker", properties={"attributeList": {}})
 @example(name="CoffeeMaker", properties={"attributeList": "<"})
+@example(name="CrockPot", properties={"cookedTime": "'"})
+@example(name="CrockPot", properties={"mode": "'"})
+@example(name="CrockPot", properties={"time": "'"})
 @example(name="Insight", properties={"InsightParams": "1"})
 def test_notify(name, properties, registry):
     device = DEVICES[name]


### PR DESCRIPTION
## Description:

Prevent invalid values for CrockPot attributes. Add Hypothesis test focused on the output of `GetCrockpotState` and the subscription notifications.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] There is no commented out code in this PR.
  - [x] I have read and agree to the [CONTRIBUTING document](
        https://github.com/pywemo/pywemo/blob/master/CONTRIBUTING.md).