### PR TITLE
Handle invalid value for colortemperature

### DIFF
--- a/pywemo/ouimeaux_device/bridge.py
+++ b/pywemo/ouimeaux_device/bridge.py
@@ -264,7 +264,7 @@ class LinkedDevice:
             temperature = color_temperature[0]
             if temperature <= 0:
                 raise ValueError(
-                    "Invalid value for color temperature: {temperature}"
+                    f"Invalid value for color temperature: {temperature}"
                 )
             self.state["temperature_mireds"] = temperature
             self.state["temperature_kelvin"] = int(1000000 / temperature)

--- a/pywemo/ouimeaux_device/bridge.py
+++ b/pywemo/ouimeaux_device/bridge.py
@@ -262,6 +262,10 @@ class LinkedDevice:
 
         if (color_temperature := status.get("colortemperature")) is not None:
             temperature = color_temperature[0]
+            if temperature <= 0:
+                raise ValueError(
+                    "Invalid value for color temperature: {temperature}"
+                )
             self.state["temperature_mireds"] = temperature
             self.state["temperature_kelvin"] = int(1000000 / temperature)
 

--- a/tests/ouimeaux_device/test_bridge.py
+++ b/tests/ouimeaux_device/test_bridge.py
@@ -224,6 +224,17 @@ def test_bridge_unavailable_light(bridge, light):
             (
                 '<?xml version="1.0" encoding="utf-8"?><StateEvent>'
                 f"<DeviceID>{LIGHT_ID}</DeviceID>"
+                "<CapabilityId>30301</CapabilityId>"
+                "<Value>0:0</Value>"
+                "</StateEvent>"
+            ),
+            False,
+            {},
+        ),
+        (
+            (
+                '<?xml version="1.0" encoding="utf-8"?><StateEvent>'
+                f"<DeviceID>{LIGHT_ID}</DeviceID>"
                 "<CapabilityId>99999</CapabilityId>"
                 "<Value>2700:0</Value>"
                 "</StateEvent>"

--- a/tests/test_registry_notify_fuzz.py
+++ b/tests/test_registry_notify_fuzz.py
@@ -486,6 +486,24 @@ def properties(names=PROPERTY_NAMES, values=PROPERTY_VALUES):
         )
     ],
 )
+@example(
+    name="Bridge",
+    properties=[
+        (
+            ConvertChildrenToText("StatusChange"),
+            [
+                (
+                    "StateEvent",
+                    [
+                        ("Value", "0"),
+                        ("DeviceID", "F0D1B8000001420C"),
+                        ("CapabilityId", "30301"),
+                    ],
+                )
+            ],
+        )
+    ],
+)
 @example(name="CoffeeMaker", properties=[("attributeList", None)])
 @example(name="CoffeeMaker", properties=[("attributeList", "<")])
 @example(


### PR DESCRIPTION
## Description:

Raise ValueError for invalid color temperature values for the Bridge device.

**Related issue (if applicable):** fixes #453

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] There is no commented out code in this PR.
  - [x] I have read and agree to the [CONTRIBUTING document](
        https://github.com/pywemo/pywemo/blob/master/CONTRIBUTING.md).