### PR TITLE
Validate attributes before assignment

### DIFF
--- a/pywemo/ouimeaux_device/api/xsd_types.py
+++ b/pywemo/ouimeaux_device/api/xsd_types.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, Dict, List
 
 from lxml import etree as et
 
@@ -133,9 +133,9 @@ class DeviceDescription:
     model_name: str
     serial_number: str
     udn: str
-    _config_any: dict[str, str]
+    _config_any: Dict[str, str]
     _device_type: str
-    _services: list[ServiceProperties]
+    _services: List[ServiceProperties]
 
     @staticmethod
     def dict_from_xml(setup_xml_content: bytes) -> dict[str, Any]:

--- a/pywemo/ouimeaux_device/coffeemaker.py
+++ b/pywemo/ouimeaux_device/coffeemaker.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 from enum import IntEnum
-from typing import Any
+from typing import Any, TypedDict
 
 from .api.attributes import AttributeDevice
 
@@ -46,15 +46,20 @@ MODE_NAMES = {
 }
 
 
+class _Attributes(TypedDict, total=False):
+    Mode: int
+
+
 class CoffeeMaker(AttributeDevice):
     """Representation of a WeMo CoffeeMaker device."""
 
     _state_property = "mode"  # Required by AttributeDevice.
+    _attributes: _Attributes  # Required by AttributeDevice.
 
     @property
     def mode(self) -> CoffeeMakerMode:
         """Return the mode of the device."""
-        return CoffeeMakerMode(int(self._attributes.get("Mode", _UNKNOWN)))
+        return CoffeeMakerMode(self._attributes.get("Mode", _UNKNOWN))
 
     @property
     def mode_string(self) -> str:

--- a/pywemo/ouimeaux_device/maker.py
+++ b/pywemo/ouimeaux_device/maker.py
@@ -1,14 +1,24 @@
 """Representation of a WeMo Maker device."""
 from __future__ import annotations
 
+from typing import TypedDict
+
 from .api.attributes import AttributeDevice
 from .api.service import RequiredService
+
+
+class _Attributes(TypedDict, total=False):
+    Switch: int
+    Sensor: int
+    SwitchMode: int
+    SensorPresent: int
 
 
 class Maker(AttributeDevice):
     """Representation of a WeMo Maker device."""
 
     _state_property = "switch_state"  # Required by AttributeDevice.
+    _attributes: _Attributes  # Required by AttributeDevice.
 
     @property
     def _required_services(self) -> list[RequiredService]:
@@ -26,19 +36,19 @@ class Maker(AttributeDevice):
     @property
     def switch_state(self) -> int:
         """Return the state of the switch."""
-        return int(self._attributes["Switch"])
+        return self._attributes["Switch"]
 
     @property
     def sensor_state(self) -> int:
         """Return the state of the sensor."""
-        return int(self._attributes["Sensor"])
+        return self._attributes["Sensor"]
 
     @property
     def switch_mode(self) -> int:
         """Return the switch mode of the sensor."""
-        return int(self._attributes["SwitchMode"])
+        return self._attributes["SwitchMode"]
 
     @property
     def has_sensor(self) -> int:
         """Return whether the device has a sensor."""
-        return int(self._attributes["SensorPresent"])
+        return self._attributes["SensorPresent"]

--- a/tests/ouimeaux_device/test_maker.py
+++ b/tests/ouimeaux_device/test_maker.py
@@ -90,12 +90,53 @@ class Test_Maker:
                 1,
                 0,
             ),
-            # Unexpected State name
+            # Unexpected State name.
             (
                 (
                     "<attribute><name>Unexpected</name><value>ABC</value>"
                     "<prevalue>1</prevalue><ts>1627869840</ts></attribute>"
                 ),
+                1,
+                1,
+                1,
+                0,
+            ),
+            # Invalid state.
+            (
+                (
+                    "<attribute><name>Switch</name><value>0.5</value>"
+                    "<prevalue>1</prevalue><ts>1627869840</ts></attribute>"
+                ),
+                1,
+                1,
+                1,
+                0,
+            ),
+            # Missing value text.
+            (
+                (
+                    "<attribute><name>Switch</name><value/>"
+                    "<prevalue>1</prevalue><ts>1627869840</ts></attribute>"
+                ),
+                1,
+                1,
+                1,
+                0,
+            ),
+            # Missing name text.
+            (
+                (
+                    "<attribute><name/><value>0</value>"
+                    "<prevalue>1</prevalue><ts>1627869840</ts></attribute>"
+                ),
+                1,
+                1,
+                1,
+                0,
+            ),
+            # Missing value.
+            (
+                ("<attribute><name>Switch</name></attribute>"),
                 1,
                 1,
                 1,


### PR DESCRIPTION
## Description:

Add better type checking for Attribute devices. This PR checks the types and names of the attributes before assignment. It also simplifies the individual devices by removing type casting within those classes.

**Related issue (if applicable):** fixes #442 

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] There is no commented out code in this PR.
  - [x] I have read and agree to the [CONTRIBUTING document](
        https://github.com/pywemo/pywemo/blob/master/CONTRIBUTING.md).