### PR TITLE
Improve setup

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -111,7 +111,7 @@ If you have issues connecting, here are several things worth trying:
 - WeMo devices can only connect to 2.4GHz wifi connections and some devices have an issue connecting if the 2.4Ghz and 5Ghz SSID are the same.
 - If issues persist, consider performing a full factory reset and power cycle on the device before trying again.
 - Consider that enabled firewall rules may block the WeMo from connecting to the intended AP.
-- See `this pywemo issue <https://github.com/pywemo/pywemo/issues/773>`_ before opening a new issue if setup does not work for your device.
+- See `this pywemo issue`_ before opening a new issue if setup does not work for your device.
 
 Firmware Warning
 ----------------
@@ -133,14 +133,14 @@ The good news is that this change will **not** affect pywemo, which will continu
 pywemo does not rely on the cloud connection for anything, including setup.
 Many products can be setup and reset with pywemo, as discussed above.
 
-Please see `this pywemo issue <https://github.com/pywemo/pywemo/issues/773>`_ to document the status of the various products and to update the table below on product status.
+Please see `this pywemo issue`_ to document the status of the various products and to update the table below on product status.
 
 Product Status
 --------------
 This is a list of known products and the pywemo status of each, including for setup.
 This list was started in November of 2025 in response to Belkin ending WeMo support.
 Any entry with N/A is unreported since this table was added.
-If you have any of these decvices and use them with PyWeMo, please let us know in `this pywemo issue <https://github.com/pywemo/pywemo/issues/773>`_ so that we can complete this list.
+If you have any of these decvices and use them with PyWeMo, please let us know in `this pywemo issue`_ so that we can complete this list.
 
 This list is mostly from the Belkin article mentioned above, but it may not be a complete list of all products.
 SKU's with an asterisk at the end, like F7C029V2*, are not listed in the article.
@@ -205,6 +205,7 @@ License
 All contents of the pywemo/ouimeaux_device directory are licensed under a BSD 3-Clause license. The full text of that license is maintained within the pywemo/ouimeaux_device/LICENSE file.
 The rest of pyWeMo is released under the MIT license. See the top-level LICENSE file for more details.
 
+.. _this pywemo issue: https://github.com/pywemo/pywemo/issues/773
 
 .. |Build Badge| image:: https://github.com/pywemo/pywemo/workflows/Build/badge.svg
     :target: https://github.com/pywemo/pywemo/actions?query=workflow%3ABuild

--- a/README.rst
+++ b/README.rst
@@ -118,15 +118,15 @@ If you have issues connecting, here are several things worth trying:
   Thus, you may want to try forcing each of the 6 possible combinations as shown below.
   If one of these other methods work, but now the automatic detection, then be sure to add a comment to the `this pywemo issue`_.
 
-    .. code-block:: python
+.. code-block:: python
 
-        device.setup(ssid='wifi_name', password='special_secret', _encrypt_method=1, _add_password_lengths=True)
-        device.setup(ssid='wifi_name', password='special_secret', _encrypt_method=2, _add_password_lengths=False)
-        device.setup(ssid='wifi_name', password='special_secret', _encrypt_method=3, _add_password_lengths=True)
-        # Only the top 3 should be valid, but go ahead and try these lower 3 too...
-        device.setup(ssid='wifi_name', password='special_secret', _encrypt_method=1, _add_password_lengths=False)
-        device.setup(ssid='wifi_name', password='special_secret', _encrypt_method=2, _add_password_lengths=True)
-        device.setup(ssid='wifi_name', password='special_secret', _encrypt_method=3, _add_password_lengths=False)
+    device.setup(ssid='wifi_name', password='special_secret', _encrypt_method=1, _add_password_lengths=True)
+    device.setup(ssid='wifi_name', password='special_secret', _encrypt_method=2, _add_password_lengths=False)
+    device.setup(ssid='wifi_name', password='special_secret', _encrypt_method=3, _add_password_lengths=True)
+    # Only the top 3 should be valid, but go ahead and try these lower 3 too...
+    device.setup(ssid='wifi_name', password='special_secret', _encrypt_method=1, _add_password_lengths=False)
+    device.setup(ssid='wifi_name', password='special_secret', _encrypt_method=2, _add_password_lengths=True)
+    device.setup(ssid='wifi_name', password='special_secret', _encrypt_method=3, _add_password_lengths=False)
 
 Search for your device on `this pywemo issue`_ before opening a new issue if setup does not work for your device.
 

--- a/README.rst
+++ b/README.rst
@@ -123,7 +123,7 @@ If you have issues connecting, here are several things worth trying:
     device.setup(ssid='wifi', password='secret', _encrypt_method=1, _add_password_lengths=True)
     device.setup(ssid='wifi', password='secret', _encrypt_method=2, _add_password_lengths=False)
     device.setup(ssid='wifi', password='secret', _encrypt_method=3, _add_password_lengths=True)
-    # Only the top 3 should be valid, but go ahead and try these lower 3 too...
+    # only the top 3 should be valid, but go ahead and try these lower 3 too...
     device.setup(ssid='wifi', password='secret', _encrypt_method=1, _add_password_lengths=False)
     device.setup(ssid='wifi', password='secret', _encrypt_method=2, _add_password_lengths=True)
     device.setup(ssid='wifi', password='secret', _encrypt_method=3, _add_password_lengths=False)

--- a/README.rst
+++ b/README.rst
@@ -94,7 +94,7 @@ Device setup is through the ``setup`` method, which has two required arguments: 
 The user must first connect to the devices locally broadcast access point, which typically starts with "WeMo.", and then discover the device there.
 Once done, pass the desired SSID and password (WPA2/AES encryption only) to the ``setup`` method to connect it to your Wi-Fi network.
 
-``device.setup(ssid='wifi_name', password='special_secret')``
+``device.setup(ssid='wifi', password='secret')``
 
 A few important notes:
 
@@ -120,13 +120,13 @@ If you have issues connecting, here are several things worth trying:
 
 .. code-block:: python
 
-    device.setup(ssid='wifi_name', password='special_secret', _encrypt_method=1, _add_password_lengths=True)
-    device.setup(ssid='wifi_name', password='special_secret', _encrypt_method=2, _add_password_lengths=False)
-    device.setup(ssid='wifi_name', password='special_secret', _encrypt_method=3, _add_password_lengths=True)
+    device.setup(ssid='wifi', password='secret', _encrypt_method=1, _add_password_lengths=True)
+    device.setup(ssid='wifi', password='secret', _encrypt_method=2, _add_password_lengths=False)
+    device.setup(ssid='wifi', password='secret', _encrypt_method=3, _add_password_lengths=True)
     # Only the top 3 should be valid, but go ahead and try these lower 3 too...
-    device.setup(ssid='wifi_name', password='special_secret', _encrypt_method=1, _add_password_lengths=False)
-    device.setup(ssid='wifi_name', password='special_secret', _encrypt_method=2, _add_password_lengths=True)
-    device.setup(ssid='wifi_name', password='special_secret', _encrypt_method=3, _add_password_lengths=False)
+    device.setup(ssid='wifi', password='secret', _encrypt_method=1, _add_password_lengths=False)
+    device.setup(ssid='wifi', password='secret', _encrypt_method=2, _add_password_lengths=True)
+    device.setup(ssid='wifi', password='secret', _encrypt_method=3, _add_password_lengths=False)
 
 Search for your device on `this pywemo issue`_ before opening a new issue if setup does not work for your device.
 

--- a/README.rst
+++ b/README.rst
@@ -92,26 +92,43 @@ Setup
 
 Device setup is through the ``setup`` method, which has two required arguments: ``ssid`` and ``password``.
 The user must first connect to the devices locally broadcast access point, which typically starts with "WeMo.", and then discover the device there.
-Once done, pass the desired SSID and password (WPA2/AES encryption only) to the ``setup`` method to connect it to your wifi network.
+Once done, pass the desired SSID and password (WPA2/AES encryption only) to the ``setup`` method to connect it to your Wi-Fi network.
 
 ``device.setup(ssid='wifi_name', password='special_secret')``
 
 A few important notes:
 
-- Not all devices are known to work with the pywemo setup method.
-- For a WeMo without internet access, see `this guide <https://github.com/pywemo/pywemo/wiki/WeMo-Cloud#disconnecting-from-the-cloud>`_ to stop any blinking lights.
 - If connecting to an open network, the password argument is ignored and you can provide anything, e.g. ``password=None``.
 - If connecting to a WPA2/AES/TKIPAES-encrypted network, OpenSSL is used to encrypt the password by the ``pywemo`` library.
   It must be installed and available on your ``PATH`` via calling ``openssl`` from a terminal or command prompt.
+- For a WeMo without internet access, see `this guide <https://github.com/pywemo/pywemo/wiki/WeMo-Cloud#disconnecting-from-the-cloud>`_ to stop any blinking lights.
 
 If you have issues connecting, here are several things worth trying:
 
-- Try again!  WeMo devices sometimes just fail to connect and repeating the exact same steps may subsequently work.
-- Bring the WeMo as close to the access point as possible.  Some devices seem to require a very strong signal for setup, even if they will work normally with a weaker one.
-- WeMo devices can only connect to 2.4GHz wifi connections and some devices have an issue connecting if the 2.4Ghz and 5Ghz SSID are the same.
+- Try again!
+  WeMo devices sometimes just fail to connect and repeating the exact same steps may subsequently work.
+- Bring the WeMo as close to the access point as possible.
+  Some devices seem to require a very strong signal for setup, even if they will work normally with a weaker one.
+- WeMo devices can only connect to 2.4GHz Wi-Fi and sometimes have trouble connecting if the 2.4Ghz and 5Ghz SSID are the same.
 - If issues persist, consider performing a full factory reset and power cycle on the device before trying again.
-- Consider that enabled firewall rules may block the WeMo from connecting to the intended AP.
-- See `this pywemo issue`_ before opening a new issue if setup does not work for your device.
+- Enabled firewall rules may block the WeMo from connecting to the intended AP.
+- Based on various differences in models and firmware, pywemo contains 3 different methods for encrypting the Wi-Fi password when sending it to the WeMo device.
+  In addition to the encryption, WeMo devices sometimes expect the get password lengths appended to the end of the password.
+  There is logic in pywemo that attempts to select the appropriate options for each device, but it maybe not be correct for all devices and firmware.
+  Thus, you may want to try forcing each of the 6 possible combinations as shown below.
+  If one of these other methods work, but now the automatic detection, then be sure to add a comment to the `this pywemo issue`_.
+
+    .. code-block:: python
+
+        device.setup(ssid='wifi_name', password='special_secret', _encrypt_method=1, _add_password_lengths=True)
+        device.setup(ssid='wifi_name', password='special_secret', _encrypt_method=2, _add_password_lengths=False)
+        device.setup(ssid='wifi_name', password='special_secret', _encrypt_method=3, _add_password_lengths=True)
+        # Only the top 3 should be valid, but go ahead and try these lower 3 too...
+        device.setup(ssid='wifi_name', password='special_secret', _encrypt_method=1, _add_password_lengths=False)
+        device.setup(ssid='wifi_name', password='special_secret', _encrypt_method=2, _add_password_lengths=True)
+        device.setup(ssid='wifi_name', password='special_secret', _encrypt_method=3, _add_password_lengths=False)
+
+Search for your device on `this pywemo issue`_ before opening a new issue if setup does not work for your device.
 
 Firmware Warning
 ----------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -271,6 +271,7 @@ max-line-length = 79
 ignore-paths = "^tests/"
 extension-pkg-whitelist = "lxml"
 max-parents = 15
+max-args = 8
 
 [tool.pylint.typecheck]
 generated-members = [

--- a/pywemo/ouimeaux_device/__init__.py
+++ b/pywemo/ouimeaux_device/__init__.py
@@ -608,6 +608,7 @@ class Device(DeviceDescription, RequiredServicesMixin, WeMoServiceTypesMixin):
                 # -->     method = 2
                 # --> else:
                 # -->     method = 1
+                # --> add_lengths = True  # for all 3 methods
 
                 # however, this works correctly more often than the logic above
                 is_rtos = self._config_any.get("rtos", "0") == "1"

--- a/pywemo/ouimeaux_device/__init__.py
+++ b/pywemo/ouimeaux_device/__init__.py
@@ -337,6 +337,13 @@ class Device(DeviceDescription, RequiredServicesMixin, WeMoServiceTypesMixin):
             add_lengths,
         )
         if method == 1:
+            # the original method
+            keydata = mac[:6] + serial + mac[6:12]
+        elif method == 2:
+            # rtos=1 (or maybe new_algo=1)
+            keydata = mac[:6] + serial + mac[6:12]
+            keydata += "b3{8t;80dIN{ra83eC1s?M70?683@2Yf"
+        elif method == 3:
             # binaryOption = 1
             characters = "".join(
                 [
@@ -368,13 +375,6 @@ class Device(DeviceDescription, RequiredServicesMixin, WeMoServiceTypesMixin):
             keydata = (
                 mac[:3] + mac[9:12] + serial + extra + mac[6:9] + mac[3:6]
             )
-        elif method == 2:
-            # new_algo = 1
-            keydata = mac[:6] + serial + mac[6:12]
-            keydata += "b3{8t;80dIN{ra83eC1s?M70?683@2Yf"
-        elif method == 3:
-            # the original method
-            keydata = mac[:6] + serial + mac[6:12]
         else:
             raise SetupException(f"{method=} must be 1, 2, or 3")
 
@@ -608,11 +608,11 @@ class Device(DeviceDescription, RequiredServicesMixin, WeMoServiceTypesMixin):
                 is_rtos = self._config_any.get("rtos", "0") == "1"
 
                 if self._config_any.get("binaryOption", "0") == "1":
-                    method = 1
+                    method = 3
                 elif is_rtos:
                     method = 2
                 else:
-                    method = 3
+                    method = 1
                 LOG.debug(
                     "Automatically detected encryption method=%s", method
                 )

--- a/pywemo/ouimeaux_device/__init__.py
+++ b/pywemo/ouimeaux_device/__init__.py
@@ -19,6 +19,7 @@ from ..exceptions import (
     ResetException,
     SetupException,
     ShortPassword,
+    SOAPFault,
     UnknownService,
 )
 from ..util import MetaInfo
@@ -314,23 +315,68 @@ class Device(DeviceDescription, RequiredServicesMixin, WeMoServiceTypesMixin):
 
     @staticmethod
     def encrypt_aes128(
-        password: str, wemo_metadata: str, is_rtos: bool
+        password: str, wemo_metadata: str, method: int, add_lengths: bool
     ) -> str:
         """Encrypt a password using OpenSSL.
 
         Function borrows heavily from Vadim Kantorov's "wemosetup" script:
         https://github.com/vadimkantorov/wemosetup
         """
+        # pylint: disable=too-many-branches, too-many-locals
         if not password:
             raise SetupException("password required for AES")
 
         # Wemo uses some meta information for salt and iv
         meta_info = MetaInfo.from_meta_info(wemo_metadata)
-        keydata = (
-            meta_info.mac[:6] + meta_info.serial_number + meta_info.mac[6:12]
+        mac = meta_info.mac
+        serial = meta_info.serial_number
+
+        LOG.debug(
+            "Using encryption method=%s and add_lengths=%s",
+            method,
+            add_lengths,
         )
-        if is_rtos:
+        if method == 1:
+            # binaryOption = 1
+            characters = "".join(
+                [
+                    "Onboard",
+                    "$",
+                    "Application",
+                    "@",
+                    "Device",
+                    "&",
+                    "Information",
+                    "#",
+                    "Wemo",
+                ]
+            )
+            mixed = ""
+            for i, char in enumerate(characters):
+                if i % 2:
+                    mixed = mixed + char
+                else:
+                    mixed = char + mixed
+            extra = base64.b64encode(mixed.encode()).decode()[:32]
+
+            # the above transformation results in the following strings, but
+            # the calculation above is left for posterity
+            # --> characters = "Onboard$Application@Device&Information#Wemo"
+            # --> mixed = 'oe#otmon&cvDniaipAdabOnor$plcto@eieIfrainWm'
+            # --> extra = 'b2Ujb3Rtb24mY3ZEbmlhaXBBZGFiT25v'
+
+            keydata = (
+                mac[:3] + mac[9:12] + serial + extra + mac[6:9] + mac[3:6]
+            )
+        elif method == 2:
+            # new_algo = 1
+            keydata = mac[:6] + serial + mac[6:12]
             keydata += "b3{8t;80dIN{ra83eC1s?M70?683@2Yf"
+        elif method == 3:
+            # the original method
+            keydata = mac[:6] + serial + mac[6:12]
+        else:
+            raise SetupException(f"{method=} must be 1, 2, or 3")
 
         salt, initialization_vector = keydata[:8], keydata[:16]
         if len(salt) != 8 or len(initialization_vector) != 16:
@@ -385,12 +431,22 @@ class Device(DeviceDescription, RequiredServicesMixin, WeMoServiceTypesMixin):
                 f"{len_original} (and {len_encrypted} after encryption)."
             )
 
-        if not is_rtos:
+        if add_lengths:
             encrypted_password += f"{len_encrypted:#04x}"[2:]
             encrypted_password += f"{len_original:#04x}"[2:]
         return encrypted_password
 
-    def setup(self, *args: Any, **kwargs: Any) -> tuple[str, str]:
+    def setup(
+        self,
+        ssid: str,
+        password: str,
+        *,
+        timeout: float = 20.0,
+        connection_attempts: int = 1,
+        status_delay: float = 1.0,
+        encrypt_method: int | None = None,
+        add_lengths: bool | None = None,
+    ) -> tuple[str, str]:
         """Connect Wemo to wifi network.
 
         This function should be used and will capture several potential
@@ -416,6 +472,15 @@ class Device(DeviceDescription, RequiredServicesMixin, WeMoServiceTypesMixin):
             status of the device.  Generally should prefer this to be as short
             as possible, but not too quick to overload the device with
             requests.  It must be less than or equal to half of the `timeout`.
+          encrypt_method (int | None, optional):
+            Override the pywemo detection for which of the 3 encryption methods
+            to use.  If set, must be 1, 2, or 3.  The default, None, will use
+            the automatically detected method.  This should generally be left
+            as the default value.
+          add_lengths (bool | None, optional):
+            Override the pywemo detection for whether to add the password
+            lengths to the encrypted password.  Similar to the encrypt_method,
+            this should generally be left as the default None value.
 
         Notes:
         -----
@@ -424,7 +489,15 @@ class Device(DeviceDescription, RequiredServicesMixin, WeMoServiceTypesMixin):
 
         """
         try:
-            return self._setup(*args, **kwargs)
+            return self._setup(
+                ssid=ssid,
+                password=password,
+                timeout=timeout,
+                connection_attempts=connection_attempts,
+                status_delay=status_delay,
+                encrypt_method=encrypt_method,
+                add_lengths=add_lengths,
+            )
         except (UnknownService, AttributeError, KeyError) as exc:
             #    Exception       | Reason to catch it
             #    --------------------------------------------------------------
@@ -452,14 +525,17 @@ class Device(DeviceDescription, RequiredServicesMixin, WeMoServiceTypesMixin):
             ) from exc
 
     def _setup(  # noqa: C901
-        # pylint: disable=too-many-arguments,too-many-branches,too-many-locals
-        # pylint: disable=too-many-statements,too-many-positional-arguments
+        # pylint: disable=too-many-branches, too-many-locals
+        # pylint: disable=too-many-statements, too-many-positional-arguments
         self,
         ssid: str,
         password: str,
-        timeout: float = 20.0,
-        connection_attempts: int = 1,
-        status_delay: float = 1.0,
+        *,
+        timeout: float,
+        connection_attempts: int,
+        status_delay: float,
+        encrypt_method: int | None,
+        add_lengths: bool | None,
     ) -> tuple[str, str]:
         """Connect Wemo to wifi network.
 
@@ -470,6 +546,14 @@ class Device(DeviceDescription, RequiredServicesMixin, WeMoServiceTypesMixin):
         timeout = max(timeout, 20.0)
         status_delay = min(status_delay, timeout / 2.0)
         connection_attempts = int(max(1, connection_attempts))
+        LOG.debug(
+            "Trying to connect to AP %s with timeout=%s, "
+            "connection_attempts=%s, and status_delay=%s",
+            ssid,
+            timeout,
+            connection_attempts,
+            status_delay,
+        )
 
         # find all access points that the device can see, and select the one
         # matching the desired SSID
@@ -515,9 +599,36 @@ class Device(DeviceDescription, RequiredServicesMixin, WeMoServiceTypesMixin):
         else:
             # get the meta information of the device and encrypt the password
             meta_info = self.get_service("metainfo").GetMetaInfo()["MetaInfo"]
-            is_rtos = self._config_any.get("rtos", "0") == "1"
+
+            if encrypt_method is None:
+                # investigation appears to indicate that method 2 should be
+                # used based on new_algo, but in practice it seems that it is
+                # actually based on rtos - not exactly sure why the discrepancy
+                _use_new_algo = self._config_any.get("new_algo", "0") == "1"
+                is_rtos = self._config_any.get("rtos", "0") == "1"
+
+                if self._config_any.get("binaryOption", "0") == "1":
+                    method = 1
+                elif is_rtos:
+                    method = 2
+                else:
+                    method = 3
+                LOG.debug(
+                    "Automatically detected encryption method=%s", method
+                )
+            else:
+                method = encrypt_method
+
+            if add_lengths is None:
+                # by default, add the lengths for methods 1 and 3, but not 2
+                add_lengths = method in (1, 3)
+                LOG.debug(
+                    "Automatically detected encryption add_lengths=%s",
+                    add_lengths,
+                )
+
             encrypted_password = self.encrypt_aes128(
-                password, meta_info, is_rtos
+                password, meta_info, method, add_lengths
             )
 
         # optionally make multiple connection attempts
@@ -588,7 +699,7 @@ class Device(DeviceDescription, RequiredServicesMixin, WeMoServiceTypesMixin):
 
         try:
             result = wifisetup.CloseSetup()
-        except AttributeError:
+        except (AttributeError, SOAPFault):
             # if CloseSetup doesn't exist, it may still work
             result = {"status": "CloseSetup action not available"}
 
@@ -612,7 +723,7 @@ class Device(DeviceDescription, RequiredServicesMixin, WeMoServiceTypesMixin):
         if status == "1" and close_status == "success":
             try:
                 self.basicevent.SetSetupDoneStatus()
-            except AttributeError:
+            except (AttributeError, SOAPFault):
                 LOG.debug(
                     "SetSetupDoneStatus not available (some devices do not "
                     "have this method)"

--- a/tests/ouimeaux_device/test_device.py
+++ b/tests/ouimeaux_device/test_device.py
@@ -297,13 +297,13 @@ class TestDevice:
     @pytest.mark.parametrize(
         "method, add_lengths, is_salted_prefix",
         [
-            # TODO: enable these
-            # --> (1, True, True),
-            # --> (1, True, False),
+            (1, True, True),
+            (1, True, False),
             (2, False, True),
             (2, False, False),
-            (3, True, True),
-            (3, True, False),
+            # TODO: get the expected results for these tests
+            # --> (3, True, True),
+            # --> (3, True, False),
         ],
     )
     @mock.patch("subprocess.run")
@@ -317,12 +317,12 @@ class TestDevice:
             "b3{8t;80dIN{ra83eC1s?M70?683@2Yf" if method == 2 else ""
         )
         stdout = {
+            1: b"I\x08\xfb\x9fh\x80\t\xd1\x99\x9cskl\xb3;\xdb",
             2: b"\xc7\xf7\x9f\xd7 \x8dL\xe3nS\xe6S\xdd\xce$\x02",
-            3: b"I\x08\xfb\x9fh\x80\t\xd1\x99\x9cskl\xb3;\xdb",
         }
         expected = {
+            1: "SQj7n2iACdGZnHNrbLM72w==1808",
             2: "x/ef1yCNTONuU+ZT3c4kAg==",
-            3: "SQj7n2iACdGZnHNrbLM72w==1808",
         }
 
         def check_args(args, **kwargs):
@@ -344,8 +344,8 @@ class TestDevice:
     @pytest.mark.parametrize(
         "method, add_lengths, expected",
         [
+            (1, True, "SQj7n2iACdGZnHNrbLM72w==1808"),
             (2, False, "x/ef1yCNTONuU+ZT3c4kAg=="),
-            (3, True, "SQj7n2iACdGZnHNrbLM72w==1808"),
         ],
     )
     @pytest.mark.skipif(
@@ -380,7 +380,7 @@ class TestDevice:
             encrypted = Device.encrypt_aes128(
                 password=password,
                 wemo_metadata=wemo_metadata,
-                method=2 if is_rtos else 3,
+                method=2 if is_rtos else 1,
                 add_lengths=not is_rtos,
             )
         except SetupException:

--- a/tests/ouimeaux_device/test_device.py
+++ b/tests/ouimeaux_device/test_device.py
@@ -284,37 +284,45 @@ class TestDevice:
     def test_encryption_no_openssl(self, mock_run, device):
         """Test device encryption (openssl not found/not installed)."""
         with pytest.raises(SetupException):
-            assert device.encrypt_aes128("password", self.METAINFO, False)
+            assert device.encrypt_aes128("password", self.METAINFO, 3, True)
         assert mock_run.call_count == 1
 
     @mock.patch("subprocess.run", side_effect=CalledProcessError(-1, "error"))
     def test_encryption_openssl_error(self, mock_run, device):
         """Test device encryption (error in openssl)."""
         with pytest.raises(SetupException):
-            assert device.encrypt_aes128("password", self.METAINFO, False)
+            assert device.encrypt_aes128("password", self.METAINFO, 3, True)
         assert mock_run.call_count == 1
 
     @pytest.mark.parametrize(
-        "is_rtos, is_salted_prefix",
-        [(False, True), (False, False), (True, True), (True, False)],
+        "method, add_lengths, is_salted_prefix",
+        [
+            # TODO: enable these
+            # --> (1, True, True),
+            # --> (1, True, False),
+            (2, False, True),
+            (2, False, False),
+            (3, True, True),
+            (3, True, False),
+        ],
     )
     @mock.patch("subprocess.run")
     def test_encryption_successful(
-        self, mock_run, is_rtos, is_salted_prefix, device
+        self, mock_run, method, add_lengths, is_salted_prefix, device
     ):
         """Test device encryption (good result)."""
         salt = "5858585858583132"
         iv = "58585858585831323334353641313233"
         password = "pass:XXXXXX123456A1234567XXXXXX" + (
-            "b3{8t;80dIN{ra83eC1s?M70?683@2Yf" if is_rtos else ""
+            "b3{8t;80dIN{ra83eC1s?M70?683@2Yf" if method == 2 else ""
         )
         stdout = {
-            False: b"I\x08\xfb\x9fh\x80\t\xd1\x99\x9cskl\xb3;\xdb",
-            True: b"\xc7\xf7\x9f\xd7 \x8dL\xe3nS\xe6S\xdd\xce$\x02",
+            2: b"\xc7\xf7\x9f\xd7 \x8dL\xe3nS\xe6S\xdd\xce$\x02",
+            3: b"I\x08\xfb\x9fh\x80\t\xd1\x99\x9cskl\xb3;\xdb",
         }
         expected = {
-            False: "SQj7n2iACdGZnHNrbLM72w==1808",
-            True: "x/ef1yCNTONuU+ZT3c4kAg==",
+            2: "x/ef1yCNTONuU+ZT3c4kAg==",
+            3: "SQj7n2iACdGZnHNrbLM72w==1808",
         }
 
         def check_args(args, **kwargs):
@@ -322,28 +330,34 @@ class TestDevice:
             assert args[args.index("-iv") + 1] == iv
             assert args[args.index("-pass") + 1] == password
             prefix = b"Salted__XXXXXX12" if is_salted_prefix else b""
-            return mock.Mock(stdout=prefix + stdout[is_rtos])
+            return mock.Mock(stdout=prefix + stdout[method])
 
         mock_run.side_effect = check_args
         assert (
-            device.encrypt_aes128("password", self.METAINFO, is_rtos)
-            == expected[is_rtos]
+            device.encrypt_aes128(
+                "password", self.METAINFO, method, add_lengths
+            )
+            == expected[method]
         )
         assert mock_run.call_count == 1
 
     @pytest.mark.parametrize(
-        "is_rtos, expected",
+        "method, add_lengths, expected",
         [
-            (False, "SQj7n2iACdGZnHNrbLM72w==1808"),
-            (True, "x/ef1yCNTONuU+ZT3c4kAg=="),
+            (2, False, "x/ef1yCNTONuU+ZT3c4kAg=="),
+            (3, True, "SQj7n2iACdGZnHNrbLM72w==1808"),
         ],
     )
     @pytest.mark.skipif(
         not shutil.which("openssl"), reason="The openssl binary was not found"
     )
-    def test_encryption_with_openssl(self, is_rtos, expected, device):
+    def test_encryption_with_openssl(
+        self, method, add_lengths, expected, device
+    ):
         """Test encryption using the OpenSSL binary (if it exists)."""
-        actual = device.encrypt_aes128("password", self.METAINFO, is_rtos)
+        actual = device.encrypt_aes128(
+            "password", self.METAINFO, method, add_lengths
+        )
         assert expected == actual
 
     @pytest.mark.skipif(
@@ -364,7 +378,10 @@ class TestDevice:
         wemo_metadata = "|".join([mac, serial, "", "", "", ""])
         try:
             encrypted = Device.encrypt_aes128(
-                password=password, wemo_metadata=wemo_metadata, is_rtos=is_rtos
+                password=password,
+                wemo_metadata=wemo_metadata,
+                method=2 if is_rtos else 3,
+                add_lengths=not is_rtos,
             )
         except SetupException:
             pass


### PR DESCRIPTION
## Description:
Improve the setup method and add options to override the automatically detected method of keydata for encryption as well as whether to add the password lengths onto the end of the encrypted password.

This will allow users to force alternative methods in case the automatic detection does not work.

Note: that there is a little bit of commented code, which is the in the `_setup` method.  The commented code is the logic that seems like it *should* be applied based on investigating the Android APK, but that doesn't seem to actually work.  I've intentionally left it there for now...

Fixes #763

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests (pytest/vcr) are added for new devices or major features.
  - [ ] There is no commented out code in this PR.
  - [x] I have read and agree to the [CONTRIBUTING document](
        https://github.com/pywemo/pywemo/blob/master/CONTRIBUTING.md).