### PR TITLE
Fixed rare incorrect startup brightness value for Dimmers

### DIFF
--- a/pywemo/ouimeaux_device/dimmer.py
+++ b/pywemo/ouimeaux_device/dimmer.py
@@ -38,6 +38,10 @@ class Dimmer(Switch):
 
     def get_state(self, force_update: bool = False) -> int:
         """Update the state & brightness for the Dimmer."""
+        force_update = force_update or (
+            self._brightness is None
+            and "brightness" not in self.basic_state_params
+        )
         state = super().get_state(force_update)
         if force_update or self._brightness is None:
             try:

--- a/tests/ouimeaux_device/test_dimmer.py
+++ b/tests/ouimeaux_device/test_dimmer.py
@@ -34,14 +34,19 @@ class Base:
         assert dimmer.get_state(force_update=True) == expected_state
         assert dimmer.get_brightness() == expected_brightness
 
+    @pytest.mark.vcr()
+    def test_brightness_on_startup(self, dimmer):
+        dimmer.on()
+        assert dimmer.get_brightness() != 0
+
     def test_subscription_update_brightness(self, dimmer):
         # Invalid value fails gracefully.
         assert dimmer.subscription_update("Brightness", "invalid") is False
 
         assert dimmer.subscription_update("BinaryState", "1") is True
-        assert dimmer.get_state() == 1
-
         assert dimmer.subscription_update("Brightness", "52") is True
+
+        assert dimmer.get_state() == 1
         assert dimmer.get_brightness() == 52
 
 

--- a/tests/vcr/tests.ouimeaux_device.test_dimmer/Test_PVT_OWRT_Dimmer_v1.test_brightness_on_startup.yaml
+++ b/tests/vcr/tests.ouimeaux_device.test_dimmer/Test_PVT_OWRT_Dimmer_v1.test_brightness_on_startup.yaml
@@ -1,0 +1,113 @@
+interactions:
+- request:
+    body: '<?xml version="1.0" encoding="utf-8"?>
+
+      <s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/" s:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/">
+
+      <s:Body>
+
+      <u:SetBinaryState xmlns:u="urn:Belkin:service:basicevent:1">
+
+      <BinaryState>1</BinaryState>
+
+      </u:SetBinaryState>
+
+      </s:Body>
+
+      </s:Envelope>'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '306'
+      Content-Type:
+      - text/xml
+      SOAPACTION:
+      - '"urn:Belkin:service:basicevent:1#SetBinaryState"'
+      User-Agent:
+      - python-requests/2.25.1
+    method: POST
+    uri: http://192.168.1.100:49153/upnp/control/basicevent1
+  response:
+    body:
+      string: "<s:Envelope xmlns:s=\"http://schemas.xmlsoap.org/soap/envelope/\" s:encodingStyle=\"\
+        http://schemas.xmlsoap.org/soap/encoding/\"><s:Body>\n<u:SetBinaryStateResponse\
+        \ xmlns:u=\"urn:Belkin:service:basicevent:1\">\r\n<BinaryState>1</BinaryState>\r\
+        \n<CountdownEndTime>0</CountdownEndTime>\r\n<deviceCurrentTime>1611822195</deviceCurrentTime>\r\
+        \n</u:SetBinaryStateResponse>\r\n</s:Body> </s:Envelope>"
+    headers:
+      CONTENT-LENGTH:
+      - '376'
+      CONTENT-TYPE:
+      - text/xml; charset="utf-8"
+      DATE:
+      - Thu, 28 Jan 2021 08:23:15 GMT
+      EXT:
+      - ''
+      SERVER:
+      - Unspecified, UPnP/1.0, Unspecified
+      X-User-Agent:
+      - redsonic
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '<?xml version="1.0" encoding="utf-8"?>
+
+      <s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/" s:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/">
+
+      <s:Body>
+
+      <u:GetBinaryState xmlns:u="urn:Belkin:service:basicevent:1">
+
+
+      </u:GetBinaryState>
+
+      </s:Body>
+
+      </s:Envelope>'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '278'
+      Content-Type:
+      - text/xml
+      SOAPACTION:
+      - '"urn:Belkin:service:basicevent:1#GetBinaryState"'
+      User-Agent:
+      - python-requests/2.25.1
+    method: POST
+    uri: http://192.168.1.100:49153/upnp/control/basicevent1
+  response:
+    body:
+      string: "<s:Envelope xmlns:s=\"http://schemas.xmlsoap.org/soap/envelope/\" s:encodingStyle=\"\
+        http://schemas.xmlsoap.org/soap/encoding/\"><s:Body>\n<u:GetBinaryStateResponse\
+        \ xmlns:u=\"urn:Belkin:service:basicevent:1\">\r\n<BinaryState>1</BinaryState>\r\
+        \n<brightness>18</brightness>\r\n<fader>300:-1:1:0:8</fader>\r\n</u:GetBinaryStateResponse>\r\
+        \n</s:Body> </s:Envelope>"
+    headers:
+      CONTENT-LENGTH:
+      - '343'
+      CONTENT-TYPE:
+      - text/xml; charset="utf-8"
+      DATE:
+      - Thu, 28 Jan 2021 08:23:15 GMT
+      EXT:
+      - ''
+      SERVER:
+      - Unspecified, UPnP/1.0, Unspecified
+      X-User-Agent:
+      - redsonic
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/vcr/tests.ouimeaux_device.test_dimmer/Test_PVT_RTOS_Dimmer_v2.test_brightness_on_startup.yaml
+++ b/tests/vcr/tests.ouimeaux_device.test_dimmer/Test_PVT_RTOS_Dimmer_v2.test_brightness_on_startup.yaml
@@ -1,41 +1,40 @@
 interactions:
 - request:
-    body: null
+    body: '<?xml version="1.0" encoding="utf-8"?>
+
+      <s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/" s:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/">
+
+      <s:Body>
+
+      <u:SetBinaryState xmlns:u="urn:Belkin:service:basicevent:1">
+
+      <BinaryState>1</BinaryState>
+
+      </u:SetBinaryState>
+
+      </s:Body>
+
+      </s:Envelope>'
     headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      CALLBACK:
-      - <http://192.168.1.1:8989/sub/basicevent>
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '0'
-      NT:
-      - upnp:event
-      TIMEOUT:
-      - Second-300
-      User-Agent:
-      - python-requests/2.31.0
-    method: SUBSCRIBE
-    uri: http://192.168.1.100:49153/upnp/event/basicevent1
+      Content-Type:
+      - text/xml
+      SOAPACTION:
+      - '"urn:Belkin:service:basicevent:1#SetBinaryState"'
+    method: POST
+    uri: http://192.168.1.100:49153/upnp/control/basicevent1
   response:
     body:
-      string: ''
+      string: "<s:Envelope xmlns:s=\"http://schemas.xmlsoap.org/soap/envelope/\" s:encodingStyle=\"\
+        http://schemas.xmlsoap.org/soap/encoding/\">\r\n<s:Body>\r\n<u:SetBinaryStateResponse\
+        \ xmlns:u=\"urn:Belkin:service:basicevent:1\"><BinaryState>1</BinaryState><brightness>45</brightness><CountdownEndTime>0</CountdownEndTime><deviceCurrentTime>1698016275</deviceCurrentTime></u:SetBinaryStateResponse></s:Body>\r\
+        \n</s:Envelope>"
     headers:
-      CONTENT-LENGTH:
-      - '0'
-      DATE:
-      - Mon, 23 Oct 2023 09:03:23
-      SERVER:
-      - Unspecified, UPnP/1.0, Unspecified
-      SID:
-      - uuid:8e002dff-79cf-479a-a337-28e03fbdc4a2
-      TIMEOUT:
-      - Second-1801
-      X-User-Agent:
-      - redsonic
+      Connection:
+      - close
+      Content-Length:
+      - '397'
+      Content-Type:
+      - text/xml
     status:
       code: 200
       message: OK
@@ -74,30 +73,6 @@ interactions:
       - '310'
       Content-Type:
       - text/xml
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '0'
-      SID:
-      - uuid:8e002dff-79cf-479a-a337-28e03fbdc4a2
-      User-Agent:
-      - python-requests/2.31.0
-    method: UNSUBSCRIBE
-    uri: http://192.168.1.100:49153/upnp/event/basicevent1
-  response:
-    body:
-      string: ''
-    headers: {}
     status:
       code: 200
       message: OK


### PR DESCRIPTION
## Description:

Stumbled upon and fixed this random minor issue while working in the repo. Unlikely that it appears as a problem downstream, just weird behaviour when writing local tests.

The bug was happening if the first operation performed on a `Dimmer` was to set its basic state value (ie. `on`, `off`, or `toggle`), followed by a request for `get_brightness(force_update=False)`. This would invoke the parent `Switch` class' 
`get_state(force_update=False)` which would early out because it already has a valid basic state. `Dimmer` would then naively look in the `basic_state_params` to try to find its "brightness" value, which it would not find, and then humbly fallback to setting its internal `_brightness` to zero (which is actually not a valid value for this parameter).

Fixed by calling an explicit `Switch.get_state(force_update=True)` in the appropriate circumstance.

**Related issue (if applicable):** fixes _an unlogged bug_

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests (pytest/vcr) are added for new devices or major features.
  - [x] There is no commented out code in this PR.
  - [x] I have read and agree to the [CONTRIBUTING document](
        https://github.com/pywemo/pywemo/blob/master/CONTRIBUTING.md).