### PR TITLE
Bridge Lights/Groups are not shared across devices

### DIFF
--- a/pywemo/ouimeaux_device/bridge.py
+++ b/pywemo/ouimeaux_device/bridge.py
@@ -41,14 +41,16 @@ def limit(value: int, min_val: int, max_val: int) -> int:
 class Bridge(Device):
     """Representation of a WeMo Bridge (Link) device."""
 
-    Lights: dict[str, Light] = {}
-    Groups: dict[str, Group] = {}
+    Lights: dict[str, Light]
+    Groups: dict[str, Group]
 
     EVENT_TYPE_STATUS_CHANGE = "StatusChange"
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         """Create a WeMo Bridge (Link) device."""
         super().__init__(*args, **kwargs)
+        self.Lights = {}  # pylint: disable=invalid-name
+        self.Groups = {}  # pylint: disable=invalid-name
         self.bridge_update()
 
     def __repr__(self) -> str:

--- a/pywemo/ouimeaux_device/bridge.py
+++ b/pywemo/ouimeaux_device/bridge.py
@@ -41,16 +41,16 @@ def limit(value: int, min_val: int, max_val: int) -> int:
 class Bridge(Device):
     """Representation of a WeMo Bridge (Link) device."""
 
-    Lights: dict[str, Light]
-    Groups: dict[str, Group]
+    lights: dict[str, Light]
+    groups: dict[str, Group]
 
     EVENT_TYPE_STATUS_CHANGE = "StatusChange"
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         """Create a WeMo Bridge (Link) device."""
         super().__init__(*args, **kwargs)
-        self.Lights = {}  # pylint: disable=invalid-name
-        self.Groups = {}  # pylint: disable=invalid-name
+        self.lights = {}
+        self.groups = {}
         self.bridge_update()
 
     def __repr__(self) -> str:
@@ -58,7 +58,7 @@ class Bridge(Device):
         return (
             '<WeMo Bridge "{name}", Lights: {lights}, ' + "Groups: {groups}>"
         ).format(
-            name=self.name, lights=len(self.Lights), groups=len(self.Groups)
+            name=self.name, lights=len(self.lights), groups=len(self.groups)
         )
 
     @property
@@ -75,7 +75,7 @@ class Bridge(Device):
         self, force_update: bool = True
     ) -> tuple[dict[str, Light], dict[str, Group]]:
         """Get updated status information for the bridge and its lights."""
-        if force_update or self.Lights is None or self.Groups is None:
+        if force_update or self.lights is None or self.groups is None:
             plugin_udn = self.basicevent.GetMacAddr().get("PluginUDN")
 
             if hasattr(self.bridge, "GetEndDevicesWithStatus"):
@@ -88,7 +88,7 @@ class Bridge(Device):
                 )
 
             if not (end_devices_xml := end_devices.get("DeviceLists")):
-                return self.Lights, self.Groups
+                return self.lights, self.groups
 
             end_device_list = et.fromstring(
                 end_devices_xml.encode("utf-8"),
@@ -96,18 +96,18 @@ class Bridge(Device):
             )
 
             for light in end_device_list.iter("DeviceInfo"):
-                if (uniqueID := light.find("DeviceID").text) in self.Lights:
-                    self.Lights[uniqueID].update_state(light)
+                if (uniqueID := light.find("DeviceID").text) in self.lights:
+                    self.lights[uniqueID].update_state(light)
                 else:
-                    self.Lights[uniqueID] = Light(self, light)
+                    self.lights[uniqueID] = Light(self, light)
 
             for group in end_device_list.iter("GroupInfo"):
-                if (uniqueID := group.find("GroupID").text) in self.Groups:
-                    self.Groups[uniqueID].update_state(group)
+                if (uniqueID := group.find("GroupID").text) in self.groups:
+                    self.groups[uniqueID].update_state(group)
                 else:
-                    self.Groups[uniqueID] = Group(self, group)
+                    self.groups[uniqueID] = Group(self, group)
 
-        return self.Lights, self.Groups
+        return self.lights, self.groups
 
     def get_state(self, force_update: bool = False) -> int:
         """Update the state of the Bridge device."""
@@ -127,11 +127,11 @@ class Bridge(Device):
                 return False
             if not (key := state_event.findtext("DeviceID")):
                 return False
-            if key in self.Lights:
-                return self.Lights[key].subscription_update(state_event)
+            if key in self.lights:
+                return self.lights[key].subscription_update(state_event)
 
-            if key in self.Groups:
-                return self.Groups[key].subscription_update(state_event)
+            if key in self.groups:
+                return self.groups[key].subscription_update(state_event)
 
             return False
         return super().subscription_update(_type, _param)

--- a/tests/ouimeaux_device/test_bridge.py
+++ b/tests/ouimeaux_device/test_bridge.py
@@ -17,15 +17,15 @@ def bridge(vcr):
 
 @pytest.fixture
 def light(bridge):
-    assert LIGHT_ID in bridge.Lights
-    light = bridge.Lights[LIGHT_ID]
+    assert LIGHT_ID in bridge.lights
+    light = bridge.lights[LIGHT_ID]
     return light
 
 
 @pytest.fixture
 def group(bridge):
-    assert GROUP_ID in bridge.Groups
-    group = bridge.Groups[GROUP_ID]
+    assert GROUP_ID in bridge.groups
+    group = bridge.groups[GROUP_ID]
     return group
 
 
@@ -274,4 +274,4 @@ def test_subscription_update(update, expected_updated, expected_state, bridge):
     updated = bridge.subscription_update("StatusChange", update)
     assert updated == expected_updated
     if updated:
-        assert bridge.Lights[LIGHT_ID].get_state() == expected_state
+        assert bridge.lights[LIGHT_ID].get_state() == expected_state

--- a/tests/vcr/tests.ouimeaux_device.test_bridge/test_light_start_ramp.yaml
+++ b/tests/vcr/tests.ouimeaux_device.test_bridge/test_light_start_ramp.yaml
@@ -11,7 +11,7 @@ interactions:
       <DeviceStatusList>&lt;?xml version=&#x27;1.0&#x27; encoding=&#x27;UTF-8&#x27;?&gt;
 
       &lt;DeviceStatus&gt;&lt;IsGroupAction&gt;NO&lt;/IsGroupAction&gt;&lt;DeviceID
-      available=&quot;YES&quot;&gt;F0D1B8000001420C&lt;/DeviceID&gt;&lt;CapabilityID&gt;30301,30009&lt;/CapabilityID&gt;&lt;CapabilityValue&gt;200:0,1:100&lt;/CapabilityValue&gt;&lt;/DeviceStatus&gt;</DeviceStatusList>
+      available=&quot;YES&quot;&gt;F0D1B8000001420C&lt;/DeviceID&gt;&lt;CapabilityID&gt;30009&lt;/CapabilityID&gt;&lt;CapabilityValue&gt;1:100&lt;/CapabilityValue&gt;&lt;/DeviceStatus&gt;</DeviceStatusList>
 
       </u:SetDeviceStatus>
 


### PR DESCRIPTION
## Description:

Bridge devices do not share state between them. Neither should the pyWeMo Bridge class. This leads to subtle bugs when multiple Bridge devices are handled by pyWeMo.

## Breaking change:

1. The Lights/Groups properties are no longer defined on the Bridge class. They are only available for instances of the Bridge class.
2. `Lights` is renamed to `lights` and `Groups` is renamed to `groups` to better follow Python's snake_case naming conventions.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] There is no commented out code in this PR.
  - [x] I have read and agree to the [CONTRIBUTING document](
        https://github.com/pywemo/pywemo/blob/master/CONTRIBUTING.md).