### PR TITLE
Run more hypothesis examples for longer under CI

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,8 +6,14 @@ import unittest.mock as mock
 from http.server import HTTPServer
 
 import pytest
+from hypothesis import settings
 
 from pywemo import SubscriptionRegistry
+
+settings.register_profile(
+    "ci", max_examples=1000, deadline=1000.0  # Milliseconds
+)
+settings.load_profile("ci" if os.getenv("CI") else "default")
 
 
 @pytest.fixture(scope="module")


### PR DESCRIPTION
## Description:

Run more hypothesis examples under GitHub actions. And extend the timeout to account for some slowness in the Windows runners.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] There is no commented out code in this PR.
  - [x] I have read and agree to the [CONTRIBUTING document](
        https://github.com/pywemo/pywemo/blob/master/CONTRIBUTING.md).