### PR TITLE
None is valid for type_filter in SubscriptionRegistry.on

### DIFF
--- a/pywemo/subscribe.py
+++ b/pywemo/subscribe.py
@@ -434,7 +434,7 @@ class SubscriptionRegistry:
         """Create the subscription registry object."""
         self.devices: dict[str, Device] = {}
         self._callbacks: dict[
-            Device, list[tuple[str, SubscriberCallback]]
+            Device, list[tuple[str | None, SubscriberCallback]]
         ] = collections.defaultdict(list)
         self._exiting = False
 
@@ -567,7 +567,10 @@ class SubscriptionRegistry:
                 callback(device, type_, value)
 
     def on(
-        self, device: Device, type_filter: str, callback: SubscriberCallback
+        self,
+        device: Device,
+        type_filter: str | None,
+        callback: SubscriberCallback,
     ) -> None:
         """Add an event callback for a device."""
         self._callbacks[device].append((type_filter, callback))


### PR DESCRIPTION
## Description:

Passing `None` for the `type_filter` allows all event types to match the filter. Extend the type hints so `None` is allowed.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] There is no commented out code in this PR.
  - [x] I have read and agree to the [CONTRIBUTING document](
        https://github.com/pywemo/pywemo/blob/master/CONTRIBUTING.md).