### PR TITLE
Unsubscribe from device when unregistering

### DIFF
--- a/tests/test_subscribe.py
+++ b/tests/test_subscribe.py
@@ -420,6 +420,7 @@ class Test_SubscriptionRegistry:
         assert subscription_registry.devices["192.168.1.100"] == device
 
         subscription_registry.unregister(device)
+        self._wait_for_registry(subscription_registry)
 
         assert len(subscription_registry._sched.queue) == 0
 

--- a/tests/vcr/tests.ouimeaux_device.test_dimmer/Test_PVT_RTOS_Dimmer_v2.test_is_subscribed.yaml
+++ b/tests/vcr/tests.ouimeaux_device.test_dimmer/Test_PVT_RTOS_Dimmer_v2.test_is_subscribed.yaml
@@ -17,7 +17,7 @@ interactions:
       TIMEOUT:
       - Second-300
       User-Agent:
-      - python-requests/2.26.0
+      - python-requests/2.31.0
     method: SUBSCRIBE
     uri: http://192.168.1.100:49153/upnp/event/basicevent1
   response:
@@ -27,15 +27,39 @@ interactions:
       CONTENT-LENGTH:
       - '0'
       DATE:
-      - Mon, 04 Apr 2022 03:32:29
+      - Mon, 28 Aug 2023 02:41:12
       SERVER:
       - Unspecified, UPnP/1.0, Unspecified
       SID:
-      - uuid:22950699-df04-49a3-a15d-b2517fc84183
+      - uuid:8e002dff-79cf-479a-a337-28e03fbdc4a2
       TIMEOUT:
       - Second-1801
       X-User-Agent:
       - redsonic
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      SID:
+      - uuid:8e002dff-79cf-479a-a337-28e03fbdc4a2
+      User-Agent:
+      - python-requests/2.31.0
+    method: UNSUBSCRIBE
+    uri: http://192.168.1.100:49153/upnp/event/basicevent1
+  response:
+    body:
+      string: ''
+    headers: {}
     status:
       code: 200
       message: OK

--- a/tests/vcr/tests.ouimeaux_device.test_insight/Test_Insight.test_subscribe.yaml
+++ b/tests/vcr/tests.ouimeaux_device.test_insight/Test_Insight.test_subscribe.yaml
@@ -79,4 +79,72 @@ interactions:
     status:
       code: 200
       message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      SID:
+      - uuid:7a5218fe-1dd2-11b2-849c-b527ba18a01e
+      User-Agent:
+      - python-requests/2.31.0
+    method: UNSUBSCRIBE
+    uri: http://192.168.1.100:49153/upnp/event/basicevent1
+  response:
+    body:
+      string: <html><body><h1>200 OK</h1></body></html>
+    headers:
+      Accept-Ranges:
+      - bytes
+      CONNECTION:
+      - close
+      CONTENT-LENGTH:
+      - '41'
+      CONTENT-TYPE:
+      - text/html
+      SERVER:
+      - Unspecified, UPnP/1.0, Unspecified
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      SID:
+      - uuid:7a59e192-1dd2-11b2-849c-b527ba18a01e
+      User-Agent:
+      - python-requests/2.31.0
+    method: UNSUBSCRIBE
+    uri: http://192.168.1.100:49153/upnp/event/insight1
+  response:
+    body:
+      string: <html><body><h1>200 OK</h1></body></html>
+    headers:
+      Accept-Ranges:
+      - bytes
+      CONNECTION:
+      - close
+      CONTENT-LENGTH:
+      - '41'
+      CONTENT-TYPE:
+      - text/html
+      SERVER:
+      - Unspecified, UPnP/1.0, Unspecified
+    status:
+      code: 200
+      message: OK
 version: 1

--- a/tests/vcr/tests.test_subscribe/Test_SubscriptionRegistry.test_register_unregister.yaml
+++ b/tests/vcr/tests.test_subscribe/Test_SubscriptionRegistry.test_register_unregister.yaml
@@ -17,21 +17,23 @@ interactions:
       TIMEOUT:
       - Second-300
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.31.0
     method: SUBSCRIBE
     uri: http://192.168.1.100:49153/upnp/event/basicevent1
   response:
     body:
       string: ''
     headers:
+      Accept-Ranges:
+      - bytes
       CONTENT-LENGTH:
       - '0'
       DATE:
-      - Tue, 26 Jan 2021 02:16:36 GMT
+      - Sun, 27 Aug 2023 16:59:22 GMT
       SERVER:
       - Unspecified, UPnP/1.0, Unspecified
       SID:
-      - uuid:84915076-1dd2-11b2-b5fd-dcf7b6ec9aaa
+      - uuid:11fdf778-44fb-11ee-b6e9-d3aaa8ff147f
       TIMEOUT:
       - Second-300
       X-User-Agent:
@@ -47,7 +49,7 @@ interactions:
       Accept-Encoding:
       - gzip, deflate
       CALLBACK:
-      - <http://192.168.1.1:8989/insight1>
+      - <http://192.168.1.1:8989/sub/insight>
       Connection:
       - keep-alive
       Content-Length:
@@ -57,25 +59,95 @@ interactions:
       TIMEOUT:
       - Second-300
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.31.0
     method: SUBSCRIBE
     uri: http://192.168.1.100:49153/upnp/event/insight1
   response:
     body:
       string: ''
     headers:
+      Accept-Ranges:
+      - bytes
       CONTENT-LENGTH:
       - '0'
       DATE:
-      - Tue, 26 Jan 2021 02:16:36 GMT
+      - Sun, 27 Aug 2023 16:59:22 GMT
       SERVER:
       - Unspecified, UPnP/1.0, Unspecified
       SID:
-      - uuid:849c1a56-1dd2-11b2-b5fd-dcf7b6ec9aaa
+      - uuid:12046e46-44fb-11ee-b6e9-d3aaa8ff147f
       TIMEOUT:
       - Second-300
       X-User-Agent:
       - redsonic
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      SID:
+      - uuid:11fdf778-44fb-11ee-b6e9-d3aaa8ff147f
+      User-Agent:
+      - python-requests/2.31.0
+    method: UNSUBSCRIBE
+    uri: http://192.168.1.100:49153/upnp/event/basicevent1
+  response:
+    body:
+      string: <html><body><h1>200 OK</h1></body></html>
+    headers:
+      Accept-Ranges:
+      - bytes
+      CONNECTION:
+      - close
+      CONTENT-LENGTH:
+      - '41'
+      CONTENT-TYPE:
+      - text/html
+      SERVER:
+      - Unspecified, UPnP/1.0, Unspecified
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      SID:
+      - uuid:12046e46-44fb-11ee-b6e9-d3aaa8ff147f
+      User-Agent:
+      - python-requests/2.31.0
+    method: UNSUBSCRIBE
+    uri: http://192.168.1.100:49153/upnp/event/insight1
+  response:
+    body:
+      string: <html><body><h1>200 OK</h1></body></html>
+    headers:
+      Accept-Ranges:
+      - bytes
+      CONNECTION:
+      - close
+      CONTENT-LENGTH:
+      - '41'
+      CONTENT-TYPE:
+      - text/html
+      SERVER:
+      - Unspecified, UPnP/1.0, Unspecified
     status:
       code: 200
       message: OK


### PR DESCRIPTION
## Description:

If there is an existing subscription, unsubscribe from that subscription when the device is unregistered with `SubscriptionRegistry.unregister`.

With #558 adding unique subscription URLs, it's important to unsubscribe. It seems the RTOS devices only support one subscription at a time.

**Related issue (if applicable):** fixes #513

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests (pytest/vcr) are added for new devices or major features.
  - [x] There is no commented out code in this PR.
  - [x] I have read and agree to the [CONTRIBUTING document](
        https://github.com/pywemo/pywemo/blob/master/CONTRIBUTING.md).