### PR TITLE
Update deptry config after update to 0.12.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,7 +69,9 @@ poetry = ">=1.2.0"
 
 [tool.deptry]
 extend_exclude = ["scripts"]
-ignore_missing = [
+
+[tool.deptry.per_rule_ignores]
+DEP001 = [
   # These are created by generateDS.
   "StringIO",
   "generatedsnamespaces",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,7 +72,7 @@ extend_exclude = ["scripts"]
 
 [tool.deptry.per_rule_ignores]
 DEP001 = [
-  # These are created by generateDS.
+  # Ignore missing dependencies created by generateDS.
   "StringIO",
   "generatedsnamespaces",
   "generatedscollector",


### PR DESCRIPTION
## Description:

Update Deptry config to use `DEP001` in place of `ignore_missing`. As mentioned in the [0.12.0 release notes](https://github.com/fpgmaas/deptry/releases/tag/0.12.0), `ignore_missing` will be removed in a future release.

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests (pytest/vcr) are added for new devices or major features.
  - [x] There is no commented out code in this PR.
  - [x] I have read and agree to the [CONTRIBUTING document](
        https://github.com/pywemo/pywemo/blob/master/CONTRIBUTING.md).