### PR TITLE
Raise exception when Wemo reports Unknown authorization mode

### DIFF
--- a/pywemo/ouimeaux_device/__init__.py
+++ b/pywemo/ouimeaux_device/__init__.py
@@ -578,7 +578,14 @@ class Device(DeviceDescription, RequiredServicesMixin, WeMoServiceTypesMixin):
         # get some information about the access point
         columns = selected_ap.split("|")
         channel = columns[1].strip()
-        auth_mode, encryption_method = columns[-1].strip().split("/")
+        auth_string = columns[-1].strip()
+        if auth_string == "Unknown":
+            raise SetupException(
+                f"Wemo reports AP {ssid} with 'Unknown' authorization mode. "
+                "AP may be using an unsupported authorization mode (ex WPA3)"
+            )
+
+        auth_mode, encryption_method = auth_string.split("/")
         LOG.debug("AP channel: %s", channel)
         LOG.debug("AP authorization mode(s): %s", auth_mode)
         LOG.debug("AP encryption method: %s", encryption_method)


### PR DESCRIPTION
## Description:

When trying to run device setup against an SSID with WPA3, the `.split("/")` call results in `ValueError: not enough values to unpack (expected 2, got 1)`. This is because the WEMO cannot identify the type of auth mode being used and returns the string "Unknown" instead. Ex: `SSIDXXX|5|100|Unknown` vs `SSIDZZZ|11|100|WPA2PSK/AES`

This change just raises a more helpful `SetupException` + message instead of the generic `ValueError`.

Tests passed locally. I didn't see a test that would cover the function I edited, but please let me know if I need to add a test case for this.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests (pytest/vcr) are added for new devices or major features.
  - [x] There is no commented out code in this PR.
  - [x] I have read and agree to the [CONTRIBUTING document](
        https://github.com/pywemo/pywemo/blob/master/CONTRIBUTING.md).