### PR TITLE
Resolve all environment variables for sigstore input

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -101,7 +101,7 @@ jobs:
       - name: Sign the release
         uses: sigstore/gh-action-sigstore-python@1e232a0c9f448840dce4eb982e4a0a7f50fee0bf # v2.0.0
         with:
-          inputs: ./${DIST_ARTIFACT}/* ./hashes/*
+          inputs: ./${{env.DIST_ARTIFACT}}/* ./hashes/*
           upload-signing-artifacts: true
 
   assets:


### PR DESCRIPTION
## Description:

Aimed at fixing the publish workflow failures that occurred after #528 (https://github.com/pywemo/pywemo/actions/runs/5799020094). The `inputs` parameter no longer performs shell environment variable expansions in version 2.0.0.

https://github.com/sigstore/gh-action-sigstore-python/issues/74

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests (pytest/vcr) are added for new devices or major features.
  - [x] There is no commented out code in this PR.
  - [x] I have read and agree to the [CONTRIBUTING document](
        https://github.com/pywemo/pywemo/blob/master/CONTRIBUTING.md).