### PR TITLE
Supply warnings for deprecated bridge Lights/Groups

### DIFF
--- a/pywemo/ouimeaux_device/bridge.py
+++ b/pywemo/ouimeaux_device/bridge.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import io
 import time
+import warnings
 from html import escape
 from typing import Any, Iterable, TypedDict
 
@@ -32,6 +33,15 @@ CAPABILITY_NAME2ID = dict(
 OFF = 0
 ON = 1
 TOGGLE = 2
+
+
+def _warn_rename(old: str, new: str, stacklevel: int = 3) -> None:
+    warnings.warn(
+        f"{old} is deprecated and will be removed in a future release. "
+        f"Use {new} instead",
+        DeprecationWarning,
+        stacklevel=stacklevel,
+    )
 
 
 def limit(value: int, min_val: int, max_val: int) -> int:
@@ -71,6 +81,18 @@ class Bridge(Device):
                 actions=["GetDeviceStatus", "SetDeviceStatus"],
             ),
         ]
+
+    @property
+    def Lights(self) -> dict[str, Light]:  # pylint: disable=invalid-name
+        """Deprecated method for accessing .lights."""
+        _warn_rename("Lights", "lights")
+        return self.lights
+
+    @property
+    def Groups(self) -> dict[str, Group]:  # pylint: disable=invalid-name
+        """Deprecated method for accessing .groups."""
+        _warn_rename("Groups", "groups")
+        return self.groups
 
     def bridge_update(
         self, force_update: bool = True

--- a/tests/ouimeaux_device/test_bridge.py
+++ b/tests/ouimeaux_device/test_bridge.py
@@ -326,3 +326,10 @@ def test_subscription_update(update, expected_updated, expected_state, bridge):
     assert updated == expected_updated
     if updated:
         assert bridge.lights[LIGHT_ID].get_state() == expected_state
+
+
+def test_deprecation_warnings(bridge):
+    with pytest.deprecated_call():
+        assert isinstance(bridge.Lights, dict)
+    with pytest.deprecated_call():
+        assert isinstance(bridge.Groups, dict)


### PR DESCRIPTION
## Description:

Supply an alias for the deprecated Lights/Groups properties of the Bridge class. These were renamed to lights/groups in #432. But it seems we should have provided warnings about these name changes before removing them.

**Related issue (if applicable):**  #432

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests (pytest/vcr) are added for new devices or major features.
  - [x] There is no commented out code in this PR.
  - [x] I have read and agree to the [CONTRIBUTING document](
        https://github.com/pywemo/pywemo/blob/master/CONTRIBUTING.md).