### PR TITLE
Fix missing setup.xml elements

### DIFF
--- a/pywemo/subscribe.py
+++ b/pywemo/subscribe.py
@@ -77,7 +77,7 @@ VIRTUAL_SETUP_XML = f"""<?xml version="1.0"?>
     <manufacturer>pywemo</manufacturer>
     <manufacturerURL>https://github.com/pywemo/pywemo</manufacturerURL>
     <modelDescription>pywemo virtual device</modelDescription>
-    <modelName>LightSwitch</modelName>
+    <modelName>Socket</modelName>
     <modelNumber>1.0</modelNumber>
     <hwVersion>v1</hwVersion>
     <modelURL>http://www.belkin.com/plugin/</modelURL>

--- a/pywemo/subscribe.py
+++ b/pywemo/subscribe.py
@@ -72,7 +72,7 @@ VIRTUAL_SETUP_XML = f"""<?xml version="1.0"?>
     <minor>0</minor>
   </specVersion>
   <device>
-    <deviceType>urn:Belkin:device:switch:1</deviceType>
+    <deviceType>urn:Belkin:device:controllee:1</deviceType>
     <friendlyName>pywemo virtual device</friendlyName>
     <manufacturer>pywemo</manufacturer>
     <manufacturerURL>https://github.com/pywemo/pywemo</manufacturerURL>

--- a/pywemo/subscribe.py
+++ b/pywemo/subscribe.py
@@ -81,7 +81,7 @@ VIRTUAL_SETUP_XML = f"""<?xml version="1.0"?>
     <modelNumber>1.0</modelNumber>
     <hwVersion>v1</hwVersion>
     <modelURL>http://www.belkin.com/plugin/</modelURL>
-    <serialNumber>VirtualDevice</serialNumber>
+    <serialNumber>PyWemoVirtualDevice</serialNumber>
     <firmwareVersion>WeMo_US_2.00.2769.PVT</firmwareVersion>
     <UDN>{VIRTUAL_DEVICE_UDN}</UDN>
     <binaryState>0</binaryState>

--- a/pywemo/subscribe.py
+++ b/pywemo/subscribe.py
@@ -82,6 +82,7 @@ VIRTUAL_SETUP_XML = f"""<?xml version="1.0"?>
     <hwVersion>v1</hwVersion>
     <modelURL>http://www.belkin.com/plugin/</modelURL>
     <serialNumber>VirtualDevice</serialNumber>
+    <firmwareVersion>WeMo_US_2.00.2769.PVT</firmwareVersion>
     <UDN>{VIRTUAL_DEVICE_UDN}</UDN>
     <binaryState>0</binaryState>
     <serviceList>
@@ -93,6 +94,7 @@ VIRTUAL_SETUP_XML = f"""<?xml version="1.0"?>
         <SCPDURL>/eventservice.xml</SCPDURL>
       </service>
     </serviceList>
+  <presentationURL>/pluginpres.html</presentationURL>
 </device>
 </root>"""
 


### PR DESCRIPTION
## Description:

Make the setup.xml more closely match the values that are expected by WeMo devices.

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests (pytest/vcr) are added for new devices or major features.
  - [x] There is no commented out code in this PR.
  - [x] I have read and agree to the [CONTRIBUTING document](
        https://github.com/pywemo/pywemo/blob/master/CONTRIBUTING.md).