### PR TITLE
Provide proper responses to Action requests for the virual device

### DIFF
--- a/pywemo/subscribe.py
+++ b/pywemo/subscribe.py
@@ -360,6 +360,7 @@ class RequestHandler(BaseHTTPRequestHandler):
     # Do not wait for more than 10 seconds for any request to complete.
     timeout = 10
     server: HTTPServer
+    server_version = f"{BaseHTTPRequestHandler.server_version} UPnP/1.0"
 
     def do_NOTIFY(self) -> None:  # pylint: disable=invalid-name
         """Handle subscription responses received from devices."""

--- a/pywemo/subscribe.py
+++ b/pywemo/subscribe.py
@@ -410,7 +410,9 @@ class RequestHandler(BaseHTTPRequestHandler):
             response = SOAP_ACTION_RESPONSE.get(
                 action, ERROR_SOAP_ACTION_RESPONSE
             )
-            self._send_response(200, response)
+            self._send_response(
+                200, response, content_type='text/xml; charset="utf-8"'
+            )
         else:
             self._send_response(404, RESPONSE_NOT_FOUND)
 

--- a/tests/test_subscribe.py
+++ b/tests/test_subscribe.py
@@ -157,6 +157,7 @@ class Test_RequestHandler:
             action
         ].encode("UTF-8")
         assert response.headers["Content-Type"] == 'text/xml; charset="utf-8"'
+        assert "UPnP/1.0" in response.headers["Server"]
         outer.event.assert_called_once_with(
             mock_light_switch, subscribe.EVENT_TYPE_LONG_PRESS, "0"
         )

--- a/tests/test_subscribe.py
+++ b/tests/test_subscribe.py
@@ -8,7 +8,7 @@ from http.server import HTTPServer
 import pytest
 import requests
 
-from pywemo import Bridge, Insight, LightSwitch, subscribe
+from pywemo import Bridge, Insight, LightSwitch, exceptions, subscribe
 
 
 @pytest.fixture
@@ -164,6 +164,16 @@ class Test_RequestHandler:
         """POST request for unrecognized path returns 404 error."""
         response = requests.post(f"{server_url}/")
         assert response.status_code == 404
+
+    def test_POST_from_pywemo(self, server_url, light_switch):
+        """Validate the POST request handler using a pyWeMo device."""
+        light_switch.session.url = server_url
+        assert light_switch.get_state(True) == 0
+        light_switch.on()
+        assert light_switch.get_state() == 1
+        assert light_switch.get_state(True) == 0
+        with pytest.raises(exceptions.SOAPFault):
+            light_switch.basicevent.GetFriendlyName()
 
     def test_SUBSCRIBE_state(self, server_url):
         """SUBSCRIBE response contains appropriate UPnP headers."""

--- a/tests/test_subscribe.py
+++ b/tests/test_subscribe.py
@@ -156,6 +156,7 @@ class Test_RequestHandler:
         assert response.content == subscribe.SOAP_ACTION_RESPONSE[
             action
         ].encode("UTF-8")
+        assert response.headers["Content-Type"] == 'text/xml; charset="utf-8"'
         outer.event.assert_called_once_with(
             mock_light_switch, subscribe.EVENT_TYPE_LONG_PRESS, "0"
         )


### PR DESCRIPTION
## Description:

WeMo devices expect the pyWeMo virtual device to respond to SOAP requests with proper SOAP responses. This PR updates the do_POST method to return a valid SOAP response.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] There is no commented out code in this PR.
  - [x] I have read and agree to the [CONTRIBUTING document](
        https://github.com/pywemo/pywemo/blob/master/CONTRIBUTING.md).