### PR TITLE
Send byebye SSDP message when exiting

### DIFF
--- a/tests/test_ssdp.py
+++ b/tests/test_ssdp.py
@@ -127,10 +127,11 @@ def test_discovery_responder_notify(
     mock_socket, mock_interface_addresses, mock_get_callback_address
 ):
     resp = ssdp.DiscoveryResponder(callback_port=MOCK_CALLBACK_PORT)
-    resp.send_notify()
+    resp.send_notify("ssdp:alive")
     params = {
         "callback": MOCK_CALLBACK_ADDRESS,
         "nls": resp._nls_uuid,
+        "nts": "ssdp:alive",
     }
     mock_socket.sendto.assert_called_with(
         (ssdp.SSDP_NOTIFY % params).encode("utf-8"),


### PR DESCRIPTION
## Description:

Notify WeMo devices when the pyWeMo DescoveryResponder is stopping. Clients should stop the DescoveryResponder before stopping the SubscriptionRegistry.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests (pytest/vcr) are added for new devices or major features.
  - [x] There is no commented out code in this PR.
  - [x] I have read and agree to the [CONTRIBUTING document](
        https://github.com/pywemo/pywemo/blob/master/CONTRIBUTING.md).