### PR TITLE
Fix WeMo Link discovery with no bulbs attached

### DIFF
--- a/pywemo/ouimeaux_device/bridge.py
+++ b/pywemo/ouimeaux_device/bridge.py
@@ -112,7 +112,8 @@ class Bridge(Device):
                     DevUDN=plugin_udn, ReqListType="PAIRED_LIST"
                 )
 
-            if not (end_devices_xml := end_devices.get("DeviceLists")):
+            end_devices_xml = end_devices.get("DeviceLists")
+            if not end_devices_xml or end_devices_xml == "0":
                 return self.lights, self.groups
 
             end_device_list = et.fromstring(


### PR DESCRIPTION
## Description:

WeMo Link (bridge) discovery is broken with no bulbs attached as they return {'DeviceLists': '0'}

Lights can be on-boarded with:

wemosetup.py addenddevices --ip WEMO_IP --port 49152




## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests (pytest/vcr) are added for new devices or major features.
  - [x] There is no commented out code in this PR.
  - [x] I have read and agree to the [CONTRIBUTING document](
        https://github.com/pywemo/pywemo/blob/master/CONTRIBUTING.md).