### PR TITLE
Use encrypt method 1 with iot

### DIFF
--- a/pywemo/ouimeaux_device/__init__.py
+++ b/pywemo/ouimeaux_device/__init__.py
@@ -619,7 +619,8 @@ class Device(DeviceDescription, RequiredServicesMixin, WeMoServiceTypesMixin):
 
                 # however, this works correctly more often than the logic above
                 is_rtos = self._config_any.get("rtos", "0") == "1"
-                if is_rtos:
+                is_iot = self._config_any.get("iot", "0") == "1"
+                if is_rtos and not is_iot:
                     method = 2
                 else:
                     method = 1


### PR DESCRIPTION
## Description:

There are some devices (F7C027, F7C028, F7C029, F7C030) that have `'rtos': '1'` in `_config_any` but require encrypt method 1 for performing WiFi Setup. One commonality between all these devices is that they all also have `'iot': '1'` in `_config_any`. They also have a firmware version starting with `WeMo_WW_2.00.11851.PVT-OWRT-...`. Let's use this `iot` config to identify them as ones that should use method 1 instead of method 2.

### Manual testing

-  [x] F7C027 Testing by @JosephRDawson in #803
```
{'binaryOption': '1',
'binaryState': '0',
'firmwareVersion': 'WeMo_WW_2.00.11851.PVT-OWRT-SNS',
'iconVersion': '0|49152',
'iot': '1',
'new_algo': '1',
'rtos': '1'}
```

-  [x] F7C027 Testing by @esev
```
{'binaryOption': '1',
 'binaryState': '0',
 'firmwareVersion': 'WeMo_WW_2.00.11851.PVT-OWRT-SNS',
 'iconVersion': '0|49152',
 'iot': '1',
 'new_algo': '1',
 'rtos': '1'}
```

-  [x] F7C028 Testing by @esev
```
{'binaryOption': '1',
 'binaryState': '0',
 'firmwareVersion': 'WeMo_WW_2.00.11851.PVT-OWRT-SNS',
 'iconVersion': '1|49153',
 'iot': '1',
 'new_algo': '1',
 'rtos': '1'}
```

-  [x] WSP090 Testing by @esev
```
{'binaryState': '0',
 'firmwareVersion': 'WEMO_WW_1.00.20081401.PVT-RTOS-OutdoorV1',
 'hkSetupCode': 'xxx-xx-xxx',
 'hwVersion': 'v1',
 'iconVersion': '1|49152',
 'new_algo': '1',
 'rtos': '1'}
```

### Alternative considered

There is overlap between devices with `'binaryOption': '1'` and encrypt method 1 as well. But my F7C030 & F7C031 work with encrypt method 1 and also doesn't have `'binaryOption': '1'`. `iot` seems to be the thing that is in common with the devices that currently aren't working with WiFi setup.

**Related issue (if applicable):** 
- fixes #803 

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests (pytest/vcr) are added for new devices or major features.
  - [x] There is no commented out code in this PR.
  - [x] I have read and agree to the [CONTRIBUTING document](
        https://github.com/pywemo/pywemo/blob/master/CONTRIBUTING.md).