### PR TITLE
F7C030 non-longpress support

### DIFF
--- a/pywemo/discovery.py
+++ b/pywemo/discovery.py
@@ -87,6 +87,8 @@ def device_from_uuid_and_location(  # noqa: C901
         if uuid.startswith("uuid:Socket"):
             return Switch(location)
         if uuid.startswith("uuid:Lightswitch-1_0"):
+            if not location.endswith("/setup.xml"):
+                return LightSwitch(location)
             return LightSwitchLongPress(location)
         if uuid.startswith("uuid:Lightswitch-2_0"):
             return LightSwitchLongPress(location)

--- a/tests/ouimeaux_device/test_lightswitch.py
+++ b/tests/ouimeaux_device/test_lightswitch.py
@@ -61,3 +61,15 @@ class Test_WLS0403(Base, long_press_helpers.TestLongPress):
             )
 
     device = lightswitch  # for TestLongPress
+
+
+class Test_NoLongPress(Base):
+    """Tests for the WeMo WeMo_WW_2.00.2263.PVT firmware."""
+
+    @pytest.fixture
+    def lightswitch(self, vcr):
+        with vcr.use_cassette("WeMo_WW_2.00.2263.PVT"):
+            return device_from_uuid_and_location(
+                "uuid:Lightswitch-1_0-SERIALNUMBER",
+                "http://192.168.1.100:49153/Lightsetup.xml",
+            )

--- a/tests/vcr/tests.ouimeaux_device.test_lightswitch/Test_NoLongPress.test_turn_off.yaml
+++ b/tests/vcr/tests.ouimeaux_device.test_lightswitch/Test_NoLongPress.test_turn_off.yaml
@@ -1,0 +1,89 @@
+interactions:
+- request:
+    body: '<?xml version="1.0" encoding="utf-8"?>
+
+      <s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/" s:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/">
+
+      <s:Body>
+
+      <u:SetBinaryState xmlns:u="urn:Belkin:service:basicevent:1">
+
+      <BinaryState>0</BinaryState>
+
+      </u:SetBinaryState>
+
+      </s:Body>
+
+      </s:Envelope>'
+    headers:
+      Content-Type:
+      - text/xml
+      SOAPACTION:
+      - '"urn:Belkin:service:basicevent:1#SetBinaryState"'
+    method: POST
+    uri: http://192.168.1.100:49153/upnp/control/basicevent1
+  response:
+    body:
+      string: "<s:Envelope xmlns:s=\"http://schemas.xmlsoap.org/soap/envelope/\" s:encodingStyle=\"http://schemas.xmlsoap.org/soap/encoding/\"><s:Body>\n<u:SetBinaryStateResponse
+        xmlns:u=\"urn:Belkin:service:basicevent:1\">\r\n<BinaryState>0</BinaryState>\r\n</u:SetBinaryStateResponse>\r\n</s:Body>
+        </s:Envelope>"
+    headers:
+      CONTENT-LENGTH:
+      - '285'
+      CONTENT-TYPE:
+      - text/xml; charset="utf-8"
+      DATE:
+      - Sat, 01 Jan 2000 05:14:04 GMT
+      EXT:
+      - ''
+      SERVER:
+      - Linux/2.6.21, UPnP/1.0, Portable SDK for UPnP devices/1.6.18
+      X-User-Agent:
+      - redsonic
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '<?xml version="1.0" encoding="utf-8"?>
+
+      <s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/" s:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/">
+
+      <s:Body>
+
+      <u:GetBinaryState xmlns:u="urn:Belkin:service:basicevent:1">
+
+
+      </u:GetBinaryState>
+
+      </s:Body>
+
+      </s:Envelope>'
+    headers:
+      Content-Type:
+      - text/xml
+      SOAPACTION:
+      - '"urn:Belkin:service:basicevent:1#GetBinaryState"'
+    method: POST
+    uri: http://192.168.1.100:49153/upnp/control/basicevent1
+  response:
+    body:
+      string: "<s:Envelope xmlns:s=\"http://schemas.xmlsoap.org/soap/envelope/\" s:encodingStyle=\"http://schemas.xmlsoap.org/soap/encoding/\"><s:Body>\n<u:GetBinaryStateResponse
+        xmlns:u=\"urn:Belkin:service:basicevent:1\">\r\n<BinaryState>0</BinaryState>\r\n</u:GetBinaryStateResponse>\r\n</s:Body>
+        </s:Envelope>"
+    headers:
+      CONTENT-LENGTH:
+      - '285'
+      CONTENT-TYPE:
+      - text/xml; charset="utf-8"
+      DATE:
+      - Sat, 01 Jan 2000 05:14:04 GMT
+      EXT:
+      - ''
+      SERVER:
+      - Linux/2.6.21, UPnP/1.0, Portable SDK for UPnP devices/1.6.18
+      X-User-Agent:
+      - redsonic
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/vcr/tests.ouimeaux_device.test_lightswitch/Test_NoLongPress.test_turn_on.yaml
+++ b/tests/vcr/tests.ouimeaux_device.test_lightswitch/Test_NoLongPress.test_turn_on.yaml
@@ -1,0 +1,89 @@
+interactions:
+- request:
+    body: '<?xml version="1.0" encoding="utf-8"?>
+
+      <s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/" s:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/">
+
+      <s:Body>
+
+      <u:SetBinaryState xmlns:u="urn:Belkin:service:basicevent:1">
+
+      <BinaryState>1</BinaryState>
+
+      </u:SetBinaryState>
+
+      </s:Body>
+
+      </s:Envelope>'
+    headers:
+      Content-Type:
+      - text/xml
+      SOAPACTION:
+      - '"urn:Belkin:service:basicevent:1#SetBinaryState"'
+    method: POST
+    uri: http://192.168.1.100:49153/upnp/control/basicevent1
+  response:
+    body:
+      string: "<s:Envelope xmlns:s=\"http://schemas.xmlsoap.org/soap/envelope/\" s:encodingStyle=\"http://schemas.xmlsoap.org/soap/encoding/\"><s:Body>\n<u:SetBinaryStateResponse
+        xmlns:u=\"urn:Belkin:service:basicevent:1\">\r\n<BinaryState>Error</BinaryState>\r\n</u:SetBinaryStateResponse>\r\n</s:Body>
+        </s:Envelope>"
+    headers:
+      CONTENT-LENGTH:
+      - '289'
+      CONTENT-TYPE:
+      - text/xml; charset="utf-8"
+      DATE:
+      - Sat, 01 Jan 2000 05:14:04 GMT
+      EXT:
+      - ''
+      SERVER:
+      - Linux/2.6.21, UPnP/1.0, Portable SDK for UPnP devices/1.6.18
+      X-User-Agent:
+      - redsonic
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '<?xml version="1.0" encoding="utf-8"?>
+
+      <s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/" s:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/">
+
+      <s:Body>
+
+      <u:GetBinaryState xmlns:u="urn:Belkin:service:basicevent:1">
+
+
+      </u:GetBinaryState>
+
+      </s:Body>
+
+      </s:Envelope>'
+    headers:
+      Content-Type:
+      - text/xml
+      SOAPACTION:
+      - '"urn:Belkin:service:basicevent:1#GetBinaryState"'
+    method: POST
+    uri: http://192.168.1.100:49153/upnp/control/basicevent1
+  response:
+    body:
+      string: "<s:Envelope xmlns:s=\"http://schemas.xmlsoap.org/soap/envelope/\" s:encodingStyle=\"http://schemas.xmlsoap.org/soap/encoding/\"><s:Body>\n<u:GetBinaryStateResponse
+        xmlns:u=\"urn:Belkin:service:basicevent:1\">\r\n<BinaryState>1</BinaryState>\r\n</u:GetBinaryStateResponse>\r\n</s:Body>
+        </s:Envelope>"
+    headers:
+      CONTENT-LENGTH:
+      - '285'
+      CONTENT-TYPE:
+      - text/xml; charset="utf-8"
+      DATE:
+      - Sat, 01 Jan 2000 05:14:04 GMT
+      EXT:
+      - ''
+      SERVER:
+      - Linux/2.6.21, UPnP/1.0, Portable SDK for UPnP devices/1.6.18
+      X-User-Agent:
+      - redsonic
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/vcr/tests.ouimeaux_device.test_lightswitch/WeMo_WW_2.00.2263.PVT.yaml
+++ b/tests/vcr/tests.ouimeaux_device.test_lightswitch/WeMo_WW_2.00.2263.PVT.yaml
@@ -1,0 +1,554 @@
+interactions:
+- request:
+    body: null
+    headers: {}
+    method: GET
+    uri: http://192.168.1.100:49153/Lightsetup.xml
+  response:
+    body:
+      string: "<?xml version=\"1.0\"?>\n<root xmlns=\"urn:Belkin:device-1-0\">\n  <specVersion>\n
+        \   <major>1</major>\n    <minor>0</minor>\n  </specVersion>\n  <device>\n<deviceType>urn:Belkin:device:lightswitch:1</deviceType>\n<friendlyName>WeMo
+        Device</friendlyName>\n    <manufacturer>Belkin International Inc.</manufacturer>\n
+        \   <manufacturerURL>http://www.belkin.com</manufacturerURL>\n    <modelDescription>Belkin
+        Plugin Socket 1.0</modelDescription>\n    <modelName>LightSwitch</modelName>\n
+        \   <modelNumber>1.0</modelNumber>\n    <modelURL>http://www.belkin.com/plugin/</modelURL>\n<serialNumber>SERIALNUMBER</serialNumber>\n<UDN>uuid:Lightswitch-1_0-SERIALNUMBER</UDN>\n
+        \   <UPC>123456789</UPC>\n    <iconList> \n      <icon> \n        <mimetype>jpg</mimetype>
+        \n        <width>100</width> \n        <height>100</height> \n        <depth>100</depth>
+        \n         <url>icon.jpg</url> \n      </icon> \n    </iconList>\n    <serviceList>\n
+        \     <service>\n        <serviceType>urn:Belkin:service:WiFiSetup:1</serviceType>\n
+        \       <serviceId>urn:Belkin:serviceId:WiFiSetup1</serviceId>\n        <controlURL>/upnp/control/WiFiSetup1</controlURL>\n
+        \       <eventSubURL>/upnp/event/WiFiSetup1</eventSubURL>\n        <SCPDURL>/setupservice.xml</SCPDURL>\n
+        \     </service>\n      <service>\n        <serviceType>urn:Belkin:service:timesync:1</serviceType>\n
+        \       <serviceId>urn:Belkin:serviceId:timesync1</serviceId>\n        <controlURL>/upnp/control/timesync1</controlURL>\n
+        \       <eventSubURL>/upnp/event/timesync1</eventSubURL>\n        <SCPDURL>/timesyncservice.xml</SCPDURL>\n
+        \     </service>\n      <service>\n        <serviceType>urn:Belkin:service:basicevent:1</serviceType>\n
+        \       <serviceId>urn:Belkin:serviceId:basicevent1</serviceId>\n        <controlURL>/upnp/control/basicevent1</controlURL>\n
+        \       <eventSubURL>/upnp/event/basicevent1</eventSubURL>\n        <SCPDURL>/eventservice.xml</SCPDURL>\n
+        \     </service>\n      <service>\n        <serviceType>urn:Belkin:service:firmwareupdate:1</serviceType>\n
+        \       <serviceId>urn:Belkin:serviceId:firmwareupdate1</serviceId>\n        <controlURL>/upnp/control/firmwareupdate1</controlURL>\n
+        \       <eventSubURL>/upnp/event/firmwareupdate1</eventSubURL>\n        <SCPDURL>/firmwareupdate.xml</SCPDURL>\n
+        \     </service>\n      <service>\n        <serviceType>urn:Belkin:service:rules:1</serviceType>\n
+        \       <serviceId>urn:Belkin:serviceId:rules1</serviceId>\n        <controlURL>/upnp/control/rules1</controlURL>\n
+        \       <eventSubURL>/upnp/event/rules1</eventSubURL>\n        <SCPDURL>/rulesservice.xml</SCPDURL>\n
+        \     </service>\n\t  \n      <service>\n        <serviceType>urn:Belkin:service:metainfo:1</serviceType>\n
+        \       <serviceId>urn:Belkin:serviceId:metainfo1</serviceId>\n        <controlURL>/upnp/control/metainfo1</controlURL>\n
+        \       <eventSubURL>/upnp/event/metainfo1</eventSubURL>\n        <SCPDURL>/metainfoservice.xml</SCPDURL>\n
+        \     </service>\n\n      <service>\n        <serviceType>urn:Belkin:service:remoteaccess:1</serviceType>\n
+        \       <serviceId>urn:Belkin:serviceId:remoteaccess1</serviceId>\n        <controlURL>/upnp/control/remoteaccess1</controlURL>\n
+        \       <eventSubURL>/upnp/event/remoteaccess1</eventSubURL>\n        <SCPDURL>/remoteaccess.xml</SCPDURL>\n
+        \     </service>\n\t   \n\n    </serviceList>\n   <presentationURL>/pluginpres.html</presentationURL>\n</device>\n</root>\n"
+    headers:
+      CONNECTION:
+      - close
+      CONTENT-LENGTH:
+      - '3292'
+      CONTENT-TYPE:
+      - text/xml
+      DATE:
+      - Sat, 01 Jan 2000 05:14:03 GMT
+      LAST-MODIFIED:
+      - Sat, 01 Jan 2000 00:00:30 GMT
+      SERVER:
+      - Linux/2.6.21, UPnP/1.0, Portable SDK for UPnP devices/1.6.18
+      X-User-Agent:
+      - redsonic
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers: {}
+    method: GET
+    uri: http://192.168.1.100:49153/setupservice.xml
+  response:
+    body:
+      string: "\uFEFF<?xml version=\"1.0\"?>\n<scpd xmlns=\"urn:Belkin:service-1-0\">\n\n
+        \ <specVersion>\n    <major>1</major>\n    <minor>0</minor>\n  </specVersion>\n
+        \ \n<actionList>\n    <action>\n        <name>GetApList</name>\n        <argumentList>\n
+        \        <argument>\n         <retval/>\n         <name>ApList</name>\n         <relatedStateVariable>ApList</relatedStateVariable>\n
+        \        <direction>out</direction>\n         </argument>\n         </argumentList>\n
+        \   </action>\n    \n    <action>\n      <name>ConnectHomeNetwork</name>    \n
+        \     <argumentList>\n\n         <argument>\n           <retval />\n           <name>ssid</name>\n
+        \          <relatedStateVariable>ssid</relatedStateVariable>\n           <direction>in</direction>\n
+        \         </argument>\n          \n          <argument>\n         <retval
+        />\n        <name>auth</name>\n        <relatedStateVariable>auth</relatedStateVariable>\n
+        \       <direction>in</direction>\n        </argument>\n\n       <argument>\n
+        \            <retval />\n             <name>password</name>\n             <relatedStateVariable>password</relatedStateVariable>\n
+        \            <direction>in</direction>\n       </argument>\n\n       <argument>\n
+        \            <retval />\n             <name>encrypt</name>\n             <relatedStateVariable>encrypt</relatedStateVariable>\n
+        \            <direction>in</direction>\n       </argument>\n\n       <argument>\n
+        \            <retval />\n             <name>channel</name>\n             <relatedStateVariable>channel</relatedStateVariable>\n
+        \            <direction>in</direction>\n       </argument>\n       \n      </argumentList>\n
+        \         \n    </action>\n    \n        <action>\n          <name>GetNetworkStatus</name>
+        \   \n          <argumentList>\n             <argument>\n               <retval
+        />\n               <name>NetworkStatus</name>\n               <relatedStateVariable>NetworkStatus</relatedStateVariable>\n
+        \              <direction>out</direction>\n              </argument>\n          </argumentList>\n
+        \   </action>\n\n    <action>\n          <name>CloseSetup</name>    \n          <argumentList>\n
+        \         </argumentList>\n    </action>\n\t\n\t<action>\n          <name>StopPair</name>
+        \   \n          <argumentList>\n          </argumentList>\n    </action>\n
+        \   \n</actionList>\n\n  <serviceStateTable>\n  \n  <!-- connected, connecting,
+        disconnected, time out error -->\n  <stateVariable sendEvents=\"yes\">\n      <name>NetworkStatus</name>\n
+        \     <dataType>string</dataType>\n      <defaultValue>Disconnected</defaultValue>\n
+        \   </stateVariable>\n  <stateVariable sendEvents=\"yes\">\t\n\t<name>PairingStatus</name>\n
+        \     <dataType>string</dataType>\n      <defaultValue>Connecting</defaultValue>\n
+        \   </stateVariable>\n    \n    <stateVariable sendEvents=\"yes\">\n      <name>ApList</name>\n
+        \     <dataType>string</dataType>\n      <defaultValue></defaultValue>\n    </stateVariable>\n\t\n
+        \ </serviceStateTable>\n  \n  </scpd>\n"
+    headers:
+      CONNECTION:
+      - close
+      CONTENT-LENGTH:
+      - '2806'
+      CONTENT-TYPE:
+      - text/xml
+      DATE:
+      - Sat, 01 Jan 2000 05:14:03 GMT
+      LAST-MODIFIED:
+      - Sat, 01 Jan 2000 00:00:30 GMT
+      SERVER:
+      - Linux/2.6.21, UPnP/1.0, Portable SDK for UPnP devices/1.6.18
+      X-User-Agent:
+      - redsonic
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers: {}
+    method: GET
+    uri: http://192.168.1.100:49153/timesyncservice.xml
+  response:
+    body:
+      string: "\uFEFF<?xml version=\"1.0\"?>\n<scpd xmlns=\"urn:Belkin:service-1-0\">\n
+        \ <specVersion>\n    <major>1</major>\n    <minor>0</minor>\n  </specVersion>\n
+        \ \n  <actionList>  \n    <action>    \n      <name>TimeSync</name>    \n
+        \     <argumentList>\n         <argument>\n           <retval />\n\t\t   <!--
+        UTC value, long -->\n           <name>UTC</name>\n           <relatedStateVariable>UTC</relatedStateVariable>\n
+        \          <direction>in</direction>\n          </argument>\n         <argument>\n
+        \          <retval />\n           <name>TimeZone</name>\n           <relatedStateVariable>TimeZone</relatedStateVariable>\n
+        \          <direction>in</direction>\n          </argument>\n         <argument>\n
+        \          <retval />\n           <name>dst</name>\n           <relatedStateVariable>dst</relatedStateVariable>\n
+        \          <direction>in</direction>\n          </argument>\n\t\t  <argument>\n
+        \          <retval />\n           <name>DstSupported</name>\n           <relatedStateVariable>DstSupported</relatedStateVariable>\n
+        \          <direction>in</direction>\n          </argument>\n      </argumentList>
+        \     \n    </action>\n\t\n    <action>\n      <name>GetTime</name> \n    </action>\n
+        \   \n</actionList>\n\n  <serviceStateTable>\n    \n        <stateVariable
+        sendEvents=\"no\">\n        <!-- UTC seconds-->\n      <name>UTC</name>\n
+        \     <dataType>long</dataType>\n      <defaultValue>0</defaultValue>\n    </stateVariable>\n
+        \   \n    \n    <stateVariable sendEvents=\"no\">\n      <name>TimeZone</name>\n
+        \     <dataType>int</dataType>\n      <defaultValue>0</defaultValue>\n    </stateVariable>\n\t\n\t<stateVariable
+        sendEvents=\"no\">\n      <name>dst</name>\n      <dataType>Boolean</dataType>\n
+        \     <defaultValue>0</defaultValue>\n    </stateVariable>\n    \n  </serviceStateTable>\n
+        \ \n  </scpd>"
+    headers:
+      CONNECTION:
+      - close
+      CONTENT-LENGTH:
+      - '1718'
+      CONTENT-TYPE:
+      - text/xml
+      DATE:
+      - Sat, 01 Jan 2000 05:14:03 GMT
+      LAST-MODIFIED:
+      - Sat, 01 Jan 2000 00:00:30 GMT
+      SERVER:
+      - Linux/2.6.21, UPnP/1.0, Portable SDK for UPnP devices/1.6.18
+      X-User-Agent:
+      - redsonic
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers: {}
+    method: GET
+    uri: http://192.168.1.100:49153/eventservice.xml
+  response:
+    body:
+      string: "\uFEFF<?xml version=\"1.0\"?>\r\n<scpd xmlns=\"urn:Belkin:service-1-0\">\r\n\r\n
+        \ <specVersion>\r\n    <major>1</major>\r\n    <minor>0</minor>\r\n  </specVersion>\r\n
+        \ \r\n  <actionList>\r\n  \r\n    <action>\r\n      <name>SetBinaryState</name>\r\n
+        \     <argumentList>\r\n         <argument>\r\n           <retval />\r\n           <name>BinaryState</name>\r\n
+        \          <relatedStateVariable>BinaryState</relatedStateVariable>\r\n           <direction>in</direction>\r\n
+        \         </argument>\r\n      </argumentList>\r\n    </action>\r\n\r\n    <action>\r\n
+        \     <name>SetLogLevelOption</name>\r\n      <argumentList>\r\n         <argument>\r\n
+        \          <retval />\r\n           <name>Level</name>\r\n           <relatedStateVariable>Level</relatedStateVariable>\r\n
+        \          <direction>in</direction>\r\n          </argument>\r\n         <argument>\r\n
+        \          <retval />\r\n           <name>Option</name>\r\n           <relatedStateVariable>Option</relatedStateVariable>\r\n
+        \          <direction>in</direction>\r\n          </argument>\r\n      </argumentList>\r\n
+        \   </action>\r\n\r\n    <action>\r\n      <name>GetFriendlyName</name>\r\n
+        \ \t  <argumentList>\r\n      <argument>\r\n      <retval />\r\n      <name>FriendlyName</name>\r\n
+        \     <relatedStateVariable>FriendlyName</relatedStateVariable>\r\n      <direction>in</direction>\r\n
+        \      </argument>\r\n       </argumentList>\r\n    </action>\r\n    <action>\r\n
+        \     <name>ReSetup</name>\r\n      <argumentList>\r\n         <argument>\r\n
+        \          <retval />\r\n           <name>Reset</name>\r\n           <relatedStateVariable>Reset</relatedStateVariable>\r\n
+        \          <direction>in</direction>\r\n          </argument>\r\n      </argumentList>\r\n
+        \   </action>\r\n\t<action>\r\n      <name>SetHomeId</name>\r\n      <argumentList>\r\n
+        \        <argument>\r\n           <retval />\r\n           <name>SetHomeId</name>\r\n
+        \          <relatedStateVariable>HomeId</relatedStateVariable>\r\n           <direction>in</direction>\r\n
+        \         </argument>\r\n      </argumentList>\r\n    </action>\r\n\t<action>\r\n
+        \     <name>GetHomeId</name>\r\n    </action>\r\n\t<action>\r\n      <name>SetDeviceId</name>\r\n
+        \     <argumentList>\r\n         <argument>\r\n           <retval />\r\n           <name>SetDeviceId</name>\r\n
+        \          <relatedStateVariable>DeviceId</relatedStateVariable>\r\n           <direction>in</direction>\r\n
+        \         </argument>\r\n      </argumentList>\r\n    </action>\r\n    <action>\r\n
+        \     <name>GetDeviceId</name>\r\n    </action>\r\n\t <action>\r\n      <name>GetMacAddr</name>\r\n
+        \   </action>\r\n    <action>\r\n      <name>GetSerialNo</name>\r\n    </action>\r\n
+        \   <action>\r\n      <name>GetPluginUDN</name>\r\n    </action>\r\n    <action>\r\n
+        \     <name>GetSmartDevInfo</name>\r\n    </action>\r\n    <action>\r\n      <name>ShareHWInfo</name>\r\n
+        \     <argumentList>\r\n         <argument>\r\n           <retval />\r\n           <name>Mac</name>\r\n
+        \          <relatedStateVariable>Mac</relatedStateVariable>\r\n           <direction>in</direction>\r\n
+        \         </argument>\r\n         <argument>\r\n           <retval />\r\n
+        \          <name>Serial</name>\r\n           <relatedStateVariable>Serial</relatedStateVariable>\r\n
+        \          <direction>in</direction>\r\n          </argument>\r\n         <argument>\r\n
+        \          <retval />\r\n           <name>Udn</name>\r\n           <relatedStateVariable>Udn</relatedStateVariable>\r\n
+        \          <direction>in</direction>\r\n          </argument>\r\n         <argument>\r\n
+        \          <retval />\r\n           <name>RestoreState</name>\r\n           <relatedStateVariable>RestoreState</relatedStateVariable>\r\n
+        \          <direction>in</direction>\r\n          </argument>\r\n         <argument>\r\n
+        \          <retval />\r\n           <name>HomeId</name>\r\n           <relatedStateVariable>HomeId</relatedStateVariable>\r\n
+        \          <direction>in</direction>\r\n          </argument>\r\n         <argument>\r\n
+        \          <retval />\r\n           <name>PluginKey</name>\r\n           <relatedStateVariable>PluginKey</relatedStateVariable>\r\n
+        \          <direction>in</direction>\r\n          </argument>\r\n      </argumentList>\r\n
+        \   </action>\r\n    <action>\r\n      <name>ChangeFriendlyName</name>\r\n
+        \     <argumentList>\r\n         <argument>\r\n           <retval />\r\n           <name>FriendlyName</name>\r\n
+        \          <relatedStateVariable>FriendlyName</relatedStateVariable>\r\n           <direction>in</direction>\r\n
+        \         </argument>\r\n      </argumentList>\r\n    </action>\r\n\t\r\n
+        \   <action>\r\n      <name>SetSmartDevInfo</name>\r\n      <argumentList>\r\n
+        \        <argument>\r\n           <retval />\r\n           <name>SmartDevURL</name>\r\n
+        \          <relatedStateVariable>SmartDevURL</relatedStateVariable>\r\n           <direction>in</direction>\r\n
+        \         </argument>\r\n      </argumentList>\r\n    </action>\r\n\t<action>\r\n
+        \     <name>GetRuleOverrideStatus</name>\r\n      <argumentList>\r\n         <argument>\r\n
+        \          <retval />\r\n           <name>RuleOverrideStatus</name>\r\n           <relatedStateVariable>RuleOverrideStatus</relatedStateVariable>\r\n
+        \          <direction>in</direction>\r\n          </argument>\r\n      </argumentList>\r\n
+        \   </action>\r\n\r\n\t<action>\r\n      <name>GetDeviceIcon</name>\r\n      <argumentList>\r\n
+        \        <argument>\r\n           <retval />\r\n           <name>DeviceIcon</name>\r\n
+        \          <relatedStateVariable>DeviceIcon</relatedStateVariable>\r\n           <direction>in</direction>\r\n
+        \         </argument>\r\n      </argumentList>\r\n    </action>\r\n\r\n\t<action>\r\n
+        \     <name>GetIconURL</name>\r\n      <argumentList>\r\n      <argument>\r\n
+        \     <retval />\r\n\t<name>URL</name>\r\n\t<relatedStateVariable>URL</relatedStateVariable>\r\n\t<direction>out</direction>\r\n\t</argument>\r\n
+        \     </argumentList>\r\n    </action>\r\n\t\r\n\t<action>\r\n      <name>GetLogFileURL</name>\r\n
+        \     <argumentList>\r\n      <argument>\r\n      <retval />\r\n\t<name>LOGURL</name>\r\n\t<relatedStateVariable>LOGURL</relatedStateVariable>\r\n\t<direction>out</direction>\r\n\t</argument>\r\n
+        \     </argumentList>\r\n    </action>\r\n\r\n\t<action>\r\n      <name>ChangeDeviceIcon</name>\r\n
+        \     <argumentList>\r\n         <argument>\r\n           <retval />\r\n           <name>PictureSize</name>\r\n
+        \          <relatedStateVariable>PictureSize</relatedStateVariable>\r\n           <direction>in</direction>\r\n
+        \         </argument>\r\n\t\t  <argument>\r\n           <retval />\r\n           <name>PictureHeight</name>\r\n
+        \          <relatedStateVariable>PictureWidth</relatedStateVariable>\r\n           <direction>in</direction>\r\n
+        \         </argument>\r\n\t\t  \r\n\t\t  <argument>\r\n           <retval
+        />\r\n           <name>PictureColorDeep</name>\r\n           <relatedStateVariable>PictureColorDeep</relatedStateVariable>\r\n
+        \          <direction>in</direction>\r\n          </argument>\r\n      </argumentList>\r\n
+        \   </action>\r\n  \r\n    <action>\r\n    <name>GetBinaryState</name>\r\n
+        \   <argumentList>\r\n    <argument>\r\n    <retval/>\r\n    <name>BinaryState</name>\r\n
+        \   <relatedStateVariable>BinaryState</relatedStateVariable>\r\n    <direction>out</direction>\r\n
+        \   </argument>\r\n    </argumentList>\r\n    </action>\r\n\t\r\n\t<action>\r\n
+        \     <name>SetMultiState</name>\r\n      <argumentList>\r\n         <argument>\r\n
+        \          <retval />\r\n           <name>state</name>\r\n           <relatedStateVariable>StateList</relatedStateVariable>\r\n
+        \          <direction>in</direction>\r\n          </argument>\r\n\r\n\t\t
+        \ <argument>\r\n           <retval />\r\n           <name>state</name>\r\n
+        \          <relatedStateVariable>StateList</relatedStateVariable>\r\n           <direction>in</direction>\r\n
+        \         </argument>\t\t  \r\n\t\r\n         <argument>\r\n           <retval
+        />\r\n           <name>state</name>\r\n           <relatedStateVariable>StateList</relatedStateVariable>\r\n
+        \          <direction>in</direction>\r\n          </argument>\r\n\t\t  \r\n
+        \     </argumentList>\r\n    </action>\r\n    \r\n    <action>\r\n      <name>GetWatchdogFile</name>\r\n
+        \     <argumentList>\r\n        <argument>\r\n          <retval />\r\n            <name>WDFile</name>\r\n
+        \           <relatedStateVariable>WDFile</relatedStateVariable>\r\n            <direction>out</direction>\r\n
+        \       </argument>\r\n      </argumentList>\r\n    </action>\r\n\r\n    <action>\r\n
+        \     <name>GetSignalStrength</name>\r\n      <argumentList>\r\n        <argument>\r\n
+        \         <retval />\r\n            <name>SignalStrength</name>\r\n            <relatedStateVariable>SignalStrength</relatedStateVariable>\r\n
+        \           <direction>in</direction>\r\n        </argument>\r\n      </argumentList>\r\n
+        \   </action>\r\n\r\n    <action>\r\n      <name>SetServerEnvironment</name>\r\n
+        \     <argumentList>\r\n        <argument>\r\n          <retval />\r\n            <name>ServerEnvironment</name>\r\n
+        \           <relatedStateVariable>ServerEnvironment</relatedStateVariable>\r\n
+        \           <direction>in</direction>\r\n        </argument>\r\n        <argument>\r\n
+        \         <retval />\r\n            <name>TurnServerEnvironment</name>\r\n
+        \           <relatedStateVariable>TurnServerEnvironment</relatedStateVariable>\r\n
+        \           <direction>in</direction>\r\n        </argument>\r\n\t<argument>\r\n
+        \         <retval />\r\n            <name>ServerEnvironmentType</name>\r\n
+        \           <relatedStateVariable>ServerEnvironmentType</relatedStateVariable>\r\n
+        \           <direction>in</direction>\r\n        </argument>\r\n      </argumentList>\r\n
+        \   </action>\r\n\r\n    <action>\r\n      <name>GetServerEnvironment</name>\r\n
+        \     <argumentList>\r\n        <argument>\r\n          <retval/>\r\n            <name>ServerEnvironment</name>\r\n
+        \           <relatedStateVariable>ServerEnvironment</relatedStateVariable>\r\n
+        \           <direction>out</direction>\r\n        </argument>\r\n        <argument>\r\n
+        \         <retval/>\r\n            <name>TurnServerEnvironment</name>\r\n
+        \           <relatedStateVariable>TurnServerEnvironment</relatedStateVariable>\r\n
+        \           <direction>out</direction>\r\n        </argument>\r\n        <argument>\r\n
+        \         <retval/>\r\n            <name>ServerEnvironmentType</name>\r\n
+        \           <relatedStateVariable>ServerEnvironmentType</relatedStateVariable>\r\n
+        \           <direction>out</direction>\r\n        </argument>\r\n      </argumentList>\r\n
+        \   </action>\r\n\r\n</actionList>\r\n\r\n  <serviceStateTable>\r\n  \r\n
+        \   <stateVariable sendEvents=\"yes\">\r\n      <name>BinaryState</name>\r\n
+        \     <dataType>Boolean</dataType>\r\n      <defaultValue>0</defaultValue>\r\n
+        \   </stateVariable>\r\n\t\r\n    <stateVariable sendEvents=\"yes\">\r\n      <name>level</name>\r\n
+        \     <dataType>string</dataType>\r\n      <defaultValue>0</defaultValue>\r\n
+        \   </stateVariable>\r\n\r\n    <stateVariable sendEvents=\"yes\">\r\n      <name>option</name>\r\n
+        \     <dataType>string</dataType>\r\n      <defaultValue>0</defaultValue>\r\n
+        \   </stateVariable>\r\n\r\n\t<stateVariable sendEvents=\"yes\">\r\n      <name>Reset</name>\r\n
+        \     <dataType>string</dataType>\r\n      <defaultValue>0</defaultValue>\r\n\r\n
+        \   </stateVariable>\r\n\t<stateVariable sendEvents=\"yes\">\r\n      <name>FriendlyName</name>\r\n
+        \     <dataType>string</dataType>\r\n      <defaultValue>0</defaultValue>\r\n
+        \   </stateVariable>\r\n\t\r\n\t<stateVariable sendEvents=\"yes\">\r\n      <name>HomeId</name>\r\n
+        \     <dataType>string</dataType>\r\n      <defaultValue>0</defaultValue>\r\n
+        \   </stateVariable>\r\n\t<stateVariable sendEvents=\"yes\">\r\n      <name>DeviceId</name>\r\n
+        \     <dataType>string</dataType>\r\n      <defaultValue>0</defaultValue>\r\n
+        \   </stateVariable>\r\n\t<stateVariable sendEvents=\"yes\">\r\n      <name>SmartDevInfo</name>\r\n
+        \     <dataType>string</dataType>\r\n      <defaultValue>0</defaultValue>\r\n
+        \   </stateVariable>\r\n\t<stateVariable sendEvents=\"yes\">\r\n      <name>MacAddr</name>\r\n
+        \     <dataType>string</dataType>\r\n      <defaultValue>0</defaultValue>\r\n
+        \   </stateVariable>\r\n\t<stateVariable sendEvents=\"yes\">\r\n      <name>SerialNo</name>\r\n
+        \     <dataType>string</dataType>\r\n      <defaultValue>0</defaultValue>\r\n
+        \   </stateVariable>\r\n\r\n\t<stateVariable sendEvents=\"yes\">\r\n      <name>PluginUDN</name>\r\n
+        \     <dataType>string</dataType>\r\n      <defaultValue>0</defaultValue>\r\n
+        \   </stateVariable>\r\n\t<stateVariable sendEvents=\"yes\">\r\n      <name>DeviceIcon</name>\r\n
+        \     <dataType>string</dataType>\r\n      <defaultValue>0</defaultValue>\r\n
+        \   </stateVariable>\r\n  \r\n    <stateVariable sendEvents=\"No\">\r\n      <name>StateList</name>\r\n
+        \     <dataType>list</dataType>\r\n      <defaultValue>0</defaultValue>\r\n
+        \   </stateVariable>\r\n  <stateVariable sendEvents=\"yes\">\r\n      <name>URL</name>\r\n\t
+        \ <dataType>string</dataType>\r\n\t  <defaultValue>0</defaultValue>\r\n  </stateVariable>\r\n\t\t\t\t\t\t\r\n\t<stateVariable
+        sendEvents=\"yes\">\r\n      <name>RuleOverrideStatus</name>\r\n\t  <dataType>string</dataType>\r\n\t
+        \ <defaultValue>0</defaultValue>\r\n  </stateVariable>\r\n\t\t\t\t\t\t\r\n
+        \   <stateVariable sendEvents=\"yes\">\r\n      <name>WDFile</name>\r\n      <dataType>string</dataType>\r\n
+        \     <defaultValue>0</defaultValue>\r\n    </stateVariable>\r\n\r\n    <stateVariable
+        sendEvents=\"yes\">\r\n      <name>SignalStrength</name>\r\n      <dataType>string</dataType>\r\n
+        \     <defaultValue>0</defaultValue>\r\n    </stateVariable>\r\n\r\n    <stateVariable
+        sendEvents=\"yes\">\r\n      <name>ServerEnvironment</name>\r\n      <dataType>string</dataType>\r\n
+        \     <defaultValue>0</defaultValue>\r\n    </stateVariable>\r\n\r\n    <stateVariable
+        sendEvents=\"yes\">\r\n      <name>TurnServerEnvironment</name>\r\n      <dataType>string</dataType>\r\n
+        \     <defaultValue>0</defaultValue>\r\n    </stateVariable>\r\n\r\n  <stateVariable
+        sendEvents=\"yes\">\r\n      <name>ServerEnvironmentType</name>\r\n      <dataType>string</dataType>\r\n
+        \     <defaultValue>0</defaultValue>\r\n    </stateVariable>\r\n\r\n  </serviceStateTable>\r\n
+        \ \r\n  </scpd>\r\n"
+    headers:
+      CONNECTION:
+      - close
+      CONTENT-LENGTH:
+      - '13082'
+      CONTENT-TYPE:
+      - text/xml
+      DATE:
+      - Sat, 01 Jan 2000 05:14:03 GMT
+      LAST-MODIFIED:
+      - Sat, 01 Jan 2000 00:00:29 GMT
+      SERVER:
+      - Linux/2.6.21, UPnP/1.0, Portable SDK for UPnP devices/1.6.18
+      X-User-Agent:
+      - redsonic
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers: {}
+    method: GET
+    uri: http://192.168.1.100:49153/firmwareupdate.xml
+  response:
+    body:
+      string: "<?xml version=\"1.0\" ?> \n<scpd xmlns=\"urn:Belkin:service-1-0\">\n<specVersion>\n<major>1</major>
+        \n<minor>0</minor> \n</specVersion>\n<actionList>\n<action>\n<name>UpdateFirmware</name>
+        \n<argumentList>\n<argument>\n<retval /> \n<name>NewFirmwareVersion</name>
+        \n<relatedStateVariable>NewFirmwareVersion</relatedStateVariable> \n<direction>in</direction>
+        \n</argument>\n<argument>\n<retval /> \n<name>ReleaseDate</name> \n<relatedStateVariable>ReleaseDate</relatedStateVariable>
+        \n<direction>in</direction> \n</argument>\n<argument>\n<retval /> \n<name>URL</name>
+        \n<relatedStateVariable>URL</relatedStateVariable> \n<direction>in</direction>
+        \n</argument>\n<argument>\n<retval /> \n<name>Signature</name> \n<relatedStateVariable>Signature</relatedStateVariable>
+        \n<direction>in</direction> \n</argument>\n<argument>\n<retval /> \n<name>DownloadStartTime</name>\n<relatedStateVariable>DownloadStartTime</relatedStateVariable>\n<direction>in</direction>\n</argument>\n</argumentList>\n</action>\n<action>\n<name>GetFirmwareVersion</name>\n<retval
+        />\n<argumentList>\n    <argument>\n<name>FirmwareVersion</name> \n<relatedStateVariable>FirmwareVersion</relatedStateVariable>
+        \n<direction>out</direction> \n         </argument>\n</argumentList>\n</action>\n</actionList>\n<serviceStateTable>\n\n<stateVariable
+        sendEvents=\"yes\">\n<name>FirmwareVersion</name>\n<dataType>string</dataType>\n<defaultValue>0</defaultValue>\n</stateVariable>\n\n<stateVariable
+        sendEvents=\"yes\">\n<name>FirmwareUpdateStatus</name>\n<dataType>string</dataType>\n<defaultValue>0</defaultValue>\n</stateVariable>\n</serviceStateTable>\n</scpd>\n"
+    headers:
+      CONNECTION:
+      - close
+      CONTENT-LENGTH:
+      - '1547'
+      CONTENT-TYPE:
+      - text/xml
+      DATE:
+      - Sat, 01 Jan 2000 05:14:03 GMT
+      LAST-MODIFIED:
+      - Sat, 01 Jan 2000 00:00:29 GMT
+      SERVER:
+      - Linux/2.6.21, UPnP/1.0, Portable SDK for UPnP devices/1.6.18
+      X-User-Agent:
+      - redsonic
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers: {}
+    method: GET
+    uri: http://192.168.1.100:49153/rulesservice.xml
+  response:
+    body:
+      string: "\uFEFF<?xml version=\"1.0\"?>\n<scpd xmlns=\"urn:Belkin:service-1-0\">\n\n
+        \ <specVersion>\n    <major>1</major>\n    <minor>0</minor>\n  </specVersion>\n
+        \ \n<actionList>\n    <action>\n          <name>UpdateWeeklyCalendar</name>
+        \  \n\t\t  <argumentList>\n\t        <argument>\n                <retval />\n<!--
+        entire day's timers list: \nNumberOfTimers|time,action,[deviceUDN;deviceUDN;...]|time,action,[deviceUDN;deviceUDN...]|time,action
+        \n -->\t\t\t\t\n<!--time, seconds from 00:00 am within 24 hours. action: 0x00
+        (OFF/NO detection), 0x01: (ON/Detection)--> \n<!--PLEASE note that, for simpler
+        timer stored on socket, deviceUDN is NULL-->\n                <name>Mon</name>\n
+        \               <relatedStateVariable>Mon</relatedStateVariable>\n                <direction>in</direction>\n
+        \           </argument>\n\t        <argument>\n                <retval />\n
+        \               <name>Tues</name>\n                <relatedStateVariable>Tues</relatedStateVariable>\n
+        \               <direction>in</direction>\n            </argument>\n\t        <argument>\n
+        \               <retval />\n                <name>Wed</name>\n                <relatedStateVariable>Wed</relatedStateVariable>\n
+        \               <direction>in</direction>\n            </argument>\n\t        <argument>\n
+        \               <retval />\n                <name>Thurs</name>\n                <relatedStateVariable>Thurs</relatedStateVariable>\n
+        \               <direction>in</direction>\n            </argument>\n\t        <argument>\n
+        \               <retval />\n                <name>Fri</name>\n                <relatedStateVariable>Fri</relatedStateVariable>\n
+        \               <direction>in</direction>\n            </argument>\n\t        <argument>\n
+        \               <retval />\n                <name>Sat</name>\n                <relatedStateVariable>Sat</relatedStateVariable>\n
+        \               <direction>in</direction>\n            </argument>\n\t        <argument>\n
+        \               <retval />\n                <name>Sun</name>\n                <relatedStateVariable>Sun</relatedStateVariable>\n
+        \               <direction>in</direction>\n            </argument>\n\n          </argumentList>\n
+        \   </action>\n\n    <action>\n          <name>EditWeeklycalendar</name>    \n
+        \         <argumentList>\n           <argument>\n                <retval />\n<!--
+        0x00: disbale; 0x01: enable; 0x02: remove-->\n<!--- Disable will disable entire
+        week schedule, now only remove will be applied \nsince app will manage all
+        rules and store on device on other way \n-->\n                <name>action</name>\n
+        \               <relatedStateVariable>action</relatedStateVariable>\n                <direction>in</direction>\n
+        \         </argument>\n          </argumentList>\n    </action>\n\n    \n
+        \   <!--Should create detailed low level protocol-->\n    <action>\n          <name>GetRulesDBPath</name>
+        \   \n          <argumentList>\n\t  <argument>\n           <retval />\n           <name>RulesDBPath</name>\n
+        \          <relatedStateVariable>RulesDBPath</relatedStateVariable>\n           <direction>out</direction>\n
+        \         </argument>\n          </argumentList>\n    </action>\n\n<action>\n
+        <name>SetRulesDBVersion</name>    \n          <argumentList>\n\t  <argument>\n
+        \          <retval />\n           <name>RulesDBVersion</name>\n           <relatedStateVariable>RulesDBVersion</relatedStateVariable>\n
+        \          <direction>in</direction>\n          </argument>\n          </argumentList>\n
+        \   </action>\n\n<action>\n\t  <name>GetRulesDBVersion</name>    \n\t  <argumentList>\n\t
+        \ <argument>\n           <retval />\n           <name>RulesDBVersion</name>\n
+        \          <relatedStateVariable>RulesDBVersion</relatedStateVariable>\n           <direction>out</direction>\n
+        \         </argument>\n          </argumentList>\n    </action>\n\t\n\t\n</actionList>\n\n
+        \ <serviceStateTable>\n  \n  <!-- connected, connecting, disconnected, time
+        out error -->\n  <stateVariable sendEvents=\"no\">\n      <name>RulesDBPath</name>\n
+        \     <dataType>string</dataType>\n      <defaultValue>/rules.db</defaultValue>\n
+        \   </stateVariable>\n\t\n\t  <stateVariable sendEvents=\"no\">\n      <name>RulesDBVersion</name>\n
+        \     <dataType>string</dataType>\n      <defaultValue></defaultValue>\n    </stateVariable>\n\t\n
+        \ <stateVariable sendEvents=\"no\">\t\n\t<name>Mon</name>\n      <dataType>string</dataType>\n
+        \     <defaultValue></defaultValue>\n    </stateVariable>\n    \n    <stateVariable
+        sendEvents=\"no\">\n      <name>Wed</name>\n      <dataType>string</dataType>\n
+        \     <defaultValue></defaultValue>\n    </stateVariable>\n\t\n\t<stateVariable
+        sendEvents=\"no\">\n      <name>Thurs</name>\n      <dataType>Thurs</dataType>\n
+        \     <defaultValue></defaultValue>\n    </stateVariable>\n\t\n\t<stateVariable
+        sendEvents=\"no\">\n      <name>Fri</name>\n      <dataType>Fri</dataType>\n
+        \     <defaultValue></defaultValue>\n    </stateVariable>\t\n\n\t<stateVariable
+        sendEvents=\"no\">\n      <name>Sat</name>\n      <dataType>Sat</dataType>\n
+        \     <defaultValue></defaultValue>\n    </stateVariable>\n\t\n\t<stateVariable
+        sendEvents=\"no\">\n      <name>Sun</name>\n      <dataType>Sun</dataType>\n
+        \     <defaultValue></defaultValue>\n    </stateVariable>\n\t\n\t</serviceStateTable>\n
+        \ \n  </scpd>\n"
+    headers:
+      CONNECTION:
+      - close
+      CONTENT-LENGTH:
+      - '4999'
+      CONTENT-TYPE:
+      - text/xml
+      DATE:
+      - Sat, 01 Jan 2000 05:14:03 GMT
+      LAST-MODIFIED:
+      - Sat, 01 Jan 2000 00:00:30 GMT
+      SERVER:
+      - Linux/2.6.21, UPnP/1.0, Portable SDK for UPnP devices/1.6.18
+      X-User-Agent:
+      - redsonic
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers: {}
+    method: GET
+    uri: http://192.168.1.100:49153/metainfoservice.xml
+  response:
+    body:
+      string: "\uFEFF<?xml version=\"1.0\"?>\n<scpd xmlns=\"urn:Belkin:service-1-0\">\n\n
+        \ <specVersion>\n    <major>1</major>\n    <minor>0</minor>\n  </specVersion>\n
+        \ \n  <actionList>\n  \n    <action>\n      <name>GetMetaInfo</name>\n      <argumentList>\n
+        \t<retval />\n           <name>GetMetaInfo</name>\n           <relatedStateVariable>MetaInfo</relatedStateVariable>\n
+        \          <direction>in</direction>\n      </argumentList>\n    </action>\n\n
+        \   \n</actionList>\n\n  <serviceStateTable>\n  \n    <stateVariable sendEvents=\"yes\">\n
+        \     <name>MetaInfo</name>\n      <dataType>string</dataType>\n      <defaultValue>0</defaultValue>\n
+        \   </stateVariable>\n\n  </serviceStateTable>\n  \n  </scpd>\n"
+    headers:
+      CONNECTION:
+      - close
+      CONTENT-LENGTH:
+      - '652'
+      CONTENT-TYPE:
+      - text/xml
+      DATE:
+      - Sat, 01 Jan 2000 05:14:04 GMT
+      LAST-MODIFIED:
+      - Sat, 01 Jan 2000 00:00:30 GMT
+      SERVER:
+      - Linux/2.6.21, UPnP/1.0, Portable SDK for UPnP devices/1.6.18
+      X-User-Agent:
+      - redsonic
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers: {}
+    method: GET
+    uri: http://192.168.1.100:49153/remoteaccess.xml
+  response:
+    body:
+      string: "<?xml version=\"1.0\"?>\n<scpd xmlns=\"urn:Belkin:service-1-0\">\n
+        \ <specVersion>\n    <major>1</major>\n    <minor>0</minor>\n  </specVersion>\n
+        \ \n  <actionList>  \n    <action>\n      <name>RemoteAccess</name>\n      <argumentList>\n
+        \        <argument>\n           <retval />\n           <name>DeviceId</name>\n
+        \          <relatedStateVariable>DeviceId</relatedStateVariable>\n           <direction>in</direction>\n
+        \         </argument>\n\t\t  <argument>\n           <retval />\n           <name>dst</name>\n
+        \          <relatedStateVariable>dst</relatedStateVariable>\n           <direction>in</direction>\n
+        \         </argument>\n\t  <argument>\n           <retval />\n           <name>HomeId</name>\n
+        \          <relatedStateVariable>HomeId</relatedStateVariable>\n           <direction>in</direction>\n
+        \         </argument>\n\t  <argument>\n           <retval />\n           <name>DeviceName</name>\n
+        \          <relatedStateVariable>DeviceName</relatedStateVariable>\n           <direction>in</direction>\n
+        \         </argument>\n\t  <argument>\n           <retval />\n           <name>MacAddr</name>\n
+        \          <relatedStateVariable>MacAddr</relatedStateVariable>\n           <direction>in</direction>\n
+        \         </argument>\n\t<argument>\n\t\t<retval />\n\t\t<name>pluginprivateKey</name>\n\t\t<relatedStateVariable>pluginprivateKey</relatedStateVariable>\n\t\t<direction>in</direction>\n\t</argument>\n\t<argument>\n\t\t<retval
+        />\n\t\t<name>smartprivateKey</name>\n\t\t<relatedStateVariable>smartprivateKey</relatedStateVariable>\n\t\t<direction>in</direction>\n\t</argument>\n\t<argument>\n\t<retval
+        />\n\t<name>smartUniqueId</name>\n\t<relatedStateVariable>smartUniqueId</relatedStateVariable>\n\t<direction>in</direction>\n\t</argument>\t
+        \t  \n\t<argument>\n\t<retval />\n\t<name>numSmartDev</name>\n\t<relatedStateVariable>numSmartDev</relatedStateVariable>\n\t<direction>in</direction>\n\t</argument>\t
+        \t  \n </argumentList>\n </action>\n\t\n    \n</actionList>\n\n  <serviceStateTable>\n
+        \   \n        <stateVariable sendEvents=\"yes\">\n        <!-- DEV ID -->\n
+        \     <name>homeId</name>\n      <dataType>string</dataType>\n      <defaultValue>0</defaultValue>\n
+        \   </stateVariable>\n\t<stateVariable sendEvents=\"yes\">\n      <name>\"pluginprivateKey\"</name>\n
+        \     <dataType>string</dataType>\n      <defaultValue>0</defaultValue>\n
+        \   </stateVariable>\n    <stateVariable sendEvents=\"yes\">\n      <name>\"smartprivateKey\"</name>\n
+        \     <dataType>string</dataType>\n      <defaultValue>0</defaultValue>\n
+        \   </stateVariable>\n\t<stateVariable sendEvents=\"yes\">\n      <name>statusCode</name>\n
+        \     <dataType>string</dataType>\n      <defaultValue>0</defaultValue>\n
+        \   </stateVariable>\n\t<stateVariable sendEvents=\"yes\">\n      <name>resultCode</name>\n
+        \     <dataType>string</dataType>\n      <defaultValue>0</defaultValue>\n
+        \   </stateVariable>\n\t<stateVariable sendEvents=\"yes\">\n      <name>description</name>\n
+        \     <dataType>string</dataType>\n      <defaultValue>0</defaultValue>\n
+        \   </stateVariable>\n\t<stateVariable sendEvents=\"yes\">\n      <name>smartUniqueId</name>\n
+        \     <dataType>string</dataType>\n      <defaultValue>0</defaultValue>\n
+        \   </stateVariable>\n\t<stateVariable sendEvents=\"yes\">\n      <name>smartDeviceDescription</name>\n
+        \     <dataType>string</dataType>\n      <defaultValue>0</defaultValue>\n
+        \   </stateVariable>\n    <stateVariable sendEvents=\"yes\">\n\t\t<name>pluginprivateKey</name>\n\t\t<dataType>string</dataType>\n\t\t<defaultValue>0</defaultValue>\n\t</stateVariable>\n\t<stateVariable
+        sendEvents=\"yes\">\n\t\t<name>smartprivateKey</name>\n\t\t<dataType>string</dataType>\n\t\t<defaultValue>0</defaultValue>\n\t</stateVariable>\n\t<stateVariable
+        sendEvents=\"yes\">\n\t\t<name>numSmartDev</name>\n\t\t<dataType>string</dataType>\n\t\t<defaultValue>0</defaultValue>\n\t</stateVariable>\n
+        \ </serviceStateTable>\n  \n  </scpd>\n"
+    headers:
+      CONNECTION:
+      - close
+      CONTENT-LENGTH:
+      - '3673'
+      CONTENT-TYPE:
+      - text/xml
+      DATE:
+      - Sat, 01 Jan 2000 05:14:04 GMT
+      LAST-MODIFIED:
+      - Sat, 01 Jan 2000 00:00:30 GMT
+      SERVER:
+      - Linux/2.6.21, UPnP/1.0, Portable SDK for UPnP devices/1.6.18
+      X-User-Agent:
+      - redsonic
+    status:
+      code: 200
+      message: OK
+version: 1


### PR DESCRIPTION
## Description:

Adds support for older F7C030 models that do not support the long-press feature. The device description XML for these devices is hosted at `/Lightsetup.xml` instead of the `/setup.xml` as used on the newer firmware versions.

Many thanks to [@xraive for this contribution](https://github.com/pywemo/pywemo/issues/517#issuecomment-1657339240)! 

**Related issue (if applicable):**
- fixes #517
- fixes #353

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests (pytest/vcr) are added for new devices or major features.
  - [x] There is no commented out code in this PR.
  - [x] I have read and agree to the [CONTRIBUTING document](
        https://github.com/pywemo/pywemo/blob/master/CONTRIBUTING.md).