### PR TITLE
Use cryptography instead of OpenSSL

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -2,10 +2,6 @@ pyWeMo |Build Badge| |PyPI Version Badge| |Coverage| |PyPI Downloads Badge| |Doc
 ================================================================================================================================================
 Python 3 module to setup, discover and control WeMo devices.
 
-Dependencies
-------------
-pyWeMo depends on Python packages: requests, ifaddr, lxml, urllib3
-
 How to use
 ----------
 

--- a/README.rst
+++ b/README.rst
@@ -99,8 +99,6 @@ Once done, pass the desired SSID and password (WPA2/AES encryption only) to the 
 A few important notes:
 
 - If connecting to an open network, the password argument is ignored and you can provide anything, e.g. ``password=None``.
-- If connecting to a WPA2/AES/TKIPAES-encrypted network, OpenSSL is used to encrypt the password by the ``pywemo`` library.
-  It must be installed and available on your ``PATH`` via calling ``openssl`` from a terminal or command prompt.
 - For a WeMo without internet access, see `this guide <https://github.com/pywemo/pywemo/wiki/WeMo-Cloud#disconnecting-from-the-cloud>`_ to stop any blinking lights.
 
 If you have issues connecting, here are several things worth trying:

--- a/poetry.lock
+++ b/poetry.lock
@@ -127,8 +127,7 @@ version = "2.0.0"
 description = "Foreign Function Interface for Python calling C code."
 optional = false
 python-versions = ">=3.9"
-groups = ["bootstrap"]
-markers = "platform_python_implementation != \"PyPy\" and sys_platform == \"linux\" or sys_platform == \"darwin\""
+groups = ["main", "bootstrap"]
 files = [
     {file = "cffi-2.0.0-cp310-cp310-macosx_10_13_x86_64.whl", hash = "sha256:0cf2d91ecc3fcc0625c2c530fe004f82c110405f101548512cce44322fa8ac44"},
     {file = "cffi-2.0.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:f73b96c41e3b2adedc34a7356e64c8eb96e03a3782b535e043a986276ce12a49"},
@@ -215,6 +214,7 @@ files = [
     {file = "cffi-2.0.0-cp39-cp39-win_amd64.whl", hash = "sha256:b882b3df248017dba09d6b16defe9b5c407fe32fc7c65a9c69798e6175601be9"},
     {file = "cffi-2.0.0.tar.gz", hash = "sha256:44d1b5909021139fe36001ae048dbdde8214afa20200eda0f64c068cac5d5529"},
 ]
+markers = {main = "platform_python_implementation != \"PyPy\"", bootstrap = "platform_python_implementation != \"PyPy\" and sys_platform == \"linux\" or sys_platform == \"darwin\""}
 
 [package.dependencies]
 pycparser = {version = "*", markers = "implementation_name != \"PyPy\""}
@@ -521,8 +521,7 @@ version = "46.0.4"
 description = "cryptography is a package which provides cryptographic recipes and primitives to Python developers."
 optional = false
 python-versions = "!=3.9.0,!=3.9.1,>=3.8"
-groups = ["bootstrap"]
-markers = "sys_platform == \"linux\""
+groups = ["main", "bootstrap"]
 files = [
     {file = "cryptography-46.0.4-cp311-abi3-macosx_10_9_universal2.whl", hash = "sha256:281526e865ed4166009e235afadf3a4c4cba6056f99336a99efba65336fd5485"},
     {file = "cryptography-46.0.4-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:5f14fba5bf6f4390d7ff8f086c566454bff0411f6d8aa7af79c88b6f9267aecc"},
@@ -574,6 +573,7 @@ files = [
     {file = "cryptography-46.0.4-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:be8c01a7d5a55f9a47d1888162b76c8f49d62b234d88f0ff91a9fbebe32ffbc3"},
     {file = "cryptography-46.0.4.tar.gz", hash = "sha256:bfd019f60f8abc2ed1b9be4ddc21cfef059c841d86d710bb69909a688cbb8f59"},
 ]
+markers = {bootstrap = "sys_platform == \"linux\""}
 
 [package.dependencies]
 cffi = {version = ">=2.0.0", markers = "python_full_version >= \"3.9.0\" and platform_python_implementation != \"PyPy\""}
@@ -1889,12 +1889,12 @@ version = "3.0"
 description = "C parser in Python"
 optional = false
 python-versions = ">=3.10"
-groups = ["bootstrap"]
-markers = "(platform_python_implementation != \"PyPy\" and sys_platform == \"linux\" or sys_platform == \"darwin\") and implementation_name != \"PyPy\""
+groups = ["main", "bootstrap"]
 files = [
     {file = "pycparser-3.0-py3-none-any.whl", hash = "sha256:b727414169a36b7d524c1c3e31839a521725078d7b2ff038656844266160a992"},
     {file = "pycparser-3.0.tar.gz", hash = "sha256:600f49d217304a5902ac3c37e1281c9fe94e4d0489de643a9504c5cdfdfc6b29"},
 ]
+markers = {main = "platform_python_implementation != \"PyPy\" and implementation_name != \"PyPy\"", bootstrap = "(platform_python_implementation != \"PyPy\" and sys_platform == \"linux\" or sys_platform == \"darwin\") and implementation_name != \"PyPy\""}
 
 [[package]]
 name = "pydantic"
@@ -2664,12 +2664,12 @@ version = "4.15.0"
 description = "Backported and Experimental Type Hints for Python 3.9+"
 optional = false
 python-versions = ">=3.9"
-groups = ["bootstrap", "dev"]
+groups = ["main", "bootstrap", "dev"]
 files = [
     {file = "typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548"},
     {file = "typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466"},
 ]
-markers = {bootstrap = "python_version < \"3.13\""}
+markers = {main = "python_version < \"3.11\"", bootstrap = "python_version < \"3.13\""}
 
 [[package]]
 name = "typing-inspection"
@@ -3068,4 +3068,4 @@ cffi = ["cffi (>=1.17,<2.0) ; platform_python_implementation != \"PyPy\" and pyt
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.10.0"
-content-hash = "71e5c0f6e099c5e9cf07578533707e1b7cbb19c2ee8e09df9296c1d72834061e"
+content-hash = "e425577990d8991bcf38e588d55eaedd965949437608d71a16b2cf1c95e46fe5"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ keywords = ['wemo', 'api']
 
 [tool.poetry.dependencies]
 python = "^3.10.0"
+cryptography = ">=3.4"
 ifaddr = ">=0.1.0"
 requests = ">=2.0"
 urllib3 = ">=2.0.2"

--- a/pywemo/ouimeaux_device/__init__.py
+++ b/pywemo/ouimeaux_device/__init__.py
@@ -318,7 +318,7 @@ class Device(DeviceDescription, RequiredServicesMixin, WeMoServiceTypesMixin):
     def encrypt_aes128(
         password: str, wemo_metadata: str, method: int, add_lengths: bool
     ) -> str:
-        """Encrypt a password using OpenSSL.
+        """Encrypt a password using Cryptography.
 
         Function borrows heavily from Vadim Kantorov's "wemosetup" script:
         https://github.com/vadimkantorov/wemosetup
@@ -431,9 +431,8 @@ class Device(DeviceDescription, RequiredServicesMixin, WeMoServiceTypesMixin):
             SSID to connect the device to.
           password (str):
             Password for the indicated SSID.  This password will be encrypted
-            with OpenSSL and then sent to the device.  To connect to an open,
-            unsecured network, pass anything for the password as it will be
-            ignored.
+            and then sent to the device.  To connect to an open, unsecured
+            network, pass anything for the password as it will be ignored.
           timeout (float, optional):
             Number of seconds to wait and poll a device to see if it has
             successfully connected to the network.  The minimum value allows is

--- a/pywemo/ouimeaux_device/api/wifi_setup.py
+++ b/pywemo/ouimeaux_device/api/wifi_setup.py
@@ -1,0 +1,40 @@
+"""Cryptography helpers for WiFi setup."""
+
+import base64
+
+from cryptography.hazmat.backends import default_backend
+from cryptography.hazmat.primitives import hashes
+from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
+
+
+def encrypt_password(password: str, key: str, salt: str, iv: str) -> str:
+    """Encrypt the WiFi password."""
+    password_bytes = password.encode("utf-8")
+    key_bytes = key.encode("utf-8")
+    salt_bytes = salt.encode("utf-8")
+    iv_bytes = iv.encode("utf-8")
+
+    # Derive the Key. Logic: MD5(key + salt)
+    # MD5 is no longer considered secure, but it's the algorithm used for WeMo.
+    hasher = hashes.Hash(hashes.MD5(), backend=default_backend())  # noqa: S303
+    hasher.update(key_bytes + salt_bytes)
+    derived_key = hasher.finalize()[:16]
+
+    # Setup Cipher (AES-128-CBC)
+    cipher = Cipher(
+        algorithms.AES(derived_key),
+        modes.CBC(iv_bytes),
+        backend=default_backend(),
+    )
+    encryptor = cipher.encryptor()
+
+    # Handle Padding (PKCS7)
+    # AES is a block cipher; data must be a multiple of 16 bytes.
+    pad_len = 16 - (len(password_bytes) % 16)
+    padded_data = password_bytes + bytes([pad_len] * pad_len)
+
+    # Encrypt
+    encrypted_data = encryptor.update(padded_data) + encryptor.finalize()
+
+    # Encode to Base64
+    return base64.b64encode(encrypted_data).decode()

--- a/tests/ouimeaux_device/api/unit/test_wifi_setup.py
+++ b/tests/ouimeaux_device/api/unit/test_wifi_setup.py
@@ -1,0 +1,31 @@
+"""Unit tests for wifi_setup.py."""
+
+import pytest
+
+from pywemo.ouimeaux_device.api import wifi_setup
+
+
+@pytest.mark.parametrize(
+    "password, key, salt, iv, expected",
+    [
+        (
+            "password",
+            "XXXXXX123456A1234567XXXXXXb3{8t;80dIN{ra83eC1s?M70?683@2Yf",
+            "XXXXXX12",
+            "XXXXXX123456A123",
+            "x/ef1yCNTONuU+ZT3c4kAg==",
+        ),
+        (
+            "password",
+            "XXXXXX123456A1234567XXXXXX",
+            "XXXXXX12",
+            "XXXXXX123456A123",
+            "SQj7n2iACdGZnHNrbLM72w==",
+        ),
+    ],
+)
+def test_encrypt_password(
+    password: str, key: str, salt: str, iv: str, expected: str
+):
+    """Test encrypt_password method."""
+    assert wifi_setup.encrypt_password(password, key, salt, iv) == expected

--- a/tests/ouimeaux_device/test_device.py
+++ b/tests/ouimeaux_device/test_device.py
@@ -287,7 +287,7 @@ class TestDevice:
         ],
     )
     def test_encryption(self, method, add_lengths, expected, device):
-        """Test encryption using the OpenSSL binary (if it exists)."""
+        """Test encryption for the WiFi password."""
         actual = device.encrypt_aes128(
             "password", self.METAINFO, method, add_lengths
         )

--- a/tests/ouimeaux_device/test_device.py
+++ b/tests/ouimeaux_device/test_device.py
@@ -3,8 +3,6 @@
 import base64
 import itertools
 import logging
-import shutil
-from subprocess import CalledProcessError
 from unittest import mock
 
 import pytest
@@ -280,67 +278,6 @@ class TestDevice:
         assert device.basicevent.ReSetup.call_count == 1
         assert device.basicevent.ReSetup.call_args_list == [({"Reset": 2},)]
 
-    @mock.patch("subprocess.run", side_effect=FileNotFoundError)
-    def test_encryption_no_openssl(self, mock_run, device):
-        """Test device encryption (openssl not found/not installed)."""
-        with pytest.raises(SetupException):
-            assert device.encrypt_aes128("password", self.METAINFO, 3, True)
-        assert mock_run.call_count == 1
-
-    @mock.patch("subprocess.run", side_effect=CalledProcessError(-1, "error"))
-    def test_encryption_openssl_error(self, mock_run, device):
-        """Test device encryption (error in openssl)."""
-        with pytest.raises(SetupException):
-            assert device.encrypt_aes128("password", self.METAINFO, 3, True)
-        assert mock_run.call_count == 1
-
-    @pytest.mark.parametrize(
-        "method, add_lengths, is_salted_prefix",
-        [
-            (1, True, True),
-            (1, True, False),
-            (2, False, True),
-            (2, False, False),
-            # TODO: get the expected results for these tests
-            # --> (3, True, True),
-            # --> (3, True, False),
-        ],
-    )
-    @mock.patch("subprocess.run")
-    def test_encryption_successful(
-        self, mock_run, method, add_lengths, is_salted_prefix, device
-    ):
-        """Test device encryption (good result)."""
-        salt = "5858585858583132"
-        iv = "58585858585831323334353641313233"
-        password = "pass:XXXXXX123456A1234567XXXXXX" + (
-            "b3{8t;80dIN{ra83eC1s?M70?683@2Yf" if method == 2 else ""
-        )
-        stdout = {
-            1: b"I\x08\xfb\x9fh\x80\t\xd1\x99\x9cskl\xb3;\xdb",
-            2: b"\xc7\xf7\x9f\xd7 \x8dL\xe3nS\xe6S\xdd\xce$\x02",
-        }
-        expected = {
-            1: "SQj7n2iACdGZnHNrbLM72w==1808",
-            2: "x/ef1yCNTONuU+ZT3c4kAg==",
-        }
-
-        def check_args(args, **kwargs):
-            assert args[args.index("-S") + 1] == salt
-            assert args[args.index("-iv") + 1] == iv
-            assert args[args.index("-pass") + 1] == password
-            prefix = b"Salted__XXXXXX12" if is_salted_prefix else b""
-            return mock.Mock(stdout=prefix + stdout[method])
-
-        mock_run.side_effect = check_args
-        assert (
-            device.encrypt_aes128(
-                "password", self.METAINFO, method, add_lengths
-            )
-            == expected[method]
-        )
-        assert mock_run.call_count == 1
-
     @pytest.mark.parametrize(
         "method, add_lengths, expected",
         [
@@ -348,21 +285,13 @@ class TestDevice:
             (2, False, "x/ef1yCNTONuU+ZT3c4kAg=="),
         ],
     )
-    @pytest.mark.skipif(
-        not shutil.which("openssl"), reason="The openssl binary was not found"
-    )
-    def test_encryption_with_openssl(
-        self, method, add_lengths, expected, device
-    ):
+    def test_encryption(self, method, add_lengths, expected, device):
         """Test encryption using the OpenSSL binary (if it exists)."""
         actual = device.encrypt_aes128(
             "password", self.METAINFO, method, add_lengths
         )
         assert expected == actual
 
-    @pytest.mark.skipif(
-        not shutil.which("openssl"), reason="The openssl binary was not found"
-    )
     @given(
         password=st.text(),
         mac=st.text(),

--- a/tests/ouimeaux_device/test_device.py
+++ b/tests/ouimeaux_device/test_device.py
@@ -283,6 +283,7 @@ class TestDevice:
         [
             (1, True, "SQj7n2iACdGZnHNrbLM72w==1808"),
             (2, False, "x/ef1yCNTONuU+ZT3c4kAg=="),
+            (3, False, "0wyEoTUUR5lTmfKTiXW3oA=="),
         ],
     )
     def test_encryption(self, method, add_lengths, expected, device):


### PR DESCRIPTION
## Description:

This PR removes the need to install OpenSSL for updating the WiFi settings for a device.

## Tested on
  - [x] F7C031 (no `rtos`)
  - [x] F7C043 (no `rtos`)
  - [x] F7C028  (`'rtos': '1', 'iot': '1'` - Works with #819)
  - [x] WSP080 (`'rtos': '1'`)
  - [x] WSP090 (`'rtos': '1'`)

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests (pytest/vcr) are added for new devices or major features.
  - [x] There is no commented out code in this PR.
  - [x] I have read and agree to the [CONTRIBUTING document](
        https://github.com/pywemo/pywemo/blob/master/CONTRIBUTING.md).