### PR TITLE
RulesDbError should be a PyWeMoException

### DIFF
--- a/pywemo/exceptions.py
+++ b/pywemo/exceptions.py
@@ -78,7 +78,7 @@ class HTTPNotOkException(HTTPException):
     """Raised when a non-200 status is returned."""
 
 
-class RulesDbError(Exception):
+class RulesDbError(PyWeMoException):
     """Base class for errors related to the Rules database."""
 
 


### PR DESCRIPTION
## Description:

RulesDbError should be a PyWeMoException. Home Assistant is now only checking for PyWeMoException after https://github.com/home-assistant/core/pull/56972. This matches the what was intended to have happened in #278.

- https://github.com/home-assistant/core/blob/f0640fc057ff8f200eb35dd6c57388432e2c33ed/homeassistant/components/wemo/wemo_device.py#L162
- https://github.com/home-assistant/core/blob/f0640fc057ff8f200eb35dd6c57388432e2c33ed/homeassistant/components/wemo/__init__.py#L183

**Related issue (if applicable):** #277

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests (pytest/vcr) are added for new devices or major features.
  - [x] There is no commented out code in this PR.
  - [x] I have read and agree to the [CONTRIBUTING document](
        https://github.com/pywemo/pywemo/blob/master/CONTRIBUTING.md).