### PR TITLE
Subscriptions support multiple devices per IP address

### DIFF
--- a/pywemo/subscribe.py
+++ b/pywemo/subscribe.py
@@ -588,14 +588,11 @@ class SubscriptionRegistry:  # pylint: disable=too-many-instance-attributes
 
         with self._event_thread_cond:
             # Remove any events, callbacks, and the device itself
-            if device in self._callbacks:
-                del self._callbacks[device]
-            if device in self._subscriptions:
-                subscriptions = self._subscriptions[device]
-                del self._subscriptions[device]
-                _cancel_events(self._sched, subscriptions)
-                for subscription in subscriptions:
-                    del self._subscription_paths[subscription.path]
+            self._callbacks.pop(device, None)
+            subscriptions = self._subscriptions.pop(device, [])
+            _cancel_events(self._sched, subscriptions)
+            for subscription in subscriptions:
+                del self._subscription_paths[subscription.path]
             self._event_thread_cond.notify()
 
     def _resubscribe(self, subscription: Subscription, retry: int = 0) -> None:

--- a/pywemo/subscribe.py
+++ b/pywemo/subscribe.py
@@ -40,6 +40,7 @@ import sched
 import secrets
 import threading
 import time
+import warnings
 from collections.abc import Iterable, MutableMapping
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from typing import Any, Callable
@@ -753,3 +754,14 @@ class SubscriptionRegistry:  # pylint: disable=too-many-instance-attributes
                 while not self._exiting and self._sched.empty():
                     self._event_thread_cond.wait(10)
             self._sched.run()
+
+    @property
+    def devices(self) -> dict[str, Device]:
+        """Deprecated mapping of IP address to device."""
+        warnings.warn(
+            "The devices dict is deprecated "
+            "and will be removed in a future release.",
+            DeprecationWarning,
+            stacklevel=1,
+        )
+        return {device.host: device for device in self._subscriptions}

--- a/pywemo/subscribe.py
+++ b/pywemo/subscribe.py
@@ -408,6 +408,12 @@ class RequestHandler(BaseHTTPRequestHandler):
         """Handle subscription responses received from devices."""
         sender_ip, _ = self.client_address
         outer = self.server.outer
+        # Security consideration: Given that the subscription paths are
+        # randomized, I considered removing the host/IP check below. However,
+        # since these requests are not encrypted, it is possible for someone
+        # to observe the random URL path. I therefore have kept the host/IP
+        # check as a defense-in-depth strategy for preventing the device state
+        # from being changed by someone who could observe the http requests.
         if (
             # pylint: disable=protected-access
             subscription := outer._subscription_paths.get(self.path)

--- a/pywemo/subscribe.py
+++ b/pywemo/subscribe.py
@@ -183,7 +183,7 @@ class Subscription:
         self.device = device
         self.callback_port = callback_port
         self.service_name = service_name
-        self.path = f"/{secrets.token_urlsafe(24)}"
+        self.path = f"/sub/{service_name}/{secrets.token_urlsafe(24)}"
 
     def __repr__(self) -> str:
         """Return a string representation of the Subscription."""

--- a/tests/ouimeaux_device/test_dimmer.py
+++ b/tests/ouimeaux_device/test_dimmer.py
@@ -73,6 +73,7 @@ class Test_PVT_RTOS_Dimmer_v2(Base):
     @pytest.mark.vcr()
     def test_is_subscribed(self, dimmer, subscription_registry):
         subscription_registry.register(dimmer)
+        path = list(subscription_registry.subscription_paths.keys())[0]
 
         # Wait for registry to be ready to make sure the Dimmer device has
         # been registered.
@@ -90,7 +91,7 @@ class Test_PVT_RTOS_Dimmer_v2(Base):
             dimmer,
             EVENT_TYPE_BINARY_STATE,
             "1",  # Dimmer is On.
-            "/sub/basicevent",
+            path,
         )
         assert dimmer.get_state() == 1
         assert subscription_registry.is_subscribed(dimmer) is False
@@ -100,7 +101,7 @@ class Test_PVT_RTOS_Dimmer_v2(Base):
             dimmer,
             EVENT_TYPE_BINARY_STATE,
             "0",  # Dimmer is Off.
-            "/sub/basicevent",
+            path,
         )
         assert dimmer.get_state() == 0
         assert subscription_registry.is_subscribed(dimmer)

--- a/tests/ouimeaux_device/test_dimmer.py
+++ b/tests/ouimeaux_device/test_dimmer.py
@@ -73,7 +73,7 @@ class Test_PVT_RTOS_Dimmer_v2(Base):
     @pytest.mark.vcr()
     def test_is_subscribed(self, dimmer, subscription_registry):
         subscription_registry.register(dimmer)
-        path = list(subscription_registry.subscription_paths.keys())[0]
+        path = list(subscription_registry._subscription_paths)[0]
 
         # Wait for registry to be ready to make sure the Dimmer device has
         # been registered.

--- a/tests/test_registry_notify_fuzz.py
+++ b/tests/test_registry_notify_fuzz.py
@@ -532,7 +532,7 @@ def test_notify(name, properties):
     device = DEVICES[name]
     REGISTRY.register(device)
     REGISTRY.on(device, None, lambda d, t, v: d.subscription_update(t, v))
-    path = list(REGISTRY.subscription_paths.keys())[0]
+    path = list(REGISTRY._subscription_paths)[0]
     try:
         response = requests.request(
             "NOTIFY",

--- a/tests/test_registry_notify_fuzz.py
+++ b/tests/test_registry_notify_fuzz.py
@@ -532,10 +532,11 @@ def test_notify(name, properties):
     device = DEVICES[name]
     REGISTRY.register(device)
     REGISTRY.on(device, None, lambda d, t, v: d.subscription_update(t, v))
+    path = list(REGISTRY.subscription_paths.keys())[0]
     try:
         response = requests.request(
             "NOTIFY",
-            f"http://127.0.0.1:{REGISTRY.port}/sub/basicevent",
+            f"http://127.0.0.1:{REGISTRY.port}{path}",
             data=toXml(properties),
         )
         assert response.status_code == 200

--- a/tests/test_subscribe.py
+++ b/tests/test_subscribe.py
@@ -40,7 +40,7 @@ class Test_RequestHandler:
             subscribe.SubscriptionRegistry, instance=True
         )
         obj._subscriptions = {}
-        obj.subscription_paths = {}
+        obj._subscription_paths = {}
         return obj
 
     @pytest.fixture
@@ -102,7 +102,7 @@ class Test_RequestHandler:
             subscribe.Subscription, instance=True
         )
         subscription.device = mock_light_switch
-        outer.subscription_paths["/path"] = subscription
+        outer._subscription_paths["/path"] = subscription
         response = requests.request(
             "NOTIFY",
             f"{server_url}/path",
@@ -416,7 +416,7 @@ class Test_SubscriptionRegistry:
 
         device._state = 1
         assert subscription_registry.is_subscribed(device) is False
-        paths = list(subscription_registry.subscription_paths.keys())
+        paths = list(subscription_registry._subscription_paths)
         assert len(paths) == 2
         subscription_registry.event(device, "", "", path=paths[0])
         assert subscription_registry.is_subscribed(device) is False

--- a/tests/test_subscribe.py
+++ b/tests/test_subscribe.py
@@ -483,3 +483,8 @@ class Test_SubscriptionRegistry:
 
         with pytest.raises(requests.ConnectionError):
             requests.request("NOTIFY", f"http://127.0.0.1:{port}/", timeout=5)
+
+    def test_deprecations(self):
+        registry = subscribe.SubscriptionRegistry(requested_port=0)
+        with pytest.deprecated_call():
+            registry.devices

--- a/tests/test_subscribe.py
+++ b/tests/test_subscribe.py
@@ -39,7 +39,7 @@ class Test_RequestHandler:
         obj = mock.create_autospec(
             subscribe.SubscriptionRegistry, instance=True
         )
-        obj.devices = {}
+        obj._subscriptions = {}
         obj.subscription_paths = {}
         return obj
 
@@ -144,7 +144,8 @@ class Test_RequestHandler:
         self, outer, server_address, server_url, mock_light_switch
     ):
         """POST (LongPress) for known device delivers the appropriate event."""
-        outer.devices[server_address] = mock_light_switch
+        mock_light_switch.host = server_address
+        outer._subscriptions[mock_light_switch] = []
         action = '"urn:Belkin:service:basicevent:1#SetBinaryState"'
         response = requests.post(
             f"{server_url}/upnp/control/basicevent1",
@@ -425,7 +426,7 @@ class Test_SubscriptionRegistry:
         assert subscription_registry.is_subscribed(device) is False
         subscription_registry.event(device, "", "", path="invalid_path")
 
-        assert subscription_registry.devices["192.168.1.100"] == device
+        assert device in subscription_registry._subscriptions
 
         subscription_registry.unregister(device)
 


### PR DESCRIPTION
## Description:

The pywemo subscription logic assumes there is only one device per IP address. This breaks WeMo emulators that have more than one switch per IP address. Use unique subscription URLs to differentiate between devices.

**Related issue (if applicable):** fixes #557

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests (pytest/vcr) are added for new devices or major features.
  - [x] There is no commented out code in this PR.
  - [x] I have read and agree to the [CONTRIBUTING document](
        https://github.com/pywemo/pywemo/blob/master/CONTRIBUTING.md).