### PR TITLE
Add Python 3.12 to the test matrix

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,10 +23,10 @@ jobs:
     outputs:
       version: ${{ steps.build.outputs.version }}
     strategy:
-      max-parallel: 4  # Set equal to the number of Linux tests.
+      max-parallel: 5  # Set equal to the number of Linux tests.
       matrix:
         os: ['ubuntu-latest']
-        python-version: ['3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
         include:
           - os: windows-latest
             python-version: '3.8'


### PR DESCRIPTION
## Description:

Add Python 3.12 to the test matrix

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests (pytest/vcr) are added for new devices or major features.
  - [x] There is no commented out code in this PR.
  - [x] I have read and agree to the [CONTRIBUTING document](
        https://github.com/pywemo/pywemo/blob/master/CONTRIBUTING.md).