### PR TITLE
Provide automatic labels for the release changelog

### DIFF
--- a/.github/labler.yml
+++ b/.github/labler.yml
@@ -1,0 +1,7 @@
+# See https://github.com/actions/labeler for examples
+ignore-for-release:
+  - any: ['**']
+    all:
+      - '!pywemo/*'
+      - '!pywemo/ouimeaux_device/*'
+      - '!pywemo/ouimeaux_device/api/*'

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,18 @@
+# https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes#configuration-options 
+changelog:
+  exclude:
+    labels:
+      - ignore-for-release
+  categories:
+    - title: Breaking Changes 🛠
+      labels:
+        - breaking-change
+    - title: What's new 🎉
+      labels:
+        - enhancement
+    - title: Bug Fixes 🕷
+      labels:
+        - bug
+    - title: Other Changes
+      labels:
+        - "*"

--- a/.github/workflows/labler.yml
+++ b/.github/workflows/labler.yml
@@ -1,0 +1,16 @@
+name: "Pull Request Labeler"
+on:
+- pull_request_target
+
+permissions: {}  # No permissions by default. Permissions are added per-job.
+
+jobs:
+  triage:
+    permissions:
+      contents: read
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/labeler@9fcb2c2f5584144ca754f8bfe8c6f81e77753375 # v4.1.0
+      with:
+        dot: true


### PR DESCRIPTION
## Description:

* Label any change that doesn't modify pyWeMo's released code as `ignore-for-release`.
* Create categories for breaking-changes/enhancements/bugs in the release changelog.

## Checklist:
  - [ ] The code change is tested and works locally.
  - [x] There is no commented out code in this PR.
  - [x] I have read and agree to the [CONTRIBUTING document](
        https://github.com/pywemo/pywemo/blob/master/CONTRIBUTING.md).