### PR TITLE
Remove flake8 global ignores

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -25,12 +25,6 @@ max-complexity = 20
 # to work with black
 max-line-length = 79
 
-# B028: Warnings about the warning.warn method.
-# E203: whitespace before ':' (must disable this when using black)
-extend-ignore = B028, E203
-
-# select = B,C,E,F,W,T4,B9
-
 per-file-ignores =
     # don't require function, method, or __init__ docstrings for tests
     tests/*: D102, D103, D107


### PR DESCRIPTION
## Description:

Remove flake8 global ignores. There is no code that matches these ignores.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] There is no commented out code in this PR.
  - [x] I have read and agree to the [CONTRIBUTING document](
        https://github.com/pywemo/pywemo/blob/master/CONTRIBUTING.md).