### PR TITLE
Pin oss-fuzz Python builder docker image

### DIFF
--- a/.clusterfuzzlite/Dockerfile
+++ b/.clusterfuzzlite/Dockerfile
@@ -1,4 +1,4 @@
-FROM gcr.io/oss-fuzz-base/base-builder-python:v1
+FROM gcr.io/oss-fuzz-base/base-builder-python:v1@sha256:c534d211cc36cc71d8a9d82827aeca4889eb7c422f3568fabaea58f34d004ebc
 RUN apt-get update && \
     apt-get install -y make autoconf automake libtool pip
 COPY . $SRC/pywemo

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,3 +14,9 @@ updates:
     schedule:
       # Check for updates to GitHub Actions every week
       interval: "weekly"
+
+  - package-ecosystem: "docker"
+    directory: "/.clusterfuzzlite/"
+    schedule:
+      # Check for updates to Docker images every month
+      interval: "monthly"


### PR DESCRIPTION
## Description:

Pin the oss-fuzz docker image by sha256 hash. And use dependabot to keep the version updated monthly.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] There is no commented out code in this PR.
  - [x] I have read and agree to the [CONTRIBUTING document](
        https://github.com/pywemo/pywemo/blob/master/CONTRIBUTING.md).