### PR TITLE
Use UPPER_SNAKE_CASE for enum constants

### DIFF
--- a/pywemo/ouimeaux_device/coffeemaker.py
+++ b/pywemo/ouimeaux_device/coffeemaker.py
@@ -17,16 +17,25 @@ class CoffeeMakerMode(IntEnum):
     """Enum to map WeMo modes to human-readable strings."""
 
     _UNKNOWN = _UNKNOWN
-    # pylint: disable=invalid-name
-    Refill = 0  # reservoir empty and carafe not in place
-    PlaceCarafe = 1  # reservoir has water but carafe not present
-    RefillWater = 2  # carafe present but reservoir is empty
-    Ready = 3
-    Brewing = 4
-    Brewed = 5
-    CleaningBrewing = 6
-    CleaningSoaking = 7
-    BrewFailCarafeRemoved = 8
+    # Note: The UpperMixedCase (invalid) names are deprecated.
+    REFILL = 0  # reservoir empty and carafe not in place
+    Refill = 0  # pylint: disable=invalid-name
+    PLACE_CARAFE = 1  # reservoir has water but carafe not present
+    PlaceCarafe = 1  # pylint: disable=invalid-name
+    REFILL_WATER = 2  # carafe present but reservoir is empty
+    RefillWater = 2  # pylint: disable=invalid-name
+    READY = 3
+    Ready = 3  # pylint: disable=invalid-name
+    BREWING = 4
+    Brewing = 4  # pylint: disable=invalid-name
+    BREWED = 5
+    Brewed = 5  # pylint: disable=invalid-name
+    CLEANING_BREWING = 6
+    CleaningBrewing = 6  # pylint: disable=invalid-name
+    CLEANING_SOAKING = 7
+    CleaningSoaking = 7  # pylint: disable=invalid-name
+    BREW_FAILED_CARAFE_REMOVED = 8
+    BrewFailCarafeRemoved = 8  # pylint: disable=invalid-name
 
     @classmethod
     def _missing_(cls, value: Any) -> CoffeeMakerMode:
@@ -34,15 +43,15 @@ class CoffeeMakerMode(IntEnum):
 
 
 MODE_NAMES = {
-    CoffeeMakerMode.Refill: "Refill",
-    CoffeeMakerMode.PlaceCarafe: "PlaceCarafe",
-    CoffeeMakerMode.RefillWater: "RefillWater",
-    CoffeeMakerMode.Ready: "Ready",
-    CoffeeMakerMode.Brewing: "Brewing",
-    CoffeeMakerMode.Brewed: "Brewed",
-    CoffeeMakerMode.CleaningBrewing: "CleaningBrewing",
-    CoffeeMakerMode.CleaningSoaking: "CleaningSoaking",
-    CoffeeMakerMode.BrewFailCarafeRemoved: "BrewFailCarafeRemoved",
+    CoffeeMakerMode.REFILL: "Refill",
+    CoffeeMakerMode.PLACE_CARAFE: "PlaceCarafe",
+    CoffeeMakerMode.REFILL_WATER: "RefillWater",
+    CoffeeMakerMode.READY: "Ready",
+    CoffeeMakerMode.BREWING: "Brewing",
+    CoffeeMakerMode.BREWED: "Brewed",
+    CoffeeMakerMode.CLEANING_BREWING: "CleaningBrewing",
+    CoffeeMakerMode.CLEANING_SOAKING: "CleaningSoaking",
+    CoffeeMakerMode.BREW_FAILED_CARAFE_REMOVED: "BrewFailCarafeRemoved",
 }
 
 
@@ -71,7 +80,7 @@ class CoffeeMaker(AttributeDevice):
         # The base implementation using GetBinaryState doesn't work for
         # CoffeeMaker (always returns 0), so use mode instead.
         # Consider the Coffee Maker to be "on" if it's currently brewing.
-        return int(super().get_state(force_update) == CoffeeMakerMode.Brewing)
+        return int(super().get_state(force_update) == CoffeeMakerMode.BREWING)
 
     def set_state(self, state: int) -> None:
         """Set the state of this device to on or off."""
@@ -80,4 +89,4 @@ class CoffeeMaker(AttributeDevice):
         if state:
             # Coffee Maker always responds with an error if SetBinaryState is
             # called. Use SetAttributes to change the Mode to "Brewing"
-            self._set_attributes(("Mode", CoffeeMakerMode.Brewing))
+            self._set_attributes(("Mode", CoffeeMakerMode.BREWING))

--- a/pywemo/ouimeaux_device/crockpot.py
+++ b/pywemo/ouimeaux_device/crockpot.py
@@ -20,11 +20,15 @@ class CrockPotMode(IntEnum):
     """Modes for the CrockPot."""
 
     _UNKNOWN = _UNKNOWN
-    # pylint: disable=invalid-name
-    Off = 0
-    Warm = 50
-    Low = 51
-    High = 52
+    # Note: The UpperMixedCase (invalid) names are deprecated.
+    OFF = 0
+    Off = 0  # pylint: disable=invalid-name
+    WARM = 50
+    Warm = 50  # pylint: disable=invalid-name
+    LOW = 51
+    Low = 51  # pylint: disable=invalid-name
+    HIGH = 52
+    High = 52  # pylint: disable=invalid-name
 
     @classmethod
     def _missing_(cls, value: Any) -> CrockPotMode:
@@ -32,10 +36,10 @@ class CrockPotMode(IntEnum):
 
 
 MODE_NAMES = {
-    CrockPotMode.Off: "Turned Off",
-    CrockPotMode.Warm: "Warm",
-    CrockPotMode.Low: "Low",
-    CrockPotMode.High: "High",
+    CrockPotMode.OFF: "Turned Off",
+    CrockPotMode.WARM: "Warm",
+    CrockPotMode.LOW: "Low",
+    CrockPotMode.HIGH: "High",
 }
 
 
@@ -133,14 +137,14 @@ class CrockPot(Switch):
         if force_update or self._attributes.get("mode") is None:
             self.update_attributes()
 
-        return int(self.mode != CrockPotMode.Off)
+        return int(self.mode != CrockPotMode.OFF)
 
     def set_state(self, state: int) -> None:
         """Set the state of this device to on or off."""
         if state:
-            self.update_settings(CrockPotMode.High, self.remaining_time)
+            self.update_settings(CrockPotMode.HIGH, self.remaining_time)
         else:
-            self.update_settings(CrockPotMode.Off, 0)
+            self.update_settings(CrockPotMode.OFF, 0)
 
     def update_settings(self, mode: CrockPotMode, time: int) -> None:
         """Update mode and cooking time."""

--- a/pywemo/ouimeaux_device/humidifier.py
+++ b/pywemo/ouimeaux_device/humidifier.py
@@ -15,13 +15,19 @@ class FanMode(IntEnum):
     """Enum to map WeMo FanModes to human-readable strings."""
 
     _UNKNOWN = _UNKNOWN
-    # pylint: disable=invalid-name
-    Off = 0  # Fan and device turned off
-    Minimum = 1
-    Low = 2
-    Medium = 3
-    High = 4
-    Maximum = 5
+    # Note: The UpperMixedCase (invalid) names are deprecated.
+    OFF = 0  # Fan and device turned off
+    Off = 0  # pylint: disable=invalid-name
+    MINIMUM = 1
+    Minimum = 1  # pylint: disable=invalid-name
+    LOW = 3
+    Low = 2  # pylint: disable=invalid-name
+    MEDIUM = 3
+    Medium = 3  # pylint: disable=invalid-name
+    HIGH = 4
+    High = 4  # pylint: disable=invalid-name
+    MAXIMUM = 5
+    Maximum = 5  # pylint: disable=invalid-name
 
     @classmethod
     def _missing_(cls, value: Any) -> FanMode:
@@ -29,12 +35,12 @@ class FanMode(IntEnum):
 
 
 FAN_MODE_NAMES = {
-    FanMode.Off: "Off",
-    FanMode.Minimum: "Minimum",
-    FanMode.Low: "Low",
-    FanMode.Medium: "Medium",
-    FanMode.High: "High",
-    FanMode.Maximum: "Maximum",
+    FanMode.OFF: "Off",
+    FanMode.MINIMUM: "Minimum",
+    FanMode.LOW: "Low",
+    FanMode.MEDIUM: "Medium",
+    FanMode.HIGH: "High",
+    FanMode.MAXIMUM: "Maximum",
 }
 
 
@@ -42,12 +48,17 @@ class DesiredHumidity(IntEnum):
     """Enum to map WeMo DesiredHumidity to human-readable strings."""
 
     _UNKNOWN = _UNKNOWN
-    # pylint: disable=invalid-name
-    FortyFivePercent = 0
-    FiftyPercent = 1
-    FiftyFivePercent = 2
-    SixtyPercent = 3
-    OneHundredPercent = 4  # "Always On" Mode
+    # Note: The UpperMixedCase (invalid) names are deprecated.
+    PERCENT_45 = 0
+    FortyFivePercent = 0  # pylint: disable=invalid-name
+    PERCENT_50 = 1
+    FiftyPercent = 1  # pylint: disable=invalid-name
+    PERCENT_55 = 2
+    FiftyFivePercent = 2  # pylint: disable=invalid-name
+    PERCENT_60 = 3
+    SixtyPercent = 3  # pylint: disable=invalid-name
+    PERCENT_100 = 4  # "Always On" Mode
+    OneHundredPercent = 4  # pylint: disable=invalid-name
 
     @classmethod
     def _missing_(cls, value: Any) -> DesiredHumidity:
@@ -55,27 +66,30 @@ class DesiredHumidity(IntEnum):
 
 
 DESIRED_HUMIDITY_NAMES = {
-    DesiredHumidity.FortyFivePercent: "45",
-    DesiredHumidity.FiftyPercent: "50",
-    DesiredHumidity.FiftyFivePercent: "55",
-    DesiredHumidity.SixtyPercent: "60",
-    DesiredHumidity.OneHundredPercent: "100",
+    DesiredHumidity.PERCENT_45: "45",
+    DesiredHumidity.PERCENT_50: "50",
+    DesiredHumidity.PERCENT_55: "55",
+    DesiredHumidity.PERCENT_60: "60",
+    DesiredHumidity.PERCENT_100: "100",
 }
 
 
 class WaterLevel(IntEnum):
     """Enum to map WeMo WaterLevel to human-readable strings."""
 
-    # pylint: disable=invalid-name
-    Empty = 0
-    Low = 1
-    Good = 2
+    # Note: The UpperMixedCase (invalid) names are deprecated.
+    EMPTY = 0
+    Empty = 0  # pylint: disable=invalid-name
+    LOW = 1
+    Low = 1  # pylint: disable=invalid-name
+    GOOD = 2
+    Good = 2  # pylint: disable=invalid-name
 
 
 WATER_LEVEL_NAMES = {
-    WaterLevel.Empty: "Empty",
-    WaterLevel.Low: "Low",
-    WaterLevel.Good: "Good",
+    WaterLevel.EMPTY: "Empty",
+    WaterLevel.LOW: "Low",
+    WaterLevel.GOOD: "Good",
 }
 
 FILTER_LIFE_MAX = 60480
@@ -131,10 +145,10 @@ class Humidifier(AttributeDevice):
     def water_level(self) -> WaterLevel:
         """Return 0 if water level is Empty, 1 if Low, and 2 if Good."""
         if self._attributes.get("NoWater") == 1:
-            return WaterLevel.Empty
+            return WaterLevel.EMPTY
         if self._attributes.get("WaterAdvise") == 1:
-            return WaterLevel.Low
-        return WaterLevel.Good
+            return WaterLevel.LOW
+        return WaterLevel.GOOD
 
     @property
     def water_level_string(self) -> str:


### PR DESCRIPTION
## Description:

Allow the use of UPPER_SNAKE_CASE names for enum constants for CoffeeMaker, CrockPot, and Humidifier devices. The previous UpperMixedCase names will be deprecated in a future release and are now aliases for the UPPER_SNAKE_CASE names.

https://docs.python.org/3.10/library/enum.html#duplicating-enum-members-and-values

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] There is no commented out code in this PR.
  - [x] I have read and agree to the [CONTRIBUTING document](
        https://github.com/pywemo/pywemo/blob/master/CONTRIBUTING.md).