### PR TITLE
Remove Poetry lock check pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,15 +9,6 @@ repos:
         types: [file]
         files: ^(pyproject.toml|poetry.lock)$
 
-      - id: poetry-lock-check
-        name: poetry-lock-check
-        language: system
-        entry: poetry lock
-        args: ['--no-update']
-        pass_filenames: false
-        types: [file]
-        files: ^(pyproject.toml|poetry.lock)$
-
       - id: bootstrap-requirements
         name: bootstrap-requirements
         language: system


### PR DESCRIPTION
## Description:

This check seems to be causing issues as new packages are published for Python 3.12 support.

**Related issue (if applicable):** fixes #<pywemo issue number goes here>

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests (pytest/vcr) are added for new devices or major features.
  - [x] There is no commented out code in this PR.
  - [x] I have read and agree to the [CONTRIBUTING document](
        https://github.com/pywemo/pywemo/blob/master/CONTRIBUTING.md).