### PR TITLE
Add action runners for Python 3.14

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -115,7 +115,7 @@ jobs:
           persist-credentials: false
       - uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
         with:
-          name: coverage-ubuntu-latest-3.10
+          name: coverage-ubuntu-latest-3.14
       - uses: coverallsapp/github-action@648a8eb78e6d50909eff900e4ec85cab4524a45b # v2.3.6
         with:
           path-to-lcov: coverage.lcov

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,12 +26,12 @@ jobs:
       max-parallel: 5  # Set equal to the number of Linux tests.
       matrix:
         os: ['ubuntu-latest']
-        python-version: ['3.10', '3.11', '3.12', '3.13']
+        python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
         include:
           - os: windows-latest
-            python-version: '3.10'
+            python-version: '3.14'
           - os: macos-latest
-            python-version: '3.10'
+            python-version: '3.14'
     runs-on: ${{ matrix.os }}
     defaults:
       run:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,7 +16,7 @@ env:
   # Artifact name to use for the release. The build matrix builds and tests
   # multiple Python versions. But the release only comes from this single
   # version.
-  DIST_ARTIFACT: dist-ubuntu-latest-3.10
+  DIST_ARTIFACT: dist-ubuntu-latest-3.14
 
 jobs:
   build:


### PR DESCRIPTION
## Description:
Adding support for Python 3.14 in the workflow actions. Also switching the default for Windows, macOS, coverage, and publishing to 3.14 as it is the version used by Home Assistant.

**Related issue (if applicable):** fixes #<pywemo issue number goes here>

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests (pytest/vcr) are added for new devices or major features.
  - [x] There is no commented out code in this PR.
  - [x] I have read and agree to the [CONTRIBUTING document](
        https://github.com/pywemo/pywemo/blob/master/CONTRIBUTING.md).