### PR TITLE
Ensure debug is a keyword arg in discovery

### DIFF
--- a/pywemo/discovery.py
+++ b/pywemo/discovery.py
@@ -43,17 +43,17 @@ def _call_once_per_uuid(
     method(*args, *kwargs)
 
 
-def discover_devices(debug: bool = False, **kwargs: Any) -> list[Device]:
+def discover_devices(*, debug: bool = False, **kwargs: Any) -> list[Device]:
     """Find WeMo devices on the local network."""
     devices = (
-        device_from_uuid_and_location(entry.udn, entry.location, debug)
+        device_from_uuid_and_location(entry.udn, entry.location, debug=debug)
         for entry in ssdp.scan(**kwargs)
     )
     return [d for d in devices if d is not None]
 
 
 def device_from_description(
-    description_url: str, debug: bool = False
+    description_url: str, *, debug: bool = False
 ) -> Device | None:
     """Return object representing WeMo device running at host, else None."""
     try:
@@ -68,11 +68,13 @@ def device_from_description(
         LOG.exception("Failed to parse description %s", description_url)
         return None
 
-    return device_from_uuid_and_location(device.udn, description_url, debug)
+    return device_from_uuid_and_location(
+        device.udn, description_url, debug=debug
+    )
 
 
 def device_from_uuid_and_location(  # noqa: C901
-    uuid: str | None, location: str | None, debug: bool = False
+    uuid: str | None, location: str | None, *, debug: bool = False
 ) -> Device | None:
     """Determine device class based on the device uuid."""
     if not (uuid and location):


### PR DESCRIPTION
## Description:

Prior to #238 the 2nd required position argument to `device_from_description` was`mac`.
https://github.com/pywemo/pywemo/blob/e05aefb0729c99f787b3d9cc060aa7b177238cff/pywemo/discovery.py#L66

In #238 we decided `mac` was deprecated and supplied a default value, allowing clients to omit the argument.
https://github.com/pywemo/pywemo/blob/da5e03af2e4873d16101220f30de2d332b901088/pywemo/discovery.py#L52

Separately, #257 introduced a new debug argument that was positioned after the `mac` argument.
https://github.com/pywemo/pywemo/blob/9c475a23cc9d7c0958525777fcec39b91570c6a1/pywemo/discovery.py#L50

Then #367 removed the `mac` argument to `device_from_description` entirely.
https://github.com/pywemo/pywemo/blob/9eac17ae34eec4dcd6033f24f466677ba1f958cd/pywemo/discovery.py#L55-L57

Prior to #238 clients used to call `device_from_description` like this [example](https://github.com/theyosh/TerrariumPI/blob/79be755b0a0dd3260a6db00b1b5e0535a8dbd1c5/hardware/relay/wemo_relay.py#L23):

```python
pywemo.discovery.device_from_description(f'http://{self.address}:{port}/setup.xml', None)
```

After #367 this causes the client to pass None for the `debug` argument.

This PR attempts to fail safely for clients that expected the `mac` argument to be the 2nd positional argument to `device_from_description`. It also makes it a requirement that the debug argument always be supplied as a keyword argument.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] There is no commented out code in this PR.
  - [x] I have read and agree to the [CONTRIBUTING document](
        https://github.com/pywemo/pywemo/blob/master/CONTRIBUTING.md).