### PR TITLE
Disable python intermediate updates for dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,10 +8,6 @@ updates:
     schedule:
       # Check for updates to Poetry dependencies every week
       interval: "weekly"
-    allow:
-      # Allow both direct and indirect updates for all packages
-      - dependency-type: direct
-      - dependency-type: indirect
 
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
## Description:

Dependabot causes too many intermediate package downgrades.

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests (pytest/vcr) are added for new devices or major features.
  - [x] There is no commented out code in this PR.
  - [x] I have read and agree to the [CONTRIBUTING document](
        https://github.com/pywemo/pywemo/blob/master/CONTRIBUTING.md).