### PR TITLE
Use assert_called_once_with in test, not called_once_with

### DIFF
--- a/tests/test_subscribe.py
+++ b/tests/test_subscribe.py
@@ -358,7 +358,7 @@ class Test_Subscription:
     def test_unsubscribe(self, mock_request, subscription):
         subscription.subscription_id = "uuid:321"
         subscription._unsubscribe()
-        mock_request.called_once_with(
+        mock_request.assert_called_once_with(
             method="UNSUBSCRIBE",
             url=subscription.url,
             headers={"SID": "uuid:321"},


### PR DESCRIPTION
## Description:

mock.called_once_with is invalid. Use mock.assert_called_once_with.

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests (pytest/vcr) are added for new devices or major features.
  - [x] There is no commented out code in this PR.
  - [x] I have read and agree to the [CONTRIBUTING document](
        https://github.com/pywemo/pywemo/blob/master/CONTRIBUTING.md).