### PR TITLE
Adjust calls/types for lxml

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1114,6 +1114,20 @@ htmlsoup = ["BeautifulSoup4"]
 source = ["Cython (>=0.29.7)"]
 
 [[package]]
+name = "lxml-stubs"
+version = "0.4.0"
+description = "Type annotations for the lxml package"
+optional = false
+python-versions = "*"
+files = [
+    {file = "lxml-stubs-0.4.0.tar.gz", hash = "sha256:184877b42127256abc2b932ba8bd0ab5ea80bd0b0fee618d16daa40e0b71abee"},
+    {file = "lxml_stubs-0.4.0-py3-none-any.whl", hash = "sha256:3b381e9e82397c64ea3cc4d6f79d1255d015f7b114806d4826218805c10ec003"},
+]
+
+[package.extras]
+test = ["coverage[toml] (==5.2)", "pytest (>=6.0.0)", "pytest-mypy-plugins (==1.9.3)"]
+
+[[package]]
 name = "mccabe"
 version = "0.7.0"
 description = "McCabe checker, plugin for flake8"
@@ -2567,4 +2581,4 @@ testing = ["big-O", "flake8 (<5)", "jaraco.functools", "jaraco.itertools", "more
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8.1"
-content-hash = "b88f04cfff348a02d5f5d9070bf00ee0a1564ad9b5e72a3dfcfa9d2e383290e8"
+content-hash = "d94ffbdc62fb3730b514971e35981920754c62d4273b694c0fce37143b931bee"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,7 @@ pylint = "^2.17.3"
 rstcheck = ">=3.3.1,<7.0.0"
 mypy = "^1.2.0"
 # testing and code coverage
+lxml-stubs = "^0.4.0"
 pytest = "^7.3.1"
 pytest-vcr = "1.0.2"
 types-requests = ">=2.0"

--- a/pywemo/exceptions.py
+++ b/pywemo/exceptions.py
@@ -21,7 +21,7 @@ class SOAPFault(ActionException):
     error_description: str = ""
 
     def __init__(
-        self, message: str = "", fault_element: et.Element | None = None
+        self, message: str = "", fault_element: et._Element | None = None
     ) -> None:
         """Initialize from a SOAP Fault lxml.etree Element."""
         details = ""
@@ -31,14 +31,13 @@ class SOAPFault(ActionException):
                 "/{urn:schemas-upnp-org:control-1-0}UPnPError/"
                 "{urn:schemas-upnp-org:control-1-0}"
             )
-            self.fault_code = fault_element.findtext("faultcode") or ""
-            self.fault_string = fault_element.findtext("faultstring") or ""
-            self.error_code = (
-                fault_element.findtext(f"{upnp_error_prefix}errorCode") or ""
+            self.fault_code = fault_element.findtext("faultcode", "")
+            self.fault_string = fault_element.findtext("faultstring", "")
+            self.error_code = fault_element.findtext(
+                f"{upnp_error_prefix}errorCode", ""
             )
-            self.error_description = (
-                fault_element.findtext(f"{upnp_error_prefix}errorDescription")
-                or ""
+            self.error_description = fault_element.findtext(
+                f"{upnp_error_prefix}errorDescription", ""
             )
             details = (
                 f" SOAP Fault {self.fault_code}:{self.fault_string}, "

--- a/pywemo/ouimeaux_device/api/attributes.py
+++ b/pywemo/ouimeaux_device/api/attributes.py
@@ -61,7 +61,10 @@ class AttributeDevice(Switch):
                 for attribute in et.fromstring(
                     xml_blob, parser=et.XMLParser(resolve_entities=False)
                 )
-                if len(attribute) >= 2 and _is_int_or_float(attribute[1].text)
+                if len(attribute) >= 2
+                and attribute[0].text is not None
+                and attribute[1].text is not None
+                and _is_int_or_float(attribute[1].text)
             }
         )
 

--- a/pywemo/ouimeaux_device/api/service.py
+++ b/pywemo/ouimeaux_device/api/service.py
@@ -257,7 +257,7 @@ class Action:
                         fault_element=response_element,
                     )
                 return {
-                    response_item.tag: response_item.text
+                    response_item.tag: response_item.text or ""
                     for response_item in response_element
                 }
 

--- a/pywemo/subscribe.py
+++ b/pywemo/subscribe.py
@@ -343,8 +343,12 @@ class RequestHandler(BaseHTTPRequestHandler):
             doc = self._get_xml_from_http_body()
             for propnode in doc.findall(f"./{NS}property"):
                 for property_ in list(propnode):
-                    text = property_.text or ""
-                    outer.event(device, property_.tag, text, path=self.path)
+                    outer.event(
+                        device,
+                        property_.tag,
+                        property_.text or "",
+                        path=self.path,
+                    )
 
         self._send_response(200, RESPONSE_SUCCESS)
 
@@ -368,10 +372,8 @@ class RequestHandler(BaseHTTPRequestHandler):
                 )
             else:
                 doc = self._get_xml_from_http_body()
-                binary_state = doc.find(".//BinaryState")
-                if binary_state is not None:
-                    text = binary_state.text
-                    outer.event(device, EVENT_TYPE_LONG_PRESS, text)
+                if binary_state := doc.findtext(".//BinaryState"):
+                    outer.event(device, EVENT_TYPE_LONG_PRESS, binary_state)
             self._send_response(200, RESPONSE_SUCCESS)
         else:
             self._send_response(404, RESPONSE_NOT_FOUND)
@@ -402,7 +404,7 @@ class RequestHandler(BaseHTTPRequestHandler):
         if body:
             self.wfile.write(body.encode("UTF-8"))
 
-    def _get_xml_from_http_body(self) -> et.Element:
+    def _get_xml_from_http_body(self) -> et._Element:
         """Build the element tree root from the body of the http request."""
         content_len = int(self.headers.get("content-length", 0))
         data = self.rfile.read(content_len)


### PR DESCRIPTION
## Description:

Add a dev dependency on lxml-stubs so the type checker (mypy) can find issues. This surfaced a number of errors that are highlighted in #433 and are fixed in this PR.

## Breaking changes

- The device_index, iconvalue, firmware, manufacturer, model, and certified properties of the Light class are now of type `str`. They were previously `Optional[str]`. They will contain an empty string if the values are not provided by the bridge device.
- An `InvalidSchemaError` exception will be raised if the bridge device does not include `DeviceID` within `DeviceInfo` or a `GroupID` within `GroupInfo` in the response to GetEndDevicesWithStatus. pyWeMo requires these fields as they are used for uniquely identifying individual lights/groups.

**Related issue (if applicable):** fixes #433

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] There is no commented out code in this PR.
  - [x] I have read and agree to the [CONTRIBUTING document](
        https://github.com/pywemo/pywemo/blob/master/CONTRIBUTING.md).